### PR TITLE
easier navigation to details 

### DIFF
--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -81,9 +81,9 @@
         <div class='dashboard'>
           <div class='panel minion-list'>
             <h1>Minions</h1>
-            <table id="minions" class='minions sortable'>
+            <table id="minions" class='minions highlightrows sortable'>
               <thead>
-              <tr><th>Minion</th><th>Status</th><th>Salt&nbsp;version</th><th>OS&nbsp;version</th><th class="sorttable_nosort"></th></tr>
+                <tr><th>Minion</th><th>Status</th><th>Salt&nbsp;version</th><th>OS&nbsp;version</th><th class="sorttable_nosort"></th></tr>
               </thead>
               <tbody>
               </tbody>
@@ -91,7 +91,7 @@
           </div>
           <div class='panel job-list'>
             <h1>Recent Jobs</h1>
-            <table class='jobs left-panel'></table>
+            <table class='jobs highlightrows'><tbody></tbody></table>
           </div>
         </div>
       </div>
@@ -102,7 +102,7 @@
             <h1>Keys</h1>
             <table id="minions" class='minions sortable'>
               <thead>
-              <tr><th>Minion</th><th>Status</th><th>Fingerprint</th><th class="sorttable_nosort"></th></tr>
+                <tr><th>Minion</th><th>Status</th><th>Fingerprint</th><th class="sorttable_nosort"></th></tr>
               </thead>
               <tbody>
               </tbody>
@@ -110,7 +110,7 @@
           </div>
           <div class='panel job-list'>
             <h1>Recent Jobs</h1>
-            <table class='jobs left-panel'></table>
+            <table class='jobs highlightrows'><tbody></tbody></table>
           </div>
         </div>
       </div>
@@ -119,9 +119,9 @@
         <div class='dashboard'>
           <div class='panel minion-list'>
             <h1>Grains</h1>
-            <table id="minions" class='minions sortable'>
+            <table id="minions" class='minions highlightrows sortable'>
               <thead>
-              <tr><th>Minion</th><th>Status</th><th>Salt&nbsp;version</th><th>OS&nbsp;version</th><th>Grains</th><th class="sorttable_nosort"></th></tr>
+                <tr><th>Minion</th><th>Status</th><th>Salt&nbsp;version</th><th>OS&nbsp;version</th><th>Grains</th><th class="sorttable_nosort"></th></tr>
               </thead>
               <tbody>
               </tbody>
@@ -129,7 +129,7 @@
           </div>
           <div class='panel job-list'>
             <h1>Recent Jobs</h1>
-            <table class='jobs left-panel'></table>
+            <table class='jobs highlightrows'><tbody></tbody></table>
           </div>
         </div>
       </div>
@@ -139,9 +139,9 @@
           <div id="grainsminion_page" class='panel minion-list'>
             <div class='nearlyvisiblebutton' id='button_close_grainsminion'>&#x2715;</div>
             <h1 id="grainsminion_title">Grains on ...</h1>
-            <table id="grainsminion_list" class='grains sortable'>
+            <table id="grainsminion_list" class='grains highlightrows sortable'>
               <thead>
-              <tr><th>Name</th><th class="sorttable_nosort"></th><th>Value</th></tr>
+                <tr><th>Name</th><th class="sorttable_nosort"></th><th>Value</th></tr>
               </thead>
               <tbody>
               </tbody>
@@ -149,7 +149,7 @@
           </div>
           <div class='panel job-list'>
             <h1>Recent Jobs</h1>
-            <table class='jobs left-panel'></table>
+            <table class='jobs highlightrows'><tbody></tbody></table>
           </div>
         </div>
       </div>
@@ -158,9 +158,9 @@
         <div class='dashboard'>
           <div class='panel minion-list'>
             <h1>Schedules</h1>
-            <table id="minions" class='minions sortable'>
+            <table id="minions" class='minions highlightrows sortable'>
               <thead>
-              <tr><th>Minion</th><th>Status</th><th>Schedules</th><th class="sorttable_nosort"></th></tr>
+                <tr><th>Minion</th><th>Status</th><th>Schedules</th><th class="sorttable_nosort"></th></tr>
               </thead>
               <tbody>
               </tbody>
@@ -168,7 +168,7 @@
           </div>
           <div class='panel job-list'>
             <h1>Recent Jobs</h1>
-            <table class='jobs left-panel'></table>
+            <table class='jobs highlightrows'><tbody></tbody></table>
           </div>
         </div>
       </div>
