### PR TITLE
null output was not supported

### DIFF
--- a/saltgui/static/scripts/output.js
+++ b/saltgui/static/scripts/output.js
@@ -29,18 +29,24 @@ class Output {
     // indent each level with 2 spaces
     const indentStep = 2;
 
+    if(value === undefined) {
+      // JSON.stringify does not return a string for this
+      // but again a value undefined
+      return "undefined";
+    }
+
     if(typeof value !== "object") {
       // a simple type
       // leave that to the builtin function
       return JSON.stringify(value);
     }
-  
+
     if(value === null) {
       // null is an object, but not really
       // leave that to the builtin function
       return JSON.stringify(value);
     }
-  
+
     if(Array.isArray(value)) {
       // an array
       // put each element on its own line
@@ -60,7 +66,7 @@ class Output {
       str += "]";
       return str;
     }
-  
+
     // regular object
     // put each name+value on its own line
     const keys = Object.keys(value);

--- a/saltgui/static/scripts/output.js
+++ b/saltgui/static/scripts/output.js
@@ -35,6 +35,12 @@ class Output {
       return JSON.stringify(value);
     }
   
+    if(value === null) {
+      // null is an object, but not really
+      // leave that to the builtin function
+      return JSON.stringify(value);
+    }
+  
     if(Array.isArray(value)) {
       // an array
       // put each element on its own line

--- a/tests/unit/output.js
+++ b/tests/unit/output.js
@@ -8,6 +8,14 @@ describe('Unittests for output.js', function() {
 
     let outputData, result;
 
+    outputData = null;
+    result = Output.formatJSON(outputData);
+    assert.equal(result, "null");
+
+    outputData = undefined;
+    result = Output.formatJSON(outputData);
+    assert.equal(result, "undefined");
+
     outputData = 123;
     result = Output.formatJSON(outputData);
     assert.equal(result, "123");


### PR DESCRIPTION
The new object formatter does not know how to handle a `null` value.
`null` is an object, but it is still quite different.
Replay with `test.echo null`

The new object formatter also did not know how to handle a `undefined` value.
It was passed to `JSON.stringify`, but that returns a `undefined` object instead of the string value `undefined`.
Not sure whether this can occur in real life.