### PR TITLE
apply new output format also to jobs output

### DIFF
--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -96,7 +96,7 @@
           <div class='nearlyvisiblebutton' id='button_close_job'>&#x2715;</div>
           <h1 class='function'></h1>
           <h2 class='time'></h2>
-          <div class='hosts'></div>
+          <pre class="output">...</pre>
         </div>
       </div>
 

--- a/saltgui/static/scripts/output.js
+++ b/saltgui/static/scripts/output.js
@@ -562,6 +562,16 @@ class Output {
   }
 
 
+  static hasProperties(obj, props) {
+    for(const prop of props) {
+      if(!obj.hasOwnProperty(prop)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+
   // the orchestrator for the output
   // determines what format should be used and uses that
   static addResponseOutput(outputContainer, response, command) {
@@ -640,7 +650,13 @@ class Output {
     // this is more generic and it simplifies the handlers
     for(const hostname of Object.keys(response).sort()) {
 
-      const hostResponse = response[hostname];
+      let hostResponse = response[hostname];
+      if(Output.hasProperties(hostResponse, ["retcode", "return", "success"])) {
+        hostResponse = hostResponse.return;
+      }
+      else if(command.startsWith("runner.") && hostResponse.hasOwnProperty("return")) {
+        hostResponse = hostResponse.return.return;
+      }
 
       let hostLabel = null;
       let hostOutput = null;

--- a/saltgui/static/scripts/routes/job.js
+++ b/saltgui/static/scripts/routes/job.js
@@ -17,72 +17,28 @@ class JobRoute extends Route {
   _onJobData(data) {
     const job = this;
     const info = data.info[0];
-    job.getPageElement().querySelector(".hosts").innerHTML = "";
+    job.getPageElement().querySelector(".output").innerHTML = "";
 
     document.querySelector('#button_close_job').addEventListener('click', _ => {
       this.router.goTo("/");
     });
 
-    const container = this.getPageElement().querySelector(".job-info");
+    const jobinfo = this.getPageElement().querySelector(".job-info");
 
     const functionText = info.Function + " on " +
       window.makeTargetText(info["Target-type"], info.Target);
-    container.querySelector('.function').innerHTML = functionText;
+    jobinfo.querySelector('.function').innerText = functionText;
 
-    container.querySelector('.time').innerHTML = info.StartTime;
+    jobinfo.querySelector('.time').innerText = info.StartTime;
 
-    const hostnames = Object.keys(info.Result);
+    const hostnames = Object.keys(info.Result).sort();
+    const output = job.getPageElement().querySelector(".output");
     hostnames.forEach(function(hostname) {
-
-      // when you do a state.apply for example you get a json response.
-      // let's format it nicely here
-      let result = info.Result[hostname].return;
-      if (typeof result === "object") {
-        result = Output.formatJSON(result);
-      } else {
-        result = window.escape(result);
-      }
-      job._addHost(job.getPageElement().querySelector(".hosts"), hostname, result);
+      // use same formatter as direct commands
+      const result = info.Result[hostname].return;
+      Output.addOutput(output, result, info.Function);
     });
     this.resolvePromise();
-  }
-
-  _addHost(container, hostname, result) {
-    const host = createElement("div", "host", `<h1>${hostname}</h1>`);
-    host.addEventListener('click', this._onHostClick);
-
-    if(typeof result === "string") {
-      const task = createElement("div", "task", "");
-      task.appendChild(createElement("div", "name", result));
-      host.appendChild(task);
-      container.appendChild(host);
-      return;
-    }
-
-    let hasFailedOnce = false;
-
-    Object.keys(result).forEach(function(taskKey) {
-      const data = result[taskKey];
-      const task = createElement("div", "task", "");
-      task.classList.add(data.result !== false ? "host_success" : "host_failure");
-      if(data.result === false) hasFailedOnce = true;
-
-      task.appendChild(createElement("div", "name", data.name));
-      task.appendChild(createElement("div", "comment", data.comment));
-      task.appendChild(createElement("div", "duration",
-        `Took ${Math.round(data.duration)} seconds.`));
-      host.appendChild(task);
-    });
-
-    host.style.color = hasFailedOnce ? "red" : "green";
-    container.appendChild(host);
-  }
-
-  _onHostClick(evt) {
-    this.childNodes.forEach(function(child) {
-      if(child.nodeName === "H1") return;
-      child.style.display = child.style.display !== "none" ? "none" : "block";
-    });
   }
 
 }

--- a/saltgui/static/scripts/routes/job.js
+++ b/saltgui/static/scripts/routes/job.js
@@ -31,13 +31,10 @@ class JobRoute extends Route {
 
     jobinfo.querySelector('.time').innerText = info.StartTime;
 
-    const hostnames = Object.keys(info.Result).sort();
     const output = job.getPageElement().querySelector(".output");
-    hostnames.forEach(function(hostname) {
-      // use same formatter as direct commands
-      const result = info.Result[hostname].return;
-      Output.addOutput(output, result, info.Function);
-    });
+    // use same formatter as direct commands
+    Output.addResponseOutput(output, info.Result, info.Function);
+
     this.resolvePromise();
   }
 

--- a/saltgui/static/stylesheets/main.css
+++ b/saltgui/static/stylesheets/main.css
@@ -179,17 +179,20 @@ input[type='submit'] {
   margin-bottom: 20px;
 }
 
-.run-command pre {
+pre.output {
   background-color: #272727;
   color: white;
   margin: 0;
   padding: 10px;
   border-radius: 2px;
-  overflow-y: scroll;
   white-space: pre-wrap;
   max-width: calc(100% - 10px);
   width: calc(100% - 10px);
+}
+
+.run-command pre.output {
   height: 250px;
+  overflow-y: scroll;
 }
 
 input,


### PR DESCRIPTION
SaltGUI shows job output in 2 places.
First is the direct output when running a command.
Second is the output produced by jobs, or from older commands.

A bit of tweaking is needed because the structure that contains the output is slightly different between commands and jobs.

Note that some of the additional details present in that structure are still ignored. This PR only handles the basic formatting and does not introduce showing new details.