@@ -178,9 +178,9 @@
           <div id="schedulesminion_page" class='panel minion-list'>
             <div class='nearlyvisiblebutton' id='button_close_schedulesminion'>&#x2715;</div>
             <h1 id="schedulesminion_title">Schedules on ...</h1>
-            <table id="schedulesminion_list" class='schedules sortable'>
+            <table id="schedulesminion_list" class='schedules highlightrows sortable'>
               <thead>
-              <tr><th>Name</th><th class="sorttable_nosort"></th><th>Details</th></tr>
+                <tr><th>Name</th><th class="sorttable_nosort"></th><th>Details</th></tr>
               </thead>
               <tbody>
               </tbody>
@@ -188,7 +188,7 @@
           </div>
           <div class='panel job-list'>
             <h1>Recent Jobs</h1>
-            <table class='jobs left-panel'></table>
+            <table class='jobs highlightrows'><tbody></tbody></table>
           </div>
         </div>
       </div>
@@ -197,9 +197,9 @@
         <div class='dashboard'>
           <div class='panel minion-list'>
             <h1>Pillars</h1>
-            <table id="minions" class='minions sortable'>
+            <table id="minions" class='minions highlightrows sortable'>
               <thead>
-              <tr><th>Minion</th><th>Status</th><th>Pillars</th><th class="sorttable_nosort"></th></tr>
+                <tr><th>Minion</th><th>Status</th><th>Pillars</th><th class="sorttable_nosort"></th></tr>
               </thead>
               <tbody>
               </tbody>
@@ -207,7 +207,7 @@
           </div>
           <div class='panel job-list'>
             <h1>Recent Jobs</h1>
-            <table class='jobs left-panel'></table>
+            <table class='jobs highlightrows'><tbody></tbody></table>
           </div>
         </div>
       </div>
@@ -217,9 +217,9 @@
           <div id="pillarsminion_page" class='panel minion-list'>
             <div class='nearlyvisiblebutton' id='button_close_pillarsminion'>&#x2715;</div>
             <h1 id="pillarsminion_title">Pillars on ...</h1>
-            <table id="pillarsminion_list" class='pillars sortable'>
+            <table id="pillarsminion_list" class='pillars highlightrows sortable'>
               <thead>
-              <tr><th>Name</th><th>Value</th></tr>
+                <tr><th>Name</th><th>Value</th></tr>
               </thead>
               <tbody>
               </tbody>
@@ -227,7 +227,7 @@
           </div>
           <div class='panel job-list'>
             <h1>Recent Jobs</h1>
-            <table class='jobs left-panel'></table>
+            <table class='jobs highlightrows'><tbody></tbody></table>
           </div>
         </div>
       </div>
@@ -246,9 +246,9 @@
         <div class='dashboard'>
           <div id='jobs_page' class='panel jobs-list'>
             <h1 id="jobs_title">Recent Jobs</h1>
-            <table id="jobs" class='jobs sortable'>
+            <table id="jobs" class='jobs highlightrows sortable'>
               <thead>
-              <tr><th>JID</th><th>Target</th><th>Function</th><th>Start Time</th><th class="sorttable_nosort"></th><th>Status</th></tr>
+                <tr><th>JID</th><th>Target</th><th>Function</th><th>Start Time</th><th class="sorttable_nosort"></th><th>Status</th></tr>
               </thead>
               <tbody>
               </tbody>
@@ -261,9 +261,9 @@
         <div class='dashboard'>
           <div class='panel templates-list'>
             <h1>Templates</h1>
-            <table id="templates" class='templates sortable'>
+            <table id="templates" class='templates highlightrows sortable'>
               <thead>
-              <tr><th>Name</th><th>Description</th><th>Target</th><th>Command</th><th class="sorttable_nosort"></th></tr>
+                <tr><th>Name</th><th>Description</th><th>Target</th><th>Command</th><th class="sorttable_nosort"></th></tr>
               </thead>
               <tbody>
               </tbody>
@@ -271,7 +271,7 @@
           </div>
           <div class='panel job-list'>
             <h1>Recent Jobs</h1>
-            <table class='jobs left-panel'></table>
+            <table class='jobs highlightrows'><tbody></tbody></table>
           </div>
         </div>
       </div>

--- a/saltgui/static/scripts/routes/grains.js
+++ b/saltgui/static/scripts/routes/grains.js
@@ -62,6 +62,8 @@ class GrainsRoute extends PageRoute {
       for(let i = 0; i < this._previewGrains.length; i++) {
         element.appendChild(Route._createTd("", ""));
       }
+
+      element.addEventListener("click", evt => window.location.assign("grainsminion?minion=" + encodeURIComponent(hostname)));
     }
 
     this.keysLoaded = true;
