### PR TITLE
removed css that prevented copy2clip to work

### DIFF
--- a/saltgui/static/stylesheets/page.css
+++ b/saltgui/static/stylesheets/page.css
@@ -105,12 +105,6 @@ pre .hostname {
   color: #3f51b5;
   cursor: pointer;
   position: relative;
-
-  /* Screw browser prefixes, am I right?! */
-  user-select: none;
-  -ms-user-select: none;
-  -moz-user-select: none;
-  -webkit-user-select: none;
 }
 
 .minions li .address::before,


### PR DESCRIPTION
See #118 
Solved by removing the `user-select: none` clauses from CSS.
@dawidmalina can you verify that this now works properly?