### PR TITLE
Jobstatus

### DIFF
--- a/saltgui/static/scripts/routes/jobs.js
+++ b/saltgui/static/scripts/routes/jobs.js
@@ -3,9 +3,6 @@ class JobsRoute extends PageRoute {
   constructor(router) {
     super("^[\/]jobs$", "Jobs", "#page_jobs", "#button_jobs", router);
     this.jobsLoaded = false;
-
-    this._updateJobs = this._updateJobs.bind(this);
-    this._runningJobs = this._runningJobs.bind(this);
   }
 
   onShow() {

--- a/saltgui/static/scripts/routes/page.js
+++ b/saltgui/static/scripts/routes/page.js
@@ -278,6 +278,8 @@ class PageRoute extends Route {
 
   _runningJobs(data, jobsStatus = false) {
     const jobs = data.return[0];
+
+    // update all running jobs
     for(const k in jobs)
     {
       const job = jobs[k];
@@ -298,7 +300,17 @@ class PageRoute extends Route {
         targetText = targetText + ", " + job.Returned.length + " returned";
 
       // the field may not (yet) be on the screen
-      if(targetField) targetField.innerText = targetText;
+      if(!targetField) continue;
+      targetField.classList.remove("no_status");
+      targetField.innerText = targetText;
+    }
+
+    // update all finished jobs
+    for(const tr of document.querySelector("table#jobs tbody").rows) {
+      const statusField = tr.querySelector(".no_status");
+      if(!statusField) continue;
+      statusField.classList.remove("no_status");
+      statusField.innerText = "done";
     }
   }
 
@@ -347,7 +359,9 @@ class PageRoute extends Route {
       this._runFullCommand(evt, job["Target-type"], job.Target, functionText);
     }.bind(this));
 
-    tr.appendChild(Route._createTd("status", ""));
+    const td = Route._createTd("status", "loading...");
+    td.classList.add("no_status");
+    tr.appendChild(td);
     
     // fill out the number of columns to that of the header
     while(tr.cells.length < container.tHead.rows[0].cells.length) {

--- a/saltgui/static/scripts/routes/page.js
+++ b/saltgui/static/scripts/routes/page.js
@@ -4,6 +4,7 @@ class PageRoute extends Route {
     super(path, name, page_selector, menuitem_selector, router);
 
     this._runCommand = this._runCommand.bind(this);
+    this._runningJobs = this._runningJobs.bind(this);
     this._updateJobs = this._updateJobs.bind(this);
     this._updateMinions = this._updateMinions.bind(this);
 

--- a/saltgui/static/stylesheets/page.css
+++ b/saltgui/static/stylesheets/page.css
@@ -74,6 +74,10 @@ table tr td {
   white-space: nowrap;
 }
 
+.jobs td.no_status {
+  color: gray;
+}
+
 .templates th,
 .templates td,
 .jobs th,


### PR DESCRIPTION
closes #172

**Is your feature request related to a problem? Please describe.**
When viewing the Jobs list, a background function is started which tells which of the jobs are still running. But it is not clear whether the information has already been updated when no jobs are running.

**Describe the solution you'd like**
Provide an indication that the information has not been retrieved yet. A simple (gray) text like "loading status..." should be sufficient.