### PR TITLE
selectable+autodetect targettype

### DIFF
--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -106,7 +106,7 @@
       <div class='run-command'>
         <div class='nearlyvisiblebutton' id='button_close_cmd'>&#x2715;</div>
         <h1>Manual Run</h1>
-        <div><input id='target' type='text' placeholder="Target"/></div>
+        <div id="targetbox"><input id='target' type='text' placeholder="Target"/></div>
         <div id="cmdbox"><input id='command' type='text' placeholder="Command"/></div>
         <div id="runblock"><input id="run_command" type='submit' value="Run command"/></div>
         <pre class='output'>Waiting for command...</pre>
@@ -120,6 +120,7 @@
     <script src='static/scripts/api.js'></script>
     <script src='static/scripts/commandbox.js'></script>
     <script src='static/scripts/runtype.js'></script>
+    <script src='static/scripts/targettype.js'></script>
     <script src='static/scripts/routes/route.js'></script>
     <script src='static/scripts/routes/login.js'></script>
     <script src='static/scripts/routes/page.js'></script>

--- a/saltgui/static/scripts/documentation.js
+++ b/saltgui/static/scripts/documentation.js
@@ -9,7 +9,7 @@ class Documentation {
     this.commandbox = commandbox;
     this._manualRunMenuSysDocRun = this._manualRunMenuSysDocRun.bind(this);
 
-    commandbox.menu.addMenuItem(
+    commandbox.cmdmenu.addMenuItem(
       this._manualRunMenuSysDocPrepare,
       this._manualRunMenuSysDocRun);
   }
@@ -87,7 +87,9 @@ class Documentation {
       dummyCommand = "sys.doc " + command;
     }
 
-    this.commandbox._getRunParams(target, docCommand).then(
+    const tgtType = TargetType.menuTargetType._value;
+
+    this.commandbox._getRunParams(tgtType, target, docCommand).then(
       response => this.commandbox._onRunReturn(response.return[0], dummyCommand)
     );
   }

--- a/saltgui/static/scripts/runtype.js
+++ b/saltgui/static/scripts/runtype.js
@@ -1,6 +1,6 @@
 class RunType {
 
-  static _registerEventListeners() {
+  static createMenu() {
     const runblock = document.getElementById("runblock");
     RunType.menuRunType = new DropDownMenu(runblock);
     // do not show the menu title at first

--- a/saltgui/static/scripts/targettype.js
+++ b/saltgui/static/scripts/targettype.js
@@ -1,0 +1,71 @@
+class TargetType {
+
+  static createMenu() {
+    const targetbox = document.getElementById("targetbox");
+    TargetType.menuTargetType = new DropDownMenu(targetbox);
+    // do not show the menu title at first
+    TargetType.menuTargetType.addMenuItem("Normal", this._updateTargetTypeText, "glob");
+    TargetType.menuTargetType.addMenuItem("List", this._updateTargetTypeText, "list");
+    TargetType.menuTargetType.addMenuItem("Compound", this._updateTargetTypeText, "compound");
+    TargetType.setTargetTypeDefault();
+  }
+
+  static autoSelectTargetType(target) {
+
+    if(TargetType.menuTargetType._value !== undefined &&
+      TargetType.menuTargetType._value !== "" &&
+      !TargetType.menuTargetType._system) {
+      // user has selected the value, do not touch it
+      return;
+    }
+
+    if(target.includes("@")) {
+      // @ is a strong indicator for compound target
+      TargetType.menuTargetType._value = "compound";
+      TargetType._updateTargetTypeText();
+      return;
+    }
+
+    if(target.includes(",")) {
+      // @ is a strong indicator for list target (when it is also not compound)
+      TargetType.menuTargetType._value = "list";
+      TargetType._updateTargetTypeText();
+      return;
+    }
+
+    // do not show it when default and not explicitly selected
+    TargetType.setTargetTypeDefault();
+  }
+
+  static _updateTargetTypeText() {
+    const targetType = TargetType.getTargetType();
+
+    switch(targetType) {
+    case "compound":
+      TargetType.menuTargetType.setTitle("Compound");
+      break;
+    case "glob":
+      // now that the menu is used show the menu title
+      TargetType.menuTargetType.setTitle("Normal");
+      break;
+    case "list":
+      TargetType.menuTargetType.setTitle("List");
+      break;
+    }
+  }
+
+  static setTargetTypeDefault() {
+    TargetType.menuTargetType._value = "glob";
+    // reset the title to the absolute minimum
+    // so that the menu does not stand out in trivial situations
+    TargetType.menuTargetType.setTitle("");
+    TargetType.menuTargetType._system = true;
+  }
+
+  static getTargetType() {
+    const targetType = TargetType.menuTargetType._value;
+    if(targetType === undefined || targetType === "") return "glob";
+    return targetType;
+  }
+
+}

--- a/saltgui/static/scripts/targettype.js
+++ b/saltgui/static/scripts/targettype.js
@@ -19,15 +19,17 @@ class TargetType {
       return;
     }
 
-    if(target.includes("@")) {
-      // @ is a strong indicator for compound target
+    if(target.includes("@") || target.includes(" ") ||
+       target.includes("(") || target.includes(")")) {
+      // "@" is a strong indicator for compound target
+      // but "space", "(" and ")" are also typical for compound target
       TargetType.menuTargetType._value = "compound";
       TargetType._updateTargetTypeText();
       return;
     }
 
     if(target.includes(",")) {
-      // @ is a strong indicator for list target (when it is also not compound)
+      // "," is a strong indicator for list target (when it is also not compound)
       TargetType.menuTargetType._value = "list";
       TargetType._updateTargetTypeText();
       return;

--- a/saltgui/static/scripts/targettype.js
+++ b/saltgui/static/scripts/targettype.js
@@ -4,9 +4,9 @@ class TargetType {
     const targetbox = document.getElementById("targetbox");
     TargetType.menuTargetType = new DropDownMenu(targetbox);
     // do not show the menu title at first
-    TargetType.menuTargetType.addMenuItem("Normal", this._updateTargetTypeText, "glob");
-    TargetType.menuTargetType.addMenuItem("List", this._updateTargetTypeText, "list");
-    TargetType.menuTargetType.addMenuItem("Compound", this._updateTargetTypeText, "compound");
+    TargetType.menuTargetType.addMenuItem("Normal", this.manualUpdateTargetTypeText, "glob");
+    TargetType.menuTargetType.addMenuItem("List", this.manualUpdateTargetTypeText, "list");
+    TargetType.menuTargetType.addMenuItem("Compound", this.manualUpdateTargetTypeText, "compound");
     TargetType.setTargetTypeDefault();
   }
 
@@ -35,6 +35,11 @@ class TargetType {
 
     // do not show it when default and not explicitly selected
     TargetType.setTargetTypeDefault();
+  }
+
+  static manualUpdateTargetTypeText() {
+    TargetType.menuTargetType._system = false;
+    TargetType._updateTargetTypeText();
   }
 
   static _updateTargetTypeText() {


### PR DESCRIPTION
Currently SaltGUI supports only `glob` style addresses as targets.
This PR allows the entry of other targettypes. Instead of supporting all targettypes, only `glob`, `list` and `compound` are now supported. With `compound` available, it is possible to effectively use all other targettypes. e.g. to target minions with a specific "grain" set, use `G@`, e.g. `G@os:CentOS`.
See also https://docs.saltstack.com/en/latest/topics/targeting/compound.html.

A dropdown control after the address field allows to select a different address type. But unless the user makes a selection there, the system will automatically choose `list` when the address contains at least one `,`. Or it will choose `compound` when the address contains at least one `@`, or any of `space`, `(` or `)`.