@@ -110,6 +112,8 @@ class GrainsRoute extends PageRoute {
       }
       element.appendChild(td);
     }
+
+    element.addEventListener("click", evt => window.location.assign("grainsminion?minion=" + encodeURIComponent(hostname)));
   }
 
   _addMenuItemShowGrains(menu, hostname) {

--- a/saltgui/static/scripts/routes/grainsminion.js
+++ b/saltgui/static/scripts/routes/grainsminion.js
@@ -87,6 +87,8 @@ class GrainsMinionRoute extends PageRoute {
       grain.appendChild(value);
 
       container.tBodies[0].appendChild(grain);
+
+      grain.addEventListener("click", evt => this._runCommand(evt, minion, "grains.setval \"" + k + "\" " + JSON.stringify(grains[k])));
     }
   }
 }

--- a/saltgui/static/scripts/routes/minions.js
+++ b/saltgui/static/scripts/routes/minions.js
@@ -58,6 +58,8 @@ class MinionsRoute extends PageRoute {
       const element = document.getElementById(hostname);
       const menu = new DropDownMenu(element);
       this._addMenuItemStateApply(menu, hostname);
+
+      element.addEventListener("click", evt => this._runCommand(evt, hostname, "state.apply"));
     }
 
     this.keysLoaded = true;
