### PR TITLE
switch to npm PART 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .gitignore
 yarn-error.log
 node_modules/
+.idea

--- a/package.json
+++ b/package.json
@@ -23,12 +23,26 @@
       "no-undef": 0,
       "no-unused-vars": 0,
       "no-console": 0,
-      "indent": ["error", 2],
+      "indent": [
+        "error",
+        2
+      ],
       "no-irregular-whitespace": 2,
       "no-whitespace-before-property": 2,
-      "no-multiple-empty-lines": ["error", { "max": 2, "maxEOF": 1 }],
+      "no-multiple-empty-lines": [
+        "error",
+        {
+          "max": 2,
+          "maxEOF": 1
+        }
+      ],
       "no-useless-escape": 0,
-      "no-constant-condition": ["error", { "checkLoops": false }],
+      "no-constant-condition": [
+        "error",
+        {
+          "checkLoops": false
+        }
+      ],
       "no-var": 2,
       "prefer-const": 2
     }

--- a/runtests.sh
+++ b/runtests.sh
@@ -8,21 +8,21 @@ trap cleanupdocker EXIT
 
 set -e
 # add testing packages
-yarn
+npm i
 
 # first see if we write es6 compatible js
-yarn jslint
+npm run jslint
 
 # and if our css is sane
-yarn stylelint
+npm run stylelint
 
 # start a salt master, three salt minions and saltgui to run tests on
 docker-compose -f docker/docker-compose.yml up -d
 
 # wait until all are up
-yarn wait-for-docker
+npm run wait-for-docker
 
 # run the unittests/nightmare.js functional tests
-yarn test
+npm run test
 
 set +e


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Yarn has a calling home feature and sends statistics to Facebook. Not sure but in EU it could be against privacy law. Furthermore NPM got more and more stable the last years. I would like to go back to NPM to be as close as possible to the NodeJS stack and reduce usage of external tools.

**Describe the solution you'd like**
Should be easily doable: Small fixes in package.json, runtests,sh and remove yarn's lockfile which will be exchanged with native package-lock.json

**Describe alternatives you've considered**
For now I see no alternatives.