### PR TITLE
implemented quick job details on Jobs screen

### DIFF
--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -265,7 +265,7 @@
             <h1 id="jobs_title">Recent Jobs</h1>
             <table id="jobs" class='jobs highlightrows sortable'>
               <thead>
-                <tr><th>JID</th><th>Target</th><th>Function</th><th>Start Time</th><th class="sorttable_nosort"></th><th>Status</th></tr>
+                <tr><th>JID</th><th>Target</th><th>Function</th><th>Start Time</th><th class="sorttable_nosort"></th><th>Status</th><th>Details</th></tr>
               </thead>
               <tbody>
               </tbody>

--- a/saltgui/static/scripts/routes/Page.js
+++ b/saltgui/static/scripts/routes/Page.js
@@ -373,7 +373,7 @@ export class PageRoute extends Route {
       tdDetails.innerText = "loading...";
       this._getJobDetails(job.id);
       evt.stopPropagation();
-      });
+    });
     tr.appendChild(tdDetails);
 
     // fill out the number of columns to that of the header
@@ -419,7 +419,7 @@ export class PageRoute extends Route {
     else
       str = data.Minions.length + " minions";
 
-    let keyCount = Object.keys(data.Result).length;
+    const keyCount = Object.keys(data.Result).length;
     str += ", ";
     if(keyCount == data.Minions.length)
       str += "<span style='color: green'>";
@@ -468,7 +468,7 @@ export class PageRoute extends Route {
   }
 
   _getJobDetails(jobid) {
-    let p = this;
+    const p = this;
     this.router.api.getRunnerJobsListJob(jobid).then(data => {
       p._showJobDetailSummary(jobid, data);
     });

--- a/saltgui/static/scripts/routes/Route.js
+++ b/saltgui/static/scripts/routes/Route.js
@@ -48,6 +48,13 @@ export class Route {
     return div;
   }
 
+  static _createSpan(className, content) {
+    const span = document.createElement("span");
+    if(className) span.className = className;
+    span.innerText = content;
+    return span;
+  }
+
   _runCommand(evt, targetString, commandString) {
     this._runFullCommand(evt, "", targetString, commandString);
   }


### PR DESCRIPTION
closes #180
closes #116 

implemented a simple job details facility on the `Jobs` page.
A new column `Details` was added with the initial value `(click)`.
When you click it, the details for that job are retrieved and shown in a summary.
The data is not remembered when you leave this screen.

![afbeelding](https://user-images.githubusercontent.com/3663742/55667649-5a33ea80-585f-11e9-98c0-434f849df3df.png)