### PR TITLE
improvement for pillar information are not always secret 

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -83,6 +83,20 @@ saltgui_templates:
         command: test.version
 ```
 
+## Pillars
+Pillars potentially contain security senstitive information.
+Therefore their values are initially hidden.
+Values become visible by clicking on them.
+This behavior can be changed by adjusting the values of the configuration
+in salt master configuration file `/etc/salt/master`.
+The values for the pillar whose name match one of these regular expressions
+are initially shown.
+e.g.:
+```
+saltgui_public_pillars:
+    - pub_.*
+```
+
 ## Development environment with Docker
 To make life a bit easier for testing SaltGUI or setting up a local development environment you can use the provided docker-compose setup in this repository to run a saltmaster with two minions, including SaltGUI:
 ```

--- a/saltgui/static/scripts/routes/minions.js
+++ b/saltgui/static/scripts/routes/minions.js
@@ -29,7 +29,7 @@ class MinionsRoute extends PageRoute {
     const templates = data.return[0].data.return.saltgui_templates;
     localStorage.setItem("templates", JSON.stringify(templates));
 
-    let public_pillars = data.return[0].data.return.saltgui_public_pillars;
+    const public_pillars = data.return[0].data.return.saltgui_public_pillars;
     localStorage.setItem("public_pillars", JSON.stringify(public_pillars));
 
     let nodegroups = data.return[0].data.return.nodegroups;

--- a/saltgui/static/scripts/routes/minions.js
+++ b/saltgui/static/scripts/routes/minions.js
@@ -25,8 +25,13 @@ class MinionsRoute extends PageRoute {
 
   _configvalues(data) {
     // store for later use
+
     const templates = data.return[0].data.return.saltgui_templates;
     localStorage.setItem("templates", JSON.stringify(templates));
+
+    let public_pillars = data.return[0].data.return.saltgui_public_pillars;
+    localStorage.setItem("public_pillars", JSON.stringify(public_pillars));
+
     let nodegroups = data.return[0].data.return.nodegroups;
     if(!nodegroups) nodegroups = {};
     localStorage.setItem("nodegroups", JSON.stringify(nodegroups));

--- a/saltgui/static/scripts/routes/pillarsminion.js
+++ b/saltgui/static/scripts/routes/pillarsminion.js
@@ -50,7 +50,7 @@ class PillarsMinionRoute extends PageRoute {
     if(!Array.isArray(public_pillars)) public_pillars = [ ];
     for(let i = 0; i < public_pillars.length; i++) {
       try {
-        public_pillars[i] = new RegExp(public_pillars);
+        public_pillars[i] = new RegExp(public_pillars[i]);
       }
       catch(err) {
         // most likely a syntax error in the RE

--- a/saltgui/static/scripts/routes/pillarsminion.js
+++ b/saltgui/static/scripts/routes/pillarsminion.js
@@ -43,6 +43,21 @@ class PillarsMinionRoute extends PageRoute {
 
     if(!pillars) return;
 
+    // collect the public pillars and compile their regexps
+    let publicPillarsText = localStorage.getItem("public_pillars");
+    if(!publicPillarsText || publicPillarsText === "undefined") publicPillarsText = "[]";
+    let public_pillars = JSON.parse(publicPillarsText);
+    if(!Array.isArray(public_pillars)) public_pillars = [ ];
+    for(let i = 0; i < public_pillars.length; i++) {
+      try {
+        public_pillars[i] = new RegExp(public_pillars);
+      }
+      catch(err) {
+        // most likely a syntax error in the RE
+        public_pillars[i] = null;
+      }
+    }
+
     const keys = Object.keys(pillars).sort();
     for(const k of keys) {
       const pillar = document.createElement('li');
@@ -50,28 +65,38 @@ class PillarsMinionRoute extends PageRoute {
       const name = Route._createDiv("pillar_name", k);
       pillar.appendChild(name);
 
-      // 8 bullet characters
+      // 8 bullet characters when hidden
       const value_hidden = "\u25CF\u25CF\u25CF\u25CF\u25CF\u25CF\u25CF\u25CF";
       const pillar_hidden = Route._createDiv("pillar_hidden", value_hidden);
-      // add the masked representation, shown
+      // initially use the hidden view
       pillar.appendChild(pillar_hidden);
 
       const value_shown = Output.formatJSON(pillars[k]);
       const pillar_shown = Route._createDiv("pillar_shown", value_shown);
+      // initially hide the normal view
       pillar_shown.style.display = "none";
       pillar.appendChild(pillar_shown);
-      // add the non-masked representation, not shown yet
-      
+
+      // show public pillars immediatelly
+      for(let i = 0; i < public_pillars.length; i++) {
+        if(public_pillars[i] && public_pillars[i].test(k)) {
+          // same code as when clicking the hidden value
+          pillar_hidden.style.display = "none";
+          pillar_shown.style.display = "";
+          break;
+        }
+      }
+
       pillar_hidden.addEventListener("click", function(evt) {
         pillar_hidden.style.display = "none";
         pillar_shown.style.display = "";
       });
-     
+
       pillar_shown.addEventListener("click", function(evt) {
         pillar_shown.style.display = "none";
         pillar_hidden.style.display = "";
       });
-     
+
       container.appendChild(pillar);
     }
 


### PR DESCRIPTION
See also #100 
It is now possible to mark a list of pillar name pattern to indicate that these do not hold sensitive information. The pillars matching these patterns are initially shown. All others are initially hidden as before.