### PR TITLE
Nodegroup

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -64,7 +64,7 @@ See the [EAUTH documentation](https://docs.saltstack.com/en/latest/topics/eauth/
 SaltGUI supports command templates for easier command entry into the command-box.
 The menu item for that becomes visible there when you define one or more templates
 in salt master configuration file `/etc/salt/master`.
-The field `targettype` supports the values `glob`, `list` and `compound`.
+The field `targettype` supports the values `glob`, `list`, `compound` and `nodegroup`.
 Entries will be sorted in the GUI based on their key.
 You can leave out any detail field.
 e.g.:

--- a/saltgui/static/scripts/api.js
+++ b/saltgui/static/scripts/api.js
@@ -75,7 +75,7 @@ class API {
     return this.apiRequest("POST", "/", params).catch(console.error);
   }
 
-  getTemplates() {
+  getConfigValues() {
     const params = {
       client: "wheel",
       fun: "config.values"

--- a/saltgui/static/scripts/commandbox.js
+++ b/saltgui/static/scripts/commandbox.js
@@ -63,7 +63,7 @@ class CommandBox {
       const targetbox = document.querySelector("#targetbox");
       // show the extended selection controls when
       targetbox.style.display = "inherit";
-      if(tt !== "glob" && tt !== "list" && tt !== "compound") {
+      if(tt !== "glob" && tt !== "list" && tt !== "compound" && tt !== "nodegroup") {
         // we don't support that, revert to standard (not default)
         tt = "glob";
       }

--- a/saltgui/static/scripts/commandbox.js
+++ b/saltgui/static/scripts/commandbox.js
@@ -218,7 +218,7 @@ class CommandBox {
     if(tgtType === "nodegroup") {
       const nodegroups = JSON.parse(window.localStorage.getItem("nodegroups"));
       if(!(target in nodegroups)) {
-        this._showError("Unknown nodegroup");
+        this._showError("Unknown nodegroup '" + target + "'");
         return null;
       }
     }

--- a/saltgui/static/scripts/commandbox.js
+++ b/saltgui/static/scripts/commandbox.js
@@ -213,6 +213,16 @@ class CommandBox {
       return null;
     }
 
+    // SALT API returns a 500-InternalServerError when it hits an unknown group
+    // Let's improve on that
+    if(tgtType === "nodegroup") {
+      const nodegroups = JSON.parse(window.localStorage.getItem("nodegroups"));
+      if(!(target in nodegroups)) {
+        this._showError("Unknown nodegroup");
+        return null;
+      }
+    }
+
     if(functionToRun.startsWith("runners.")) {
       params.client = "runner";
       // use only the part after "runners." (8 chars)

--- a/saltgui/static/scripts/routes/minions.js
+++ b/saltgui/static/scripts/routes/minions.js
@@ -21,15 +21,18 @@ class MinionsRoute extends PageRoute {
       minions.router.api.getKeys().then(minions._updateKeys);
       minions.router.api.getJobs().then(minions._updateJobs);
       minions.router.api.getRunningJobs().then(minions._runningJobs);
-      //we need these functions to poulate the dropdown boxes
-      minions.router.api.getTemplates().then(minions._templates);
+      //we need these functions to populate the dropdown boxes
+      minions.router.api.getConfigValues().then(minions._configvalues);
     });
   }
 
-  _templates(data) {
+  _configvalues(data) {
     // store for later use
     const templates = data.return[0].data.return.saltgui_templates;
     localStorage.setItem("templates", JSON.stringify(templates));
+    let nodegroups = data.return[0].data.return.nodegroups;
+    if(!nodegroups) nodegroups = {};
+    localStorage.setItem("nodegroups", JSON.stringify(nodegroups));
   }
 
   _updateKeys(data) {

--- a/saltgui/static/scripts/targettype.js
+++ b/saltgui/static/scripts/targettype.js
@@ -6,6 +6,7 @@ class TargetType {
     // do not show the menu title at first
     TargetType.menuTargetType.addMenuItem("Normal", this.manualUpdateTargetTypeText, "glob");
     TargetType.menuTargetType.addMenuItem("List", this.manualUpdateTargetTypeText, "list");
+    TargetType.menuTargetType.addMenuItem("Nodegroup", this.manualUpdateTargetTypeText, "nodegroup");
     TargetType.menuTargetType.addMenuItem("Compound", this.manualUpdateTargetTypeText, "compound");
     TargetType.setTargetTypeDefault();
   }
@@ -57,6 +58,9 @@ class TargetType {
       break;
     case "list":
       TargetType.menuTargetType.setTitle("List");
+      break;
+    case "nodegroup":
+      TargetType.menuTargetType.setTitle("Nodegroup");
       break;
     }
   }

--- a/saltgui/static/scripts/targettype.js
+++ b/saltgui/static/scripts/targettype.js
@@ -6,9 +6,21 @@ class TargetType {
     // do not show the menu title at first
     TargetType.menuTargetType.addMenuItem("Normal", this.manualUpdateTargetTypeText, "glob");
     TargetType.menuTargetType.addMenuItem("List", this.manualUpdateTargetTypeText, "list");
-    TargetType.menuTargetType.addMenuItem("Nodegroup", this.manualUpdateTargetTypeText, "nodegroup");
+    TargetType.menuTargetType.addMenuItem(TargetType._targetTypeNodeGroupPrepare, this.manualUpdateTargetTypeText, "nodegroup");
     TargetType.menuTargetType.addMenuItem("Compound", this.manualUpdateTargetTypeText, "compound");
     TargetType.setTargetTypeDefault();
+  }
+
+  // It takes a while before we known the list of nodegroups
+  // so this conclusion must be re-evaluated each time
+  static _targetTypeNodeGroupPrepare(menuitem) {
+    const nodegroups = window.localStorage.getItem("nodegroups");
+    if(nodegroups && nodegroups != "{}") {
+      menuitem.innerText = "Nodegroup";
+      menuitem.style.display = "block";
+    } else {
+      menuitem.style.display = "none";
+    }
   }
 
   static autoSelectTargetType(target) {


### PR DESCRIPTION
Based on #83 and the first implementation by @lostsnow, the commandbox now supports nodegroups.
The menuitem for that only appears when there are nodegroups defined.
A custom error message is shown when the node group is unknown, which is better than the "Internal Server Error" that the SaltAPI would return.