### PR TITLE
Fix authentication failures for some commands when using docker

### DIFF
--- a/docker/conf/master
+++ b/docker/conf/master
@@ -11,10 +11,7 @@ pillar_roots:
 external_auth:
   pam:
     salt:
-      - grains.items
-      - sys.doc
-      - state.apply
-
+      - .*
       - '@runner':
         - 'jobs.*'
       - '@wheel':


### PR DESCRIPTION
See #97 
The docker images contained a more restrictive `master` file than what was advertised in the documentation in `README.MD`.