### PR TITLE
added support for command templates

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -60,6 +60,26 @@ SaltGUI supports the following authentication methods supported by salt:
 
 See the [EAUTH documentation](https://docs.saltstack.com/en/latest/topics/eauth/index.html) and the [Salt auth source code](https://github.com/saltstack/salt/tree/2018.3/salt/auth) for more information.
 
+## Templates
+SaltGUI supports command templates for easier command entry into the command-box.
+The menu item for that becomes visible there when you define one or more templates
+in salt master configuration file `/etc/salt/master`.
+The field `targettype` supports the values `glob`, `list` and `compound`.
+You can leave out any detail field.
+e.g.:
+```
+saltgui_templates:
+    template1:
+        description: First template
+        target: "*"
+        command: test.fib num=10
+    template2:
+        description: Second template
+        targettype: glob
+        target: dev*
+        command: test.version
+```
+
 ## Development environment with Docker
 To make life a bit easier for testing SaltGUI or setting up a local development environment you can use the provided docker-compose setup in this repository to run a saltmaster with two minions, including SaltGUI:
 ```

--- a/README.MD
+++ b/README.MD
@@ -65,6 +65,7 @@ SaltGUI supports command templates for easier command entry into the command-box
 The menu item for that becomes visible there when you define one or more templates
 in salt master configuration file `/etc/salt/master`.
 The field `targettype` supports the values `glob`, `list` and `compound`.
+Entries will be sorted in the GUI based on their key.
 You can leave out any detail field.
 e.g.:
 ```

--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -105,7 +105,7 @@
     <div class='popup' id='popup_runcommand'>
       <div class='run-command'>
         <div class='nearlyvisiblebutton' id='button_close_cmd'>&#x2715;</div>
-        <h1>Manual Run</h1>
+        <div><h1>Manual Run</h1><p style="display: inline" id="templatemenuhere"></p></div>
         <div id="targetbox"><input id='target' type='text' placeholder="Target"/></div>
         <div id="cmdbox"><input id='command' type='text' placeholder="Command"/></div>
         <div id="runblock"><input id="run_command" type='submit' value="Run command"/></div>

--- a/saltgui/static/scripts/api.js
+++ b/saltgui/static/scripts/api.js
@@ -75,6 +75,14 @@ class API {
     return this.apiRequest("POST", "/", params).catch(console.error);
   }
 
+  getTemplates() {
+    const params = {
+      client: "wheel",
+      fun: "config.values"
+    };
+    return this.apiRequest("POST", "/", params).catch(console.error);
+  }
+
   apiRequest(method, route, params) {
     const location = this.APIURL + route;
     const token = window.sessionStorage.getItem("token");

--- a/saltgui/static/scripts/commandbox.js
+++ b/saltgui/static/scripts/commandbox.js
@@ -17,15 +17,15 @@ class CommandBox {
     RunType.createMenu();
     TargetType.createMenu();
 
-    var title = document.querySelector(".run-command #templatemenuhere");
-    var menu = new DropDownMenu(title);
-    var templatesText = localStorage.getItem("templates");
+    const title = document.querySelector(".run-command #templatemenuhere");
+    const menu = new DropDownMenu(title);
+    let templatesText = localStorage.getItem("templates");
     if(!templatesText || templatesText === "undefined") templatesText = "{}";
-    var templates = JSON.parse(templatesText);
-    var keys = Object.keys(templates).sort();
-    let page = this;
+    const templates = JSON.parse(templatesText);
+    const keys = Object.keys(templates).sort();
+    const page = this;
     for(let key of keys) {
-      let template = templates[key];
+      const template = templates[key];
       let description = template["description"];
       if(!description) description = "(" + key + ")";
       menu.addMenuItem(
@@ -60,12 +60,12 @@ class CommandBox {
 
     if(template.targettype) {
       let tt = template.targettype;
-      var targetbox = document.querySelector("#targetbox");
+      const targetbox = document.querySelector("#targetbox");
       // show the extended selection controls when
       targetbox.style.display = "inherit";
       if(tt !== "glob" && tt !== "list" && tt !== "compound") {
-	// we don't support that, revert to standard (not default)
-	tt = "glob";
+        // we don't support that, revert to standard (not default)
+        tt = "glob";
       }
       TargetType.setTargetType(tt);
     } else {
@@ -74,12 +74,12 @@ class CommandBox {
     }
 
     if(template.target) {
-      var target = document.querySelector(".run-command #target");
+      const target = document.querySelector(".run-command #target");
       target.value = template.target;
     }
 
     if(template.command) {
-      var command = document.querySelector(".run-command #command");
+      const command = document.querySelector(".run-command #command");
       command.value = template.command;
     }
   }

--- a/saltgui/static/scripts/commandbox.js
+++ b/saltgui/static/scripts/commandbox.js
@@ -16,6 +16,25 @@ class CommandBox {
 
     RunType.createMenu();
     TargetType.createMenu();
+
+    var title = document.querySelector(".run-command #templatemenuhere");
+    var menu = new DropDownMenu(title);
+    var templatesText = localStorage.getItem("templates");
+    if(!templatesText || templatesText === "undefined") templatesText = "{}";
+    var templates = JSON.parse(templatesText);
+    var keys = Object.keys(templates).sort();
+    let page = this;
+    for(let key of keys) {
+      let template = templates[key];
+      let description = template["description"];
+      if(!description) description = "(" + key + ")";
+      menu.addMenuItem(
+        description,
+        function() {
+          page._applyTemplate(template);
+        }
+      );
+    }
   }
 
   _registerEventListeners() {
@@ -37,13 +56,41 @@ class CommandBox {
     this._addKeyEventListener("#command", this.cmdmenu.verifyAll);
   }
 
+  _applyTemplate(template) {
+
+    if(template.targettype) {
+      let tt = template.targettype;
+      var targetbox = document.querySelector("#targetbox");
+      // show the extended selection controls when
+      targetbox.style.display = "inherit";
+      if(tt !== "glob" && tt !== "list" && tt !== "compound") {
+	// we don't support that, revert to standard (not default)
+	tt = "glob";
+      }
+      TargetType.setTargetType(tt);
+    } else {
+      // not in the template, revert to default
+      TargetType.setTargetTypeDefault();
+    }
+
+    if(template.target) {
+      var target = document.querySelector(".run-command #target");
+      target.value = template.target;
+    }
+
+    if(template.command) {
+      var command = document.querySelector(".run-command #command");
+      command.value = template.command;
+    }
+  }
+
   _addKeyEventListener(selector, func) {
     // keydown is too early, keypress also does not work
     document.querySelector(selector).addEventListener("keyup", func);
     // cut/paste do not work everywhere
     document.querySelector(selector).addEventListener("cut", func);
     document.querySelector(selector).addEventListener("paste", func);
-    // blur/focus should not be needed but are a valueable fallback
+    // blur/focus should not be needed but are a valuable fallback
     document.querySelector(selector).addEventListener("blur", func);
     document.querySelector(selector).addEventListener("focus", func);
   }

--- a/saltgui/static/scripts/commandbox.js
+++ b/saltgui/static/scripts/commandbox.js
@@ -24,7 +24,7 @@ class CommandBox {
     const templates = JSON.parse(templatesText);
     const keys = Object.keys(templates).sort();
     const page = this;
-    for(let key of keys) {
+    for(const key of keys) {
       const template = templates[key];
       let description = template["description"];
       if(!description) description = "(" + key + ")";

--- a/saltgui/static/scripts/dropdown.js
+++ b/saltgui/static/scripts/dropdown.js
@@ -38,12 +38,13 @@ class DropDownMenu {
   }
 
   verifyAll() {
-    if(!this.menuDropdownContent) return;
     let visibleCount = 0;
-    for(const chld of this.menuDropdownContent.children) {
-      const verifyCallback = chld.verifyCallback;
-      if(verifyCallback) verifyCallback(chld);
-      if(chld.style.display !== "none") visibleCount++;
+    if(this.menuDropdownContent) {
+      for(const chld of this.menuDropdownContent.children) {
+        const verifyCallback = chld.verifyCallback;
+        if(verifyCallback) verifyCallback(chld);
+        if(chld.style.display !== "none") visibleCount++;
+      }
     }
     // hide the menu when it has no visible menu-items
     this.menuDropdown.style.display = (visibleCount > 0) ? "inline-block" : "none";

--- a/saltgui/static/scripts/output.js
+++ b/saltgui/static/scripts/output.js
@@ -767,8 +767,8 @@ class Output {
     // this is more generic and it simplifies the handlers
     for(const hostname of minions.sort()) {
 
-      let isSuccess = true;
-      let retCode = 0;
+      const isSuccess = true;
+      const retCode = 0;
 
       let hostResponse = response[hostname];
       if(Output.hasProperties(hostResponse, ["retcode", "return", "success"])) {

--- a/saltgui/static/scripts/routes/minions.js
+++ b/saltgui/static/scripts/routes/minions.js
@@ -21,7 +21,15 @@ class MinionsRoute extends PageRoute {
       minions.router.api.getKeys().then(minions._updateKeys);
       minions.router.api.getJobs().then(minions._updateJobs);
       minions.router.api.getRunningJobs().then(minions._runningJobs);
+      //we need these functions to poulate the dropdown boxes
+      minions.router.api.getTemplates().then(minions._templates);
     });
+  }
+
+  _templates(data) {
+    // store for later use
+    let templates = data.return[0].data.return.saltgui_templates;
+    localStorage.setItem("templates", JSON.stringify(templates));
   }
 
   _updateKeys(data) {

--- a/saltgui/static/scripts/routes/minions.js
+++ b/saltgui/static/scripts/routes/minions.js
@@ -28,7 +28,7 @@ class MinionsRoute extends PageRoute {
 
   _templates(data) {
     // store for later use
-    let templates = data.return[0].data.return.saltgui_templates;
+    const templates = data.return[0].data.return.saltgui_templates;
     localStorage.setItem("templates", JSON.stringify(templates));
   }
 

--- a/saltgui/static/scripts/routes/page.js
+++ b/saltgui/static/scripts/routes/page.js
@@ -139,6 +139,7 @@ class PageRoute extends Route {
       if(job.Function === "saltutil.find_job") continue;
       if(job.Function === "saltutil.running") continue;
       if(job.Function === "sys.doc") continue;
+      if(job.Function === "wheel.config.values") continue;
       if(job.Function === "wheel.key.list_all") continue;
 
       this._addJob(jobContainer, job);

--- a/saltgui/static/scripts/targettype.js
+++ b/saltgui/static/scripts/targettype.js
@@ -69,6 +69,12 @@ class TargetType {
     TargetType.menuTargetType._system = true;
   }
 
+  static setTargetType(tt) {
+    TargetType.menuTargetType._value = tt;
+    TargetType.menuTargetType._system = true;
+    TargetType._updateTargetTypeText();
+  }
+
   static getTargetType() {
     const targetType = TargetType.menuTargetType._value;
     if(targetType === undefined || targetType === "") return "glob";

--- a/saltgui/static/stylesheets/dropdown.css
+++ b/saltgui/static/stylesheets/dropdown.css
@@ -19,6 +19,9 @@ header .menu-dropdown-content {
   display: none;
   box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 0.5);
   position: absolute;
+  max-height: 200px;
+  overflow-y: auto;
+  overflow-x: visible;
   background-color: #e0e0e0;
   border: 10px solid #e0e0e0;
   z-index: 5;


### PR DESCRIPTION
This PR adds support for templates for the command-box.
As requested in #11.
Templates are maintained in the `master` file.
Values from the selected template are simply copied into the on-screen fields.
