### PR TITLE
ignore error from the login-session-check

### DIFF
--- a/saltgui/static/scripts/api.js
+++ b/saltgui/static/scripts/api.js
@@ -18,7 +18,7 @@ class API {
     return this.apiRequest("GET", "/stats", {})
       .then(response => {
         return window.sessionStorage.getItem("token") !== null;
-      });
+      }, response => { return false; } );
   }
 
   login(username, password, eauth="pam") {


### PR DESCRIPTION
SaltGUI verifies the validity of the login session.
However, it leaves a nasty looking (but harmless) error message when the user is not logged in.
That error is now suppressed.