### PR TITLE
add a few simple commands for schedules

### DIFF
--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -139,7 +139,7 @@
 
       <div class='route' id='page_schedulesminion'>
         <div class='dashboard'>
-          <div class='panel minion-list'>
+          <div id="schedulesminion_page" class='panel minion-list'>
             <div class='nearlyvisiblebutton' id='button_close_schedulesminion'>&#x2715;</div>
             <h1 id="schedulesminion_title">Schedules on ...</h1>
             <ul id="schedulesminion_list" class='schedules'></ul>

--- a/saltgui/static/scripts/commandbox.js
+++ b/saltgui/static/scripts/commandbox.js
@@ -181,6 +181,12 @@ class CommandBox {
     const command = document.querySelector(".run-command #command").value.split(" ")[0];
     const output = document.querySelector(".run-command pre").innerText;
     const screenModifyingCommands = [
+      "schedule.delete",
+      "schedule.disable",
+      "schedule.disable_job",
+      "schedule.enable",
+      "schedule.enable_job",
+      "schedule.modify",
       "wheel.key.accept",
       "wheel.key.delete",
       "wheel.key.reject",

--- a/saltgui/static/scripts/routes/page.js
+++ b/saltgui/static/scripts/routes/page.js
@@ -165,7 +165,14 @@ class PageRoute extends Route {
       if(job.Function === "runner.jobs.list_jobs") continue;
       if(job.Function === "saltutil.find_job") continue;
       if(job.Function === "saltutil.running") continue;
+      if(job.Function === "schedule.delete") continue;
+      if(job.Function === "schedule.disable") continue;
+      if(job.Function === "schedule.disable_job") continue;
+      if(job.Function === "schedule.enable") continue;
+      if(job.Function === "schedule.enable_job") continue;
       if(job.Function === "schedule.list") continue;
+      if(job.Function === "schedule.modify") continue;
+      if(job.Function === "schedule.run_job") continue;
       if(job.Function === "sys.doc") continue;
       if(job.Function === "wheel.config.values") continue;
       if(job.Function === "wheel.key.accept") continue;

--- a/saltgui/static/scripts/routes/schedules.js
+++ b/saltgui/static/scripts/routes/schedules.js
@@ -84,10 +84,8 @@ class SchedulesRoute extends PageRoute {
     element.appendChild(Route._createDiv("scheduleinfo", scheduleinfo));
 
     const menu = new DropDownMenu(element);
-    if(cnt > 0) {
-      menu.addMenuItem("Show&nbsp;schedules", function(evt) {
-        window.location.assign("schedulesminion?minion=" + encodeURIComponent(hostname));
-      }.bind(this));
-    }
+    menu.addMenuItem("Show&nbsp;schedules", function(evt) {
+      window.location.assign("schedulesminion?minion=" + encodeURIComponent(hostname));
+    }.bind(this));
   }
 }

--- a/saltgui/static/scripts/routes/schedulesminion.js
+++ b/saltgui/static/scripts/routes/schedulesminion.js
@@ -37,7 +37,18 @@ class SchedulesMinionRoute extends PageRoute {
     if(!schedules.enabled) txt += " (disabled)";
     title.innerText = txt;
 
+    const page = document.getElementById("schedulesminion_page");
+
+    const menu = new DropDownMenu(page);
+    menu.addMenuItem("Enable&nbsp;scheduler...", function(evt) {
+      this._runCommand(evt, minion, "schedule.enable");
+    }.bind(this));
+    menu.addMenuItem("Disable&nbsp;scheduler...", function(evt) {
+      this._runCommand(evt, minion, "schedule.disable");
+    }.bind(this));
+
     const container = document.getElementById("schedulesminion_list");
+    page.append(container);
 
     while(container.firstChild) {
       container.removeChild(container.firstChild);
@@ -68,10 +79,33 @@ class SchedulesMinionRoute extends PageRoute {
 
       const schedule_value = Output.formatJSON(schedule);
       const value = Route._createDiv("schedule_value", schedule_value);
-      if(schedule.hasOwnProperty("enabled") && !schedule.enabled) {
-        value.classList.add("disabled_schedule");
-      }
+      const isJobDisabled = schedule.hasOwnProperty("enabled") && !schedule.enabled;
+      if(isJobDisabled) value.classList.add("disabled_schedule");
       li.appendChild(value);
+
+      const menu = new DropDownMenu(li);
+      menu.addMenuItem("Modify&nbsp;job...", function(evt) {
+        let cmd = "schedule.modify " + k;
+        for(const key in schedule) {
+          cmd = cmd + " " + key + "=" + JSON.stringify(schedule[key]);
+        }
+        this._runCommand(evt, minion, cmd);
+      }.bind(this));
+      menu.addMenuItem("Enable&nbsp;job...", function(evt) {
+        this._runCommand(evt, minion, "schedule.enable_job " + k);
+      }.bind(this));
+      menu.addMenuItem("Disable&nbsp;job...", function(evt) {
+        this._runCommand(evt, minion, "schedule.disable_job " + k);
+      }.bind(this));
+      menu.addMenuItem("Delete&nbsp;job...", function(evt) {
+        this._runCommand(evt, minion, "schedule.delete " + k);
+      }.bind(this));
+      menu.addMenuItem("Run&nbsp;job...", function(evt) {
+        let cmd = "schedule.run_job";
+        if(isJobDisabled) cmd += " force=true";
+        cmd += " " + k;
+        this._runCommand(evt, minion, cmd);
+      }.bind(this));
 
       container.appendChild(li);
     }


### PR DESCRIPTION
See #61 

* run a job manually
    compose a ready-to-run `schedule.run_job` command to start the selected schedule
* commands to enable/disable jobs
    compose a ready-to-run `schedule.enable_job` or `schedule.disable_job` for the selected schedule
* commands to enable/disable scheduler
    compose a ready-to-run `schedule.enable` or `schedule.disable` for the selected minion.
* command to delete a job
    compose a ready-to-run `schedule.delete` command for the selected schedule
* commands to edit a job
    compose a `schedule.modify` command for the selected schedule. all displayed parameters are pre-filled in the command