### PR TITLE
Fix package name for centos

### DIFF
--- a/docker/srv/salt/install-packages.sls
+++ b/docker/srv/salt/install-packages.sls
@@ -1,9 +1,0 @@
-{%- if grains['os_family'] == 'Debian' %}
-  {%- set package = "vim" %}
-{%- elif grains['os_family'] == 'RedHat' %}
-  {%- set package = "vim-enhanced" %}
-{%- endif %}
-requirements:
-  pkg.installed:
-    - pkgs:
-      - {{ package }}

--- a/docker/srv/salt/install-packages.sls
+++ b/docker/srv/salt/install-packages.sls
@@ -1,4 +1,9 @@
+{%- if grains['os_family'] == 'Debian' %}
+  {%- set package = "vim" %}
+{%- elif grains['os_family'] == 'RedHat' %}
+  {%- set package = "vim-enhanced" %}
+{%- endif %}
 requirements:
   pkg.installed:
     - pkgs:
-      - vim
+      - {{ package }}

--- a/docker/srv/salt/top.sls
+++ b/docker/srv/salt/top.sls
@@ -1,3 +1,3 @@
 base:
   '*':
-    - install-packages
+    - vim

--- a/docker/srv/salt/vim/init.sls
+++ b/docker/srv/salt/vim/init.sls
@@ -1,0 +1,6 @@
+{% from "vim/map.jinja" import vim with context %}
+
+install vim package :
+  pkg.installed:
+    - pkgs:
+      - {{ vim.package }}

--- a/docker/srv/salt/vim/map.jinja
+++ b/docker/srv/salt/vim/map.jinja
@@ -1,5 +1,5 @@
 {% set vim = salt['grains.filter_by']({
-    'Debian': {
+    'default': {
         'package': 'vim',
     },
     'RedHat': {

--- a/docker/srv/salt/vim/map.jinja
+++ b/docker/srv/salt/vim/map.jinja
@@ -1,0 +1,8 @@
+{% set vim = salt['grains.filter_by']({
+    'Debian': {
+        'package': 'vim',
+    },
+    'RedHat': {
+        'package': 'vim-enhanced',
+    }
+}) %}


### PR DESCRIPTION
CentOS package name is different and highstate failed:
```
local:
----------
          ID: requirements
    Function: pkg.installed
      Result: False
     Comment: The following packages failed to install/update: vim
     Started: 21:37:56.588012
    Duration: 9044.587 ms
     Changes:

Summary for local
------------
Succeeded: 0
Failed:    1
```