### PR TITLE
added autocomplete for minion or nodegroup entry

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -121,6 +121,10 @@ This excellent frontend is originally written by [Oliver Dunk](https://github.co
 
 ## Changelog
 
+## 1.5.1 (2018-12-08)
+- fixed named parameter issues reported by marceliq (erwindon)
+- fixed result display for wheel/runner functions (erwindon)
+
 ## 1.5.0 (2018-12-03)
 - added command templates (erwindon)
 - added targettype nodegroups (lostsnow)

--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -54,7 +54,7 @@
           </select>
           <input type='submit' id='login-submit' value='Login'/>
           <div class='attribution'>
-            <img src='static/images/github.png' />SaltGUI v1.5.0
+            <img src='static/images/github.png' />SaltGUI v1.5.1
           </div>
         </form>
       </div>

--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -106,7 +106,7 @@
       <div class='run-command'>
         <div class='nearlyvisiblebutton' id='button_close_cmd'>&#x2715;</div>
         <div><h1>Manual Run</h1><p style="display: inline" id="templatemenuhere"></p></div>
-        <div id="targetbox"><input id='target' type='text' placeholder="Target"/></div>
+        <div id="targetbox"><input list="targetlist" id='target' type='text' placeholder="Target"/><datalist id="targetlist"/></div>
         <div id="cmdbox"><input id='command' type='text' placeholder="Command"/></div>
         <div id="runblock"><input id="run_command" type='submit' value="Run command"/></div>
         <pre class='output'>Waiting for command...</pre>

--- a/saltgui/static/scripts/commandbox.js
+++ b/saltgui/static/scripts/commandbox.js
@@ -138,6 +138,24 @@ class CommandBox {
 
     RunType.setRunTypeDefault();
 
+    // (re-)populate the dropdown box
+    const targetlist = document.getElementById("targetlist");
+    while (targetlist.firstChild) {
+      targetlist.removeChild(targetlist.firstChild);
+    }
+    const nodegroups = JSON.parse(window.localStorage.getItem("nodegroups"));
+    for(let nodegroup of Object.keys(nodegroups).sort()) {
+      let option = document.createElement("option");
+      option.value = "#" + nodegroup;
+      targetlist.appendChild(option);
+    }
+    const minions = JSON.parse(window.localStorage.getItem("minions"));
+    for(let minion of minions.sort()) {
+      let option = document.createElement("option");
+      option.value = minion;
+      targetlist.appendChild(option);
+    }
+
     evt.stopPropagation();
   }
 

--- a/saltgui/static/scripts/commandbox.js
+++ b/saltgui/static/scripts/commandbox.js
@@ -144,14 +144,14 @@ class CommandBox {
       targetlist.removeChild(targetlist.firstChild);
     }
     const nodegroups = JSON.parse(window.localStorage.getItem("nodegroups"));
-    for(let nodegroup of Object.keys(nodegroups).sort()) {
-      let option = document.createElement("option");
+    for(const nodegroup of Object.keys(nodegroups).sort()) {
+      const option = document.createElement("option");
       option.value = "#" + nodegroup;
       targetlist.appendChild(option);
     }
     const minions = JSON.parse(window.localStorage.getItem("minions"));
-    for(let minion of minions.sort()) {
-      let option = document.createElement("option");
+    for(const minion of minions.sort()) {
+      const option = document.createElement("option");
       option.value = minion;
       targetlist.appendChild(option);
     }

--- a/saltgui/static/scripts/commandbox.js
+++ b/saltgui/static/scripts/commandbox.js
@@ -190,9 +190,9 @@ class CommandBox {
     const args = [ ];
 
     // collection for named parameters
-    const params = { };
+    const kwargs = { };
 
-    const ret = window.parseCommandLine(toRun, args, params);
+    const ret = window.parseCommandLine(toRun, args, kwargs);
     if(ret !== null) {
       // that is an error message being returned
       this._showError(ret);
@@ -230,15 +230,18 @@ class CommandBox {
       }
     }
 
+    let params = { };
     if(functionToRun.startsWith("runners.")) {
+      params = kwargs;
       params.client = "runner";
       // use only the part after "runners." (8 chars)
       params.fun = functionToRun.substring(8);
-      if(args.length !== 0) params.arg = args;
+      if(args.length > 0) params.arg = args;
     } else if(functionToRun.startsWith("wheel.")) {
       // wheel.key functions are treated slightly different
       // we re-use the "target" field to fill the parameter "match"
       // as used by the salt.wheel.key functions
+      params = kwargs;
       params.client = "wheel";
       // use only the part after "wheel." (6 chars)
       params.fun = functionToRun.substring(6);
@@ -249,6 +252,7 @@ class CommandBox {
       params.tgt = target;
       if(tgtType) params.tgt_type = tgtType;
       if(args.length !== 0) params.arg = args;
+      if(Object.keys(kwargs).length > 0) params.kwarg = kwargs;
     }
 
     const runType = RunType.getRunType();

--- a/saltgui/static/scripts/commandbox.js
+++ b/saltgui/static/scripts/commandbox.js
@@ -118,7 +118,9 @@ class CommandBox {
 
   _onRunReturn(response, command) {
     const outputContainer = document.querySelector(".run-command pre");
-    const minions = Object.keys(response);
+    let minions = Object.keys(response);
+    if(command.startsWith("runners.")) minions = ["RUNNER"];
+    if(command.startsWith("wheel.")) minions = ["WHEEL"];
     Output.addResponseOutput(outputContainer, minions, response, command);
     const button = document.querySelector(".run-command input[type='submit']");
     button.disabled = false;

--- a/saltgui/static/scripts/routes/page.js
+++ b/saltgui/static/scripts/routes/page.js
@@ -26,6 +26,9 @@ class PageRoute extends Route {
     const list = this.getPageElement().querySelector("#minions");
     const hostnames = Object.keys(minions).sort();
 
+    // save for the autocompletion
+    window.localStorage.setItem("minions", JSON.stringify(hostnames));
+
     for(const hostname of hostnames) {
       const minion_info = minions[hostname];
 


### PR DESCRIPTION
As requested in #86 
Uses the html native feature `<datalist>`.
The list holds the minion names and the node-group names. The node-group names are prefixed with `#` for easy entry.
Note that both the minion list and the node-group list are updated asynchronously. So entries in the list may be available only a few seconds after start-up.