### PR TITLE
show keys with monospace font

### DIFF
--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -5,6 +5,7 @@
     <link rel='stylesheet' type='text/css' href='static/stylesheets/main.css' />
     <link rel='stylesheet' type='text/css' href='static/stylesheets/login.css' />
     <link rel='stylesheet' type='text/css' href='static/stylesheets/page.css' />
+    <link rel='stylesheet' type='text/css' href='static/stylesheets/keys.css' />
     <link rel='stylesheet' type='text/css' href='static/stylesheets/job.css' />
     <link rel='stylesheet' type='text/css' href='static/stylesheets/grains.css' />
     <link rel='stylesheet' type='text/css' href='static/stylesheets/schedules.css' />

--- a/saltgui/static/stylesheets/keys.css
+++ b/saltgui/static/stylesheets/keys.css
@@ -1,0 +1,3 @@
+.fingerprint {
+  font-family: monospace;
+}

--- a/saltgui/static/stylesheets/page.css
+++ b/saltgui/static/stylesheets/page.css
@@ -68,7 +68,7 @@ table tr th {
 
 table tr td {
   padding-right: 20px;
-  vertical-align: top;
+  vertical-align: middle;
   padding-top: 5px;
   padding-bottom: 5px;
   white-space: nowrap;

--- a/saltgui/static/stylesheets/schedules.css
+++ b/saltgui/static/stylesheets/schedules.css
@@ -6,7 +6,6 @@
   font-weight: 500;
   font-size: 17px;
   min-width: 120px;
-  vertical-align: top;
 }
 
 .schedules li .schedule_value {


### PR DESCRIPTION
Currently, keys are shown in a proportional font on the Keys page.
This looks slightly chaotic.
This PR sets a monospace font only for that column.