### PR TITLE
Use jobs.active to show which output is still expected

### DIFF
--- a/saltgui/static/scripts/output/Output.js
+++ b/saltgui/static/scripts/output/Output.js
@@ -212,6 +212,7 @@ export class Output {
       // runners/wheel responses are not per minion
       // Do not produce a #response line for async-start confirmation
       const span = document.createElement("span");
+      span.id = "summary";
 
       const cntResponses = Object.keys(response).length;
       const cntMinions = minions.length;
@@ -323,6 +324,7 @@ export class Output {
 
       if(!fndRepresentation && !response.hasOwnProperty(hostname)) {
         hostOutput = Output.getTextOutput("(no response)");
+        hostOutput.classList.add("noresponse");
         fndRepresentation = true;
       }
 
@@ -386,6 +388,7 @@ export class Output {
 
       // compose the actual output
       const div = document.createElement("div");
+      div.id = hostname;
 
       div.append(hostLabel);
 

--- a/saltgui/static/scripts/output/Output.js
+++ b/saltgui/static/scripts/output/Output.js
@@ -215,6 +215,7 @@ export class Output {
       // for the result of jobs.active
       const summaryJobsActiveSpan = document.createElement("span");
       summaryJobsActiveSpan.id = "summary_jobsactive";
+      summaryJobsActiveSpan.innerText = "(loading), ";
 
       // for the result of jobs.list_job
       const summaryJobsListJobSpan = document.createElement("span");

--- a/saltgui/static/scripts/output/Output.js
+++ b/saltgui/static/scripts/output/Output.js
@@ -211,8 +211,14 @@ export class Output {
        !Output.isAsyncOutput(response)) {
       // runners/wheel responses are not per minion
       // Do not produce a #response line for async-start confirmation
-      const span = document.createElement("span");
-      span.id = "summary";
+
+      // for the result of jobs.active
+      const summaryJobsActiveSpan = document.createElement("span");
+      summaryJobsActiveSpan.id = "summary_jobsactive";
+
+      // for the result of jobs.list_job
+      const summaryJobsListJobSpan = document.createElement("span");
+      summaryJobsListJobSpan.id = "summary_listjob";
 
       const cntResponses = Object.keys(response).length;
       const cntMinions = minions.length;
@@ -258,8 +264,10 @@ export class Output {
       // some room for the triangle
       txt = txt + " ";
 
-      span.innerText = txt;
-      allDiv.appendChild(span);
+      allDiv.appendChild(summaryJobsActiveSpan);
+
+      summaryJobsListJobSpan.innerText = txt;
+      allDiv.appendChild(summaryJobsListJobSpan);
     }
 
     const masterTriangle = document.createElement("span");

--- a/saltgui/static/scripts/routes/Job.js
+++ b/saltgui/static/scripts/routes/Job.js
@@ -157,9 +157,9 @@ export class JobRoute extends Route {
         const noResponseSpan = this.getPageElement().querySelector("pre.output div#" + minion + " span.noresponse");
         if(!noResponseSpan) continue;
         // show that this minion is still active on the request
-	noResponseSpan.innerHTML = noResponseSpan.innerHTML.replace("no response", "active");
-	noResponseSpan.classList.remove("noresponse");
-	noResponseSpan.classList.add("active");
+        noResponseSpan.innerHTML = noResponseSpan.innerHTML.replace("no response", "active");
+        noResponseSpan.classList.remove("noresponse");
+        noResponseSpan.classList.add("active");
       }
     }
   }

--- a/saltgui/static/scripts/routes/Job.js
+++ b/saltgui/static/scripts/routes/Job.js
@@ -140,9 +140,15 @@ export class JobRoute extends Route {
     const info = data.return[0][id];
 
     const summarySpan = this.getPageElement().querySelector("pre.output span#summary");
-    if(info.Running.length > 0 && summarySpan) {
-      summarySpan.innerText = info.Running.length + " active, " + summarySpan.innerText;
+    if(!summarySpan) return;
+
+    // when the job is already completely done, nothing is returned
+    if(!info) {
+      summarySpan.innerText = "done, " + summarySpan.innerText;
+      return;
     }
+
+    summarySpan.innerText = info.Running.length + " active, " + summarySpan.innerText;
 
     // update the minion details
     for(const minionInfo of info.Running) {

--- a/saltgui/static/scripts/routes/Job.js
+++ b/saltgui/static/scripts/routes/Job.js
@@ -139,16 +139,16 @@ export class JobRoute extends Route {
   _handleRunnerJobsActive(id, data) {
     const info = data.return[0][id];
 
-    const summarySpan = this.getPageElement().querySelector("pre.output span#summary");
-    if(!summarySpan) return;
+    const summaryJobsActiveSpan = this.getPageElement().querySelector("pre.output span#summary_jobsactive");
+    if(!summaryJobsActiveSpan) return;
 
     // when the job is already completely done, nothing is returned
     if(!info) {
-      summarySpan.innerText = "done, " + summarySpan.innerText;
+      summaryJobsActiveSpan.innerText = "done, ";
       return;
     }
 
-    summarySpan.innerText = info.Running.length + " active, " + summarySpan.innerText;
+    summaryJobsActiveSpan.innerText = info.Running.length + " active, ";
 
     // update the minion details
     for(const minionInfo of info.Running) {

--- a/saltgui/static/scripts/routes/Keys.js
+++ b/saltgui/static/scripts/routes/Keys.js
@@ -97,7 +97,8 @@ export class KeysRoute extends PageRoute {
     if(hostnames_rejected.length === 0)
       summary += ", no rejected keys";
     if(summary) {
-      const div = Route._createDiv("msg", summary.replace(/, n/, "N"));
+      // remove the first comma and capitalize the first word
+      const div = Route._createDiv("msg", summary.replace(/, no/, "No"));
       this.getPageElement().querySelector(".minion-list").appendChild(div);
     }
 

--- a/saltgui/static/stylesheets/page.css
+++ b/saltgui/static/stylesheets/page.css
@@ -50,6 +50,11 @@ pre .hostname {
   color: #4caf50;
 }
 
+pre span.active {
+  color: greenyellow;
+  font-weight: bold;
+}
+
 table {
   min-width: 100%;
   border-spacing: 5px;


### PR DESCRIPTION
closes #206

**Is your feature request related to a problem? Please describe.**
When job details are shown, all minions without data are treated equally. It is assumed that the job has timed out. This a result of the usage of call jobs.list_job.
But the jobs overview(s) already show how many minions are still working on a job.

**Describe the solution you'd like**
Use function jobs.active provides the difference between minions that timed out and minions that are still working on the request.