### PR TITLE
add a few simple commands for grains

### DIFF
--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -112,7 +112,7 @@
 
       <div class='route' id='page_grainsminion'>
         <div class='dashboard'>
-          <div class='panel minion-list'>
+          <div id="grainsminion_page" class='panel minion-list'>
             <div class='nearlyvisiblebutton' id='button_close_grainsminion'>&#x2715;</div>
             <h1 id="grainsminion_title">Grains on ...</h1>
             <ul id="grainsminion_list" class='grains'></ul>

--- a/saltgui/static/scripts/commandbox.js
+++ b/saltgui/static/scripts/commandbox.js
@@ -181,6 +181,10 @@ class CommandBox {
     const command = document.querySelector(".run-command #command").value.split(" ")[0];
     const output = document.querySelector(".run-command pre").innerText;
     const screenModifyingCommands = [
+      "grains.append",
+      "grains.delkey",
+      "grains.delval",
+      "grains.setval",
       "wheel.key.accept",
       "wheel.key.delete",
       "wheel.key.reject",

--- a/saltgui/static/scripts/routes/grainsminion.js
+++ b/saltgui/static/scripts/routes/grainsminion.js
@@ -34,7 +34,18 @@ class GrainsMinionRoute extends PageRoute {
     const title = document.getElementById("grainsminion_title");
     title.innerText = "Grains on " + minion;
 
+    const gmp = document.getElementById("grainsminion_page");
+    const menu = new DropDownMenu(gmp);
+    menu.addMenuItem("Add&nbsp;grain...", function(evt) {
+      // use placeholders for name and value
+      this._runCommand(evt, minion, "grains.setval \"name\" \"value\"");
+    }.bind(this));
+
     const container = document.getElementById("grainsminion_list");
+
+    // new menu's are always added at the bottom of the div
+    // fix that by re-adding the minion list
+    gmp.appendChild(container);
 
     while(container.firstChild) {
       container.removeChild(container.firstChild);
@@ -53,6 +64,22 @@ class GrainsMinionRoute extends PageRoute {
       const grain_value = Output.formatJSON(grains[k]);
       const value = Route._createDiv("grain_value", grain_value);
       grain.appendChild(value);
+
+      const menu = new DropDownMenu(grain);
+      menu.addMenuItem("Edit&nbsp;grain...", function(evt) {
+        this._runCommand(evt, minion, "grains.setval \"" + k + "\" " + JSON.stringify(grains[k]));
+      }.bind(this));
+      if(grain_value.startsWith("[")) {
+        menu.addMenuItem("Add&nbsp;value...", function(evt) {
+          this._runCommand(evt, minion, "grains.append \"" + k + "\" \"value\"");
+        }.bind(this));
+      }
+      menu.addMenuItem("Delete&nbsp;key...", function(evt) {
+        this._runCommand(evt, minion, "grains.delkey \"" + k + "\"");
+      }.bind(this));
+      menu.addMenuItem("Delete&nbsp;value...", function(evt) {
+        this._runCommand(evt, minion, "grains.delval \"" + k + "\"");
+      }.bind(this));
 
       container.appendChild(grain);
     }

--- a/saltgui/static/scripts/routes/page.js
+++ b/saltgui/static/scripts/routes/page.js
@@ -158,7 +158,11 @@ class PageRoute extends Route {
     while(shown < 7 && jobs[i] !== undefined) {
       const job = jobs[i];
       i = i + 1;
+      if(job.Function === "grains.append") continue;
+      if(job.Function === "grains.delkey") continue;
+      if(job.Function === "grains.delval") continue;
       if(job.Function === "grains.items") continue;
+      if(job.Function === "grains.setval") continue;
       if(job.Function === "pillar.items") continue;
       if(job.Function === "runner.jobs.active") continue;
       if(job.Function === "runner.jobs.list_job") continue;


### PR DESCRIPTION
See #60 

*  edit grain
    compose a `grains.setval` command to update the grain value. the command is ready-to-run, but usually the value is updated first by the user.
 *   delete grain
    compose a `grains.delkey` command to delete the grain. the command is ready-to-run
 *   delete grain value
    compose a `grains.delval` command to delete the grain value. this may have limited use next to the previous command. the command is ready-to-run
 *   add item to grain
    only available when the grain value is a list. compose a `grains.append` command. it is easier to use than the edit-grain function
*    delete item from grain
Chose to not implement this, due to fact that GUI would become messy