@@ -81,6 +83,8 @@ class MinionsRoute extends PageRoute {
     const element = document.getElementById(hostname);
     const menu = new DropDownMenu(element);
     this._addMenuItemStateApply(menu, hostname);
+
+    element.addEventListener("click", evt => this._runCommand(evt, hostname, "state.apply"));
   }
 
   _addMenuItemStateApply(menu, hostname) {

--- a/saltgui/static/scripts/routes/page.js
+++ b/saltgui/static/scripts/routes/page.js
@@ -321,7 +321,6 @@ class PageRoute extends Route {
     const tr = document.createElement("tr");
 
     const td = document.createElement("td");
-    tr.appendChild(td);
 
     td.id = "job" + job.id;
     const targetText = window.makeTargetText(job["Target-type"], job.Target);
@@ -332,6 +331,13 @@ class PageRoute extends Route {
 
     const startTimeText = Output.dateTimeStr(job.StartTime);
     td.appendChild(Route._createDiv("time", startTimeText));
+
+    tr.appendChild(td);
+
+    const menu = new DropDownMenu(tr);
+    menu.addMenuItem("Show&nbsp;details", function(evt) {
+      window.location.assign("/job?id=" + encodeURIComponent(job.id));
+    }.bind(this));
 
     container.appendChild(tr);
 
@@ -372,6 +378,8 @@ class PageRoute extends Route {
     }
 
     container.appendChild(tr);
+
+    tr.addEventListener("click", evt => window.location.assign("/job?id=" + encodeURIComponent(job.id)));
   }
 
   _createJobListener(id) {

--- a/saltgui/static/scripts/routes/page.js
+++ b/saltgui/static/scripts/routes/page.js
@@ -228,7 +228,7 @@ class PageRoute extends Route {
   }
 
   _updateJobs(data, numberOfJobs = 7, detailedJob = false) {
-    const jobContainer = this.getPageElement().querySelector(".jobs");
+    const jobContainer = this.getPageElement().querySelector(".jobs tbody");
     const jobs = this._jobsToArray(data.return[0]);
     this._sortJobs(jobs);
 
@@ -367,11 +367,11 @@ class PageRoute extends Route {
     tr.appendChild(td);
     
     // fill out the number of columns to that of the header
-    while(tr.cells.length < container.tHead.rows[0].cells.length) {
+    while(tr.cells.length < container.parentElement.tHead.rows[0].cells.length) {
       tr.appendChild(Route._createTd("", ""));
     }
 
-    container.tBodies[0].appendChild(tr);
+    container.appendChild(tr);
   }
 
   _createJobListener(id) {

--- a/saltgui/static/scripts/routes/pillars.js
+++ b/saltgui/static/scripts/routes/pillars.js
@@ -36,6 +36,8 @@ class PillarsRoute extends PageRoute {
       const element = document.getElementById(hostname);
       const menu = new DropDownMenu(element);
       this._addMenuItemShowPillars(menu, hostname);
+
+      element.addEventListener("click", evt => window.location.assign("pillarsminion?minion=" + encodeURIComponent(hostname)));
     }
 
     this.keysLoaded = true;
@@ -72,6 +74,8 @@ class PillarsRoute extends PageRoute {
 
     const menu = new DropDownMenu(element);
     this._addMenuItemShowPillars(menu, hostname);
+
+    element.addEventListener("click", evt => window.location.assign("pillarsminion?minion=" + encodeURIComponent(hostname)));
   }
 
   _addMenuItemShowPillars(menu, hostname) {

--- a/saltgui/static/scripts/routes/schedules.js
+++ b/saltgui/static/scripts/routes/schedules.js
@@ -54,6 +54,8 @@ class SchedulesRoute extends PageRoute {
       const element = document.getElementById(hostname);
       const menu = new DropDownMenu(element);
       this._addMenuItemShowSchedules(menu, hostname);
+
+      element.addEventListener("click", evt => window.location.assign("schedulesminion?minion=" + encodeURIComponent(hostname)));
     }
 
     this.keysLoaded = true;
@@ -103,6 +105,8 @@ class SchedulesRoute extends PageRoute {
 
     const menu = new DropDownMenu(element);
     this._addMenuItemShowSchedules(menu, hostname);
+
+    element.addEventListener("click", evt => window.location.assign("schedulesminion?minion=" + encodeURIComponent(hostname)));
   }
 
   _addMenuItemShowSchedules(menu, hostname) {

--- a/saltgui/static/scripts/routes/schedulesminion.js
+++ b/saltgui/static/scripts/routes/schedulesminion.js
@@ -85,11 +85,11 @@ class SchedulesMinionRoute extends PageRoute {
       const isJobDisabled = schedule.hasOwnProperty("enabled") && !schedule.enabled;
 
       const menu = new DropDownMenu(tr);
+      let cmd = "schedule.modify " + k;
+      for(const key in schedule) {
+        cmd = cmd + " " + key + "=" + JSON.stringify(schedule[key]);
+      }
       menu.addMenuItem("Modify&nbsp;job...", function(evt) {
-        let cmd = "schedule.modify " + k;
-        for(const key in schedule) {
-          cmd = cmd + " " + key + "=" + JSON.stringify(schedule[key]);
-        }
         this._runCommand(evt, minion, cmd);
       }.bind(this));
       menu.addMenuItem("Enable&nbsp;job...", function(evt) {
@@ -115,6 +115,8 @@ class SchedulesMinionRoute extends PageRoute {
       tr.appendChild(value);
 
       container.tBodies[0].appendChild(tr);
+
+      tr.addEventListener("click", evt => this._runCommand(evt, minion, cmd));
     }
 
     if(!keys.length) {

--- a/saltgui/static/scripts/routes/templates.js
+++ b/saltgui/static/scripts/routes/templates.js
@@ -73,6 +73,8 @@ class TemplatesRoute extends PageRoute {
     }.bind(this));
 
     container.tBodies[0].appendChild(tr);
+
+    tr.addEventListener("click", evt => this._applyTemplate(evt, targettype, target, command));
   }
 
   _applyTemplate(evt, targettype, target, command) {

--- a/saltgui/static/stylesheets/page.css
+++ b/saltgui/static/stylesheets/page.css
@@ -108,11 +108,6 @@ table tr td:last-of-type {
   padding-right: 0;
 }
 
-table tr td.starttime,
-table tr td.target {
-  white-space: nowrap;
-}
-
 .value_none {
   opacity: 0.4;
 }
@@ -213,7 +208,7 @@ table tr td.target {
   font-weight: 500;
   font-size: 18px;
   color: #505050;
-  white-space: pre-wrap;
+  white-space: nowrap;
 }
 
 .jobs td .function {

--- a/saltgui/static/stylesheets/page.css
+++ b/saltgui/static/stylesheets/page.css
@@ -235,7 +235,7 @@ table tr td.target {
   margin-right: 0;
 }
 
-.left-panel td:hover {
+.highlightrows tbody tr:hover {
   background-color: whitesmoke;
   cursor: pointer;
 }


### PR DESCRIPTION
closes #148

Several menu items exist for which the only action is to show more details.
That action should also be implemented by highlighting the line with `whitesmoke` background (see jobs list in secondary panel). Clicking on the line should navigate to the details.
A menu item for this should remain.

This is already implemented in the jobs panel. But the jobs panel is lacking a popup menu. That should be added.

The following actions should be realised:
*  `jobs` (panel) --> `Show details...` (and add menu to do that also)
* `minions` --> `Apply state...`
* `keys` --> NONE
* `grains` --> `Show grains`
* `grains (details)` --> `Edit grain...`
* `schedules` --> `Show schedules`
* `schedules (details)` --> `Modify job...`
* `pillars` --> `Show pillars`
* `pillars (details)` --> show/hide value (and add menu to do that also)
*  `jobs` (menu) --> `Show details...`