### PR TITLE
dropdown menu not immediatelly visible

### DIFF
--- a/saltgui/static/scripts/routes/grains.js
+++ b/saltgui/static/scripts/routes/grains.js
@@ -29,7 +29,12 @@ class GrainsRoute extends PageRoute {
 
     const hostnames = keys.minions.sort();
     for(const hostname of hostnames) {
-      this._addMinion(list, hostname);
+      this._addMinion(list, hostname, 1);
+
+      // preliminary dropdown menu
+      const element = document.getElementById(hostname);
+      const menu = new DropDownMenu(element);
+      this._addMenuItemShowGrains(menu, hostname);
     }
 
     this.keysLoaded = true;
@@ -60,6 +65,10 @@ class GrainsRoute extends PageRoute {
     element.appendChild(grainInfoTd);
 
     const menu = new DropDownMenu(element);
+    this._addMenuItemShowGrains(menu, hostname);
+  }
+
+  _addMenuItemShowGrains(menu, hostname) {
     menu.addMenuItem("Show&nbsp;grains", function(evt) {
       window.location.assign("grainsminion?minion=" + encodeURIComponent(hostname));
     }.bind(this));

--- a/saltgui/static/scripts/routes/grainsminion.js
+++ b/saltgui/static/scripts/routes/grainsminion.js
@@ -18,6 +18,9 @@ class GrainsMinionRoute extends PageRoute {
 
     const minion = decodeURIComponent(window.getQueryParam("minion"));
 
+    const title = document.getElementById("grainsminion_title");
+    title.innerText = "Grains on " + minion;
+
     return new Promise(function(resolve, reject) {
       minions.resolvePromise = resolve;
       if(minions.keysLoaded && minions.jobsLoaded) resolve();
@@ -30,9 +33,6 @@ class GrainsMinionRoute extends PageRoute {
     const minion = decodeURIComponent(window.getQueryParam("minion"));
 
     const grains = data.return[0][minion];
-
-    const title = document.getElementById("grainsminion_title");
-    title.innerText = "Grains on " + minion;
 
     const gmp = document.getElementById("grainsminion_page");
     const menu = new DropDownMenu(gmp);

--- a/saltgui/static/scripts/routes/keys.js
+++ b/saltgui/static/scripts/routes/keys.js
@@ -6,9 +6,6 @@ class KeysRoute extends PageRoute {
     this.jobsLoaded = false;
 
     this._updateKeys = this._updateKeys.bind(this);
-    this._runAcceptKey = this._runAcceptKey.bind(this);
-    this._runRejectKey = this._runRejectKey.bind(this);
-    this._runDeleteKey = this._runDeleteKey.bind(this);
   }
 
   onShow() {
@@ -36,7 +33,13 @@ class KeysRoute extends PageRoute {
 
     const hostnames_accepted = keys.minions.sort();
     for(const hostname of hostnames_accepted) {
-      this._addMinion(list, hostname);
+      this._addMinion(list, hostname, 1);
+
+      // preliminary dropdown menu
+      const element = document.getElementById(hostname);
+      const menu = new DropDownMenu(element);
+      this._addMenuItemReject(menu, hostname, " include_accepted=true");
+      this._addMenuItemDelete(menu, hostname, "");
     }
 
     const hostnames_denied = keys.minions_denied.sort();
@@ -65,24 +68,6 @@ class KeysRoute extends PageRoute {
 
     this.keysLoaded = true;
     if(this.keysLoaded && this.jobsLoaded) this.resolvePromise();
-  }
-
-  _addMenuItemAccept(menu, hostname, extra) {
-    menu.addMenuItem("Accept&nbsp;key...", function(evt) {
-      this._runAcceptKey(evt, hostname, extra);
-    }.bind(this));
-  }
-
-  _addMenuItemDelete(menu, hostname, extra) {
-    menu.addMenuItem("Delete&nbsp;key...", function(evt) {
-      this._runDeleteKey(evt, hostname, extra);
-    }.bind(this));
-  }
-
-  _addMenuItemReject(menu, hostname, extra) {
-    menu.addMenuItem("Reject&nbsp;key...", function(evt) {
-      this._runRejectKey(evt, hostname, extra);
-    }.bind(this));
   }
 
   _updateOfflineMinion(container, hostname) {
@@ -171,15 +156,21 @@ class KeysRoute extends PageRoute {
     container.tBodies[0].appendChild(element);
   }
 
-  _runAcceptKey(evt, hostname, extra) {
-    this._runCommand(evt, hostname, "wheel.key.accept" + extra);
+  _addMenuItemAccept(menu, hostname, extra) {
+    menu.addMenuItem("Accept&nbsp;key...", function(evt) {
+      this._runCommand(evt, hostname, "wheel.key.accept" + extra);
+    }.bind(this));
   }
 
-  _runRejectKey(evt, hostname, extra) {
-    this._runCommand(evt, hostname, "wheel.key.reject" + extra);
+  _addMenuItemReject(menu, hostname, extra) {
+    menu.addMenuItem("Reject&nbsp;key...", function(evt) {
+      this._runCommand(evt, hostname, "wheel.key.reject" + extra);
+    }.bind(this));
   }
 
-  _runDeleteKey(evt, hostname, extra) {
-    this._runCommand(evt, hostname, "wheel.key.delete" + extra);
+  _addMenuItemDelete(menu, hostname, extra) {
+    menu.addMenuItem("Delete&nbsp;key...", function(evt) {
+      this._runCommand(evt, hostname, "wheel.key.delete" + extra);
+    }.bind(this));
   }
 }

--- a/saltgui/static/scripts/routes/minions.js
+++ b/saltgui/static/scripts/routes/minions.js
@@ -6,7 +6,6 @@ class MinionsRoute extends PageRoute {
     this.jobsLoaded = false;
 
     this._updateKeys = this._updateKeys.bind(this);
-    this._runStateApply = this._runStateApply.bind(this);
   }
 
   onShow() {
@@ -50,17 +49,16 @@ class MinionsRoute extends PageRoute {
 
     const hostnames = keys.minions.sort();
     for(const hostname of hostnames) {
-      this._addMinion(list, hostname);
+      this._addMinion(list, hostname, 1);
+
+      // preliminary dropdown menu
+      const element = document.getElementById(hostname);
+      const menu = new DropDownMenu(element);
+      this._addMenuItemStateApply(menu, hostname);
     }
 
     this.keysLoaded = true;
     if(this.keysLoaded && this.jobsLoaded) this.resolvePromise();
-  }
-
-  _addMenuItemStateApply(menu, hostname) {
-    menu.addMenuItem("Apply&nbsp;state...", function(evt) {
-      this._runStateApply(evt, hostname);
-    }.bind(this));
   }
 
   _updateOfflineMinion(container, hostname) {
@@ -82,7 +80,9 @@ class MinionsRoute extends PageRoute {
     this._addMenuItemStateApply(menu, hostname);
   }
 
-  _runStateApply(evt, hostname) {
-    this._runCommand(evt, hostname, "state.apply");
+  _addMenuItemStateApply(menu, hostname) {
+    menu.addMenuItem("Apply&nbsp;state...", function(evt) {
+      this._runCommand(evt, hostname, "state.apply");
+    }.bind(this));
   }
 }

--- a/saltgui/static/scripts/routes/page.js
+++ b/saltgui/static/scripts/routes/page.js
@@ -327,7 +327,7 @@ class PageRoute extends Route {
     tr.appendChild(Route._createTd("starttime", startTimeText));
 
     const menu = new DropDownMenu(tr);
-    menu.addMenuItem("Show&nbsp;details...", function(evt) {
+    menu.addMenuItem("Show&nbsp;details", function(evt) {
       window.location.assign("/job?id=" + encodeURIComponent(job.id));
     }.bind(this));
 

--- a/saltgui/static/scripts/routes/page.js
+++ b/saltgui/static/scripts/routes/page.js
@@ -182,7 +182,7 @@ class PageRoute extends Route {
     }
   }
 
-  _addMinion(container, hostname) {
+  _addMinion(container, hostname, freeColumns = 0) {
 
     let element = document.getElementById(hostname);
     if(element !== null) {
@@ -202,7 +202,7 @@ class PageRoute extends Route {
     element.appendChild(Route._createTd("os", "loading..."));
 
     // fill out the number of columns to that of the header
-    while(element.cells.length < container.tHead.rows[0].cells.length) {
+    while(element.cells.length < container.tHead.rows[0].cells.length - freeColumns) {
       element.appendChild(Route._createTd("", ""));
     }
 

--- a/saltgui/static/scripts/routes/pillars.js
+++ b/saltgui/static/scripts/routes/pillars.js
@@ -29,7 +29,12 @@ class PillarsRoute extends PageRoute {
 
     const hostnames = keys.minions.sort();
     for(const hostname of hostnames) {
-      this._addMinion(list, hostname);
+      this._addMinion(list, hostname, 1);
+
+      // preliminary dropdown menu
+      const element = document.getElementById(hostname);
+      const menu = new DropDownMenu(element);
+      this._addMenuItemShowPillars(menu, hostname);
     }
 
     this.keysLoaded = true;
@@ -65,6 +70,10 @@ class PillarsRoute extends PageRoute {
     element.appendChild(pillarInfoTd);
 
     const menu = new DropDownMenu(element);
+    this._addMenuItemShowPillars(menu, hostname);
+  }
+
+  _addMenuItemShowPillars(menu, hostname) {
     menu.addMenuItem("Show&nbsp;pillars", function(evt) {
       window.location.assign("pillarsminion?minion=" + encodeURIComponent(hostname));
     }.bind(this));

--- a/saltgui/static/scripts/routes/pillarsminion.js
+++ b/saltgui/static/scripts/routes/pillarsminion.js
@@ -36,9 +36,7 @@ class PillarsMinionRoute extends PageRoute {
 
     const pmp = document.getElementById("pillarsminion_page");
     const menu = new DropDownMenu(pmp);
-    menu.addMenuItem("Refresh&nbsp;pillar...", function(evt) {
-      this._runCommand(evt, minion, "saltutil.refresh_pillar");
-    }.bind(this));
+    this._addMenuItemRefreshPillar(menu, minion);
 
     const container = document.getElementById("pillarsminion_list");
 
@@ -116,5 +114,11 @@ class PillarsMinionRoute extends PageRoute {
       const noPillarsMsg = Route._createTd("msg", "No pillars found");
       container.tBodies[0].appendChild(noPillarsMsg);
     }
+  }
+
+  _addMenuItemRefreshPillar(menu, hostname) {
+    menu.addMenuItem("Refresh&nbsp;pillar...", function(evt) {
+      this._runCommand(evt, hostname, "saltutil.refresh_pillar");
+    }.bind(this));
   }
 }

--- a/saltgui/static/scripts/routes/pillarsminion.js
+++ b/saltgui/static/scripts/routes/pillarsminion.js
@@ -18,6 +18,9 @@ class PillarsMinionRoute extends PageRoute {
 
     const minion = decodeURIComponent(window.getQueryParam("minion"));
 
+    const title = document.getElementById("pillarsminion_title");
+    title.innerText = "Pillars on " + minion;
+
     return new Promise(function(resolve, reject) {
       minions.resolvePromise = resolve;
       if(minions.keysLoaded && minions.jobsLoaded) resolve();
@@ -30,9 +33,6 @@ class PillarsMinionRoute extends PageRoute {
     const minion = decodeURIComponent(window.getQueryParam("minion"));
 
     const pillars = data.return[0][minion];
-
-    const title = document.getElementById("pillarsminion_title");
-    title.innerText = "Pillars on " + minion;
 
     const pmp = document.getElementById("pillarsminion_page");
     const menu = new DropDownMenu(pmp);

--- a/saltgui/static/scripts/routes/schedules.js
+++ b/saltgui/static/scripts/routes/schedules.js
@@ -47,7 +47,12 @@ class SchedulesRoute extends PageRoute {
 
     const hostnames = keys.minions.sort();
     for(const hostname of hostnames) {
-      this._addMinion(list, hostname);
+      this._addMinion(list, hostname, 1);
+
+      // preliminary dropdown menu
+      const element = document.getElementById(hostname);
+      const menu = new DropDownMenu(element);
+      this._addMenuItemShowSchedules(menu, hostname);
     }
 
     this.keysLoaded = true;
@@ -96,6 +101,10 @@ class SchedulesRoute extends PageRoute {
     element.appendChild(td);
 
     const menu = new DropDownMenu(element);
+    this._addMenuItemShowSchedules(menu, hostname);
+  }
+
+  _addMenuItemShowSchedules(menu, hostname) {
     menu.addMenuItem("Show&nbsp;schedules", function(evt) {
       window.location.assign("schedulesminion?minion=" + encodeURIComponent(hostname));
     }.bind(this));

--- a/saltgui/static/scripts/routes/schedulesminion.js
+++ b/saltgui/static/scripts/routes/schedulesminion.js
@@ -18,6 +18,10 @@ class SchedulesMinionRoute extends PageRoute {
 
     const minion = decodeURIComponent(window.getQueryParam("minion"));
 
+    // preliminary title
+    const title = document.getElementById("schedulesminion_title");
+    title.innerText = "Schedules on " + minion;
+
     return new Promise(function(resolve, reject) {
       minions.resolvePromise = resolve;
       if(minions.keysLoaded && minions.jobsLoaded) resolve();

--- a/saltgui/static/stylesheets/pillars.css
+++ b/saltgui/static/stylesheets/pillars.css
@@ -6,10 +6,6 @@
   padding: 0;
 }
 
-.pillars li .pillar_value {
-  white-space: pre-wrap;
-}
-
 .pillar_hidden {
   cursor: pointer;
 }


### PR DESCRIPTION
closes #113:
On most pages, a dropdown menu exists per minion.
It is made visible when all information for the minion has been retrieved.
That is not always useful.
On the Keys page, it should be possible to reject/delete a key before that information is present.
On the Grains/Schedules/Pillars pages, it should be possible to zoom in to a specific minion before that information is present. User may select an unresponsive minion. But it is always a risk that a minion becomes unresponsive in the mean time.

Additionally:
Menu item "`Job details`" should not contain `...`

Additionally:
Show minion name in title of grains-details, schedule-details and pillar-details earlier.