### PR TITLE
always use the regular api

### DIFF
--- a/saltgui/static/scripts/api.js
+++ b/saltgui/static/scripts/api.js
@@ -51,42 +51,22 @@ class API {
       });
   }
 
-  getMinions() {
-    return this.apiRequest("GET", "/minions", {});
-  }
-
-  getKeys() {
-    return this.apiRequest("GET", "/keys", {});
-  }
-
-  getKeysFingerprint() {
-    const params = {
-      client: "wheel",
-      fun: "key.finger",
-      match: "*"
-    };
-    return this.apiRequest("POST", "/", params).catch(console.error);
-  }
-
-  getJobs() {
-    return this.apiRequest("GET", "/jobs", {});
-  }
-
-  getJob(id) {
-    return this.apiRequest("GET", "/jobs/" + id, {});
-  }
-
-  getGrainsItems(minion) {
+  getLocalGrainsItems(minion) {
     const params = {
       client: "local",
       fun: "grains.items",
-      tgt_type: "list",
-      tgt: minion
     };
+    if(minion) {
+      params.tgt_type = "list";
+      params.tgt = minion;
+    } else {
+      params.tgt_type = "glob";
+      params.tgt = "*";
+    }
     return this.apiRequest("POST", "/", params).catch(console.error);
   }
 
-  getPillarItems(minion) {
+  getLocalPillarItems(minion) {
     const params = {
       client: "local",
       fun: "pillar.items"
@@ -101,7 +81,7 @@ class API {
     return this.apiRequest("POST", "/", params).catch(console.error);
   }
 
-  getPillarObfuscate(minion) {
+  getLocalPillarObfuscate(minion) {
     const params = {
       client: "local",
       fun: "pillar.obfuscate"
@@ -116,7 +96,7 @@ class API {
     return this.apiRequest("POST", "/", params).catch(console.error);
   }
 
-  getScheduleList(minion) {
+  getLocalScheduleList(minion) {
     const params = {
       client: "local",
       fun: "schedule.list",
@@ -132,7 +112,7 @@ class API {
     return this.apiRequest("POST", "/", params).catch(console.error);
   }
 
-  getJobsActive() {
+  getRunnerJobsActive() {
     const params = {
       client: "runner",
       fun: "jobs.active"
@@ -140,10 +120,44 @@ class API {
     return this.apiRequest("POST", "/", params).catch(console.error);
   }
 
-  getConfigValues() {
+  getRunnerJobsListJob(id) {
+    const params = {
+      client: "runner",
+      fun: "jobs.list_job",
+      jid: id
+    };
+    return this.apiRequest("POST", "/", params).catch(console.error);
+  }
+
+  getRunnerJobsListJobs() {
+    const params = {
+      client: "runner",
+      fun: "jobs.list_jobs"
+    };
+    return this.apiRequest("POST", "/", params).catch(console.error);
+  }
+
+  getWheelConfigValues() {
     const params = {
       client: "wheel",
       fun: "config.values"
+    };
+    return this.apiRequest("POST", "/", params).catch(console.error);
+  }
+
+  getWheelKeyFinger() {
+    const params = {
+      client: "wheel",
+      fun: "key.finger",
+      match: "*"
+    };
+    return this.apiRequest("POST", "/", params).catch(console.error);
+  }
+
+  getWheelKeyListAll() {
+    const params = {
+      client: "wheel",
+      fun: "key.list_all",
     };
     return this.apiRequest("POST", "/", params).catch(console.error);
   }

--- a/saltgui/static/scripts/routes/grains.js
+++ b/saltgui/static/scripts/routes/grains.js
@@ -45,15 +45,15 @@ class GrainsRoute extends PageRoute {
     return new Promise(function(resolve, reject) {
       minions.resolvePromise = resolve;
       if(minions.keysLoaded && minions.jobsLoaded) resolve();
-      minions.router.api.getMinions().then(minions._updateMinions);
-      minions.router.api.getKeys().then(minions._updateKeys);
-      minions.router.api.getJobs().then(minions._updateJobs);
-      minions.router.api.getJobsActive().then(minions._runningJobs);
+      minions.router.api.getLocalGrainsItems(null).then(minions._updateMinions);
+      minions.router.api.getWheelKeyListAll().then(minions._updateKeys);
+      minions.router.api.getRunnerJobsListJobs().then(minions._updateJobs);
+      minions.router.api.getRunnerJobsActive().then(minions._runningJobs);
     });
   }
 
   _updateKeys(data) {
-    const keys = data.return;
+    const keys = data.return[0].data.return;
 
     const list = this.getPageElement().querySelector('#minions');
 

--- a/saltgui/static/scripts/routes/grainsminion.js
+++ b/saltgui/static/scripts/routes/grainsminion.js
@@ -24,9 +24,9 @@ class GrainsMinionRoute extends PageRoute {
     return new Promise(function(resolve, reject) {
       minions.resolvePromise = resolve;
       if(minions.keysLoaded && minions.jobsLoaded) resolve();
-      minions.router.api.getGrainsItems(minion).then(minions._showGrains);
-      minions.router.api.getJobs().then(minions._updateJobs);
-      minions.router.api.getJobsActive().then(minions._runningJobs);
+      minions.router.api.getLocalGrainsItems(minion).then(minions._showGrains);
+      minions.router.api.getRunnerJobsListJobs().then(minions._updateJobs);
+      minions.router.api.getRunnerJobsActive().then(minions._runningJobs);
     });
   }
 

--- a/saltgui/static/scripts/routes/job.js
+++ b/saltgui/static/scripts/routes/job.js
@@ -10,7 +10,7 @@ class JobRoute extends Route {
     const id = decodeURIComponent(window.getQueryParam("id"));
     return new Promise(function(resolve, reject) {
       job.resolvePromise = resolve;
-      job.router.api.getJob(id).then(job._onJobData);
+      job.router.api.getRunnerJobsListJob(id).then(job._onJobData);
     });
   }
 
@@ -22,7 +22,7 @@ class JobRoute extends Route {
 
   _onJobData(data) {
     const job = this;
-    const info = data.info[0];
+    const info = data.return[0];
     job.getPageElement().querySelector(".output").innerText = "";
 
     document.querySelector("#button_close_job").addEventListener("click", _ => {

--- a/saltgui/static/scripts/routes/jobs.js
+++ b/saltgui/static/scripts/routes/jobs.js
@@ -10,10 +10,10 @@ class JobsRoute extends PageRoute {
     return new Promise(function(resolve, reject) {
       jobs.resolvePromise = resolve;
       if(jobs.jobsLoaded) resolve();
-      jobs.router.api.getJobs().then(data => {
+      jobs.router.api.getRunnerJobsListJobs().then(data => {
         jobs._updateJobs(data, 50, true);
       });
-      jobs.router.api.getJobsActive().then(data => {
+      jobs.router.api.getRunnerJobsActive().then(data => {
         jobs._runningJobs(data, true);
       });
     });

--- a/saltgui/static/scripts/routes/keys.js
+++ b/saltgui/static/scripts/routes/keys.js
@@ -11,8 +11,8 @@ class KeysRoute extends PageRoute {
 
   onShow() {
     const keys = this;
-    const p1 = keys.router.api.getKeys();
-    const p2 = keys.router.api.getKeysFingerprint();
+    const p1 = keys.router.api.getWheelKeyListAll();
+    const p2 = keys.router.api.getWheelKeyFinger();
 
     Promise.all([p1, p2])
       .then(function(data){
@@ -24,8 +24,8 @@ class KeysRoute extends PageRoute {
     return new Promise(function(resolve, reject) {
       keys.resolvePromise = resolve;
       if(keys.keysLoaded && keys.jobsLoaded) resolve();
-      keys.router.api.getJobs().then(keys._updateJobs);
-      keys.router.api.getJobsActive().then(keys._runningJobs);
+      keys.router.api.getRunnerJobsListJobs().then(keys._updateJobs);
+      keys.router.api.getRunnerJobsActive().then(keys._runningJobs);
     });
   }
 
@@ -52,7 +52,7 @@ class KeysRoute extends PageRoute {
   }
 
   _updateKeys(data) {
-    const keys = data.return;
+    const keys = data.return[0].data.return;
     const list = this.getPageElement().querySelector("#minions");
 
     // Unaccepted goes first because that is where the user must decide

--- a/saltgui/static/scripts/routes/minions.js
+++ b/saltgui/static/scripts/routes/minions.js
@@ -13,12 +13,12 @@ class MinionsRoute extends PageRoute {
     return new Promise(function(resolve, reject) {
       minions.resolvePromise = resolve;
       if(minions.keysLoaded && minions.jobsLoaded) resolve();
-      minions.router.api.getMinions().then(minions._updateMinions);
-      minions.router.api.getKeys().then(minions._updateKeys);
-      minions.router.api.getJobs().then(minions._updateJobs);
-      minions.router.api.getJobsActive().then(minions._runningJobs);
+      minions.router.api.getLocalGrainsItems(null).then(minions._updateMinions);
+      minions.router.api.getWheelKeyListAll().then(minions._updateKeys);
+      minions.router.api.getRunnerJobsListJobs().then(minions._updateJobs);
+      minions.router.api.getRunnerJobsActive().then(minions._runningJobs);
       //we need these functions to populate the dropdown boxes
-      minions.router.api.getConfigValues().then(minions._configvalues);
+      minions.router.api.getWheelConfigValues().then(minions._configvalues);
     });
   }
 
@@ -46,7 +46,7 @@ class MinionsRoute extends PageRoute {
   }
 
   _updateKeys(data) {
-    const keys = data.return;
+    const keys = data.return[0].data.return;
 
     const list = this.getPageElement().querySelector("#minions");
 

--- a/saltgui/static/scripts/routes/pillars.js
+++ b/saltgui/static/scripts/routes/pillars.js
@@ -16,15 +16,15 @@ class PillarsRoute extends PageRoute {
     return new Promise(function(resolve, reject) {
       minions.resolvePromise = resolve;
       if(minions.keysLoaded && minions.jobsLoaded) resolve();
-      minions.router.api.getPillarObfuscate(null).then(minions._updateMinions);
-      minions.router.api.getKeys().then(minions._updateKeys);
-      minions.router.api.getJobs().then(minions._updateJobs);
-      minions.router.api.getJobsActive().then(minions._runningJobs);
+      minions.router.api.getLocalPillarObfuscate(null).then(minions._updateMinions);
+      minions.router.api.getWheelKeyListAll().then(minions._updateKeys);
+      minions.router.api.getRunnerJobsListJobs().then(minions._updateJobs);
+      minions.router.api.getRunnerJobsActive().then(minions._runningJobs);
     });
   }
 
   _updateKeys(data) {
-    const keys = data.return;
+    const keys = data.return[0].data.return;
 
     const list = this.getPageElement().querySelector('#minions');
 

--- a/saltgui/static/scripts/routes/pillarsminion.js
+++ b/saltgui/static/scripts/routes/pillarsminion.js
@@ -24,9 +24,9 @@ class PillarsMinionRoute extends PageRoute {
     return new Promise(function(resolve, reject) {
       minions.resolvePromise = resolve;
       if(minions.keysLoaded && minions.jobsLoaded) resolve();
-      minions.router.api.getPillarItems(minion).then(minions._showPillars);
-      minions.router.api.getJobs().then(minions._updateJobs);
-      minions.router.api.getJobsActive().then(minions._runningJobs);
+      minions.router.api.getLocalPillarItems(minion).then(minions._showPillars);
+      minions.router.api.getRunnerJobsListJobs().then(minions._updateJobs);
+      minions.router.api.getRunnerJobsActive().then(minions._runningJobs);
     });
   }
 

--- a/saltgui/static/scripts/routes/schedules.js
+++ b/saltgui/static/scripts/routes/schedules.js
@@ -15,11 +15,11 @@ class SchedulesRoute extends PageRoute {
     return new Promise(function(resolve, reject) {
       minions.resolvePromise = resolve;
       if(minions.keysLoaded && minions.jobsLoaded) resolve();
-      minions.router.api.getScheduleList(null)
+      minions.router.api.getLocalScheduleList(null)
         .then(minions._updateMinions, minions._updateMinions);
-      minions.router.api.getKeys().then(minions._updateKeys);
-      minions.router.api.getJobs().then(minions._updateJobs);
-      minions.router.api.getJobsActive().then(minions._runningJobs);
+      minions.router.api.getWheelKeyListAll().then(minions._updateKeys);
+      minions.router.api.getRunnerJobsListJobs().then(minions._updateJobs);
+      minions.router.api.getRunnerJobsActive().then(minions._runningJobs);
     });
   }
 
@@ -42,7 +42,7 @@ class SchedulesRoute extends PageRoute {
   }
 
   _updateKeys(data) {
-    const keys = data.return;
+    const keys = data.return[0].data.return;
 
     const list = this.getPageElement().querySelector('#minions');
 

--- a/saltgui/static/scripts/routes/schedulesminion.js
+++ b/saltgui/static/scripts/routes/schedulesminion.js
@@ -25,9 +25,9 @@ class SchedulesMinionRoute extends PageRoute {
     return new Promise(function(resolve, reject) {
       minions.resolvePromise = resolve;
       if(minions.keysLoaded && minions.jobsLoaded) resolve();
-      minions.router.api.getScheduleList(minion).then(minions._showSchedules);
-      minions.router.api.getJobs().then(minions._updateJobs);
-      minions.router.api.getJobsActive().then(minions._runningJobs);
+      minions.router.api.getLocalScheduleList(minion).then(minions._showSchedules);
+      minions.router.api.getRunnerJobsListJobs().then(minions._updateJobs);
+      minions.router.api.getRunnerJobsActive().then(minions._runningJobs);
     });
   }
 

--- a/saltgui/static/scripts/routes/templates.js
+++ b/saltgui/static/scripts/routes/templates.js
@@ -13,9 +13,9 @@ class TemplatesRoute extends PageRoute {
     return new Promise(function(resolve, reject) {
       templates.resolvePromise = resolve;
       if(templates.jobsLoaded) resolve();
-      templates.router.api.getJobs().then(templates._updateJobs);
-      templates.router.api.getJobsActive().then(templates._runningJobs);
-      templates.router.api.getConfigValues().then(templates._updateTemplates);
+      templates.router.api.getRunnerJobsListJobs().then(templates._updateJobs);
+      templates.router.api.getRunnerJobsActive().then(templates._runningJobs);
+      templates.router.api.getWheelConfigValues().then(templates._updateTemplates);
     });
   }
 


### PR DESCRIPTION
for #182 and other reasons, the api functions must be sanitized:
* only use the direct api functions (prevents name conflicts)
* rename all api functions according to the api function that they are calling
* organize the api functions alphabetically

closes #182 