### PR TITLE
Rework on promise creations/executions

### DIFF
--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -47,6 +47,7 @@ The following configuration is a mimimum set of permissions, so that SaltGUI can
         - jobs.list_jobs
       - '@wheel':
         - config.values
+        - key.finger
         - key.list_all
 ```
 Adititional permissions are needed to run the commands associated with the popupmenu items.

--- a/saltgui/static/scripts/Api.js
+++ b/saltgui/static/scripts/Api.js
@@ -63,7 +63,7 @@ export class API {
       params.tgt_type = "glob";
       params.tgt = "*";
     }
-    return this.apiRequest("POST", "/", params).catch(console.error);
+    return this.apiRequest("POST", "/", params);
   }
 
   getLocalPillarItems(minion) {
@@ -78,7 +78,7 @@ export class API {
       params.tgt_type = "glob";
       params.tgt = "*";
     }
-    return this.apiRequest("POST", "/", params).catch(console.error);
+    return this.apiRequest("POST", "/", params);
   }
 
   getLocalPillarObfuscate(minion) {
@@ -93,7 +93,7 @@ export class API {
       params.tgt_type = "glob";
       params.tgt = "*";
     }
-    return this.apiRequest("POST", "/", params).catch(console.error);
+    return this.apiRequest("POST", "/", params);
   }
 
   getLocalScheduleList(minion) {
@@ -109,7 +109,7 @@ export class API {
       params.tgt_type = "glob";
       params.tgt = "*";
     }
-    return this.apiRequest("POST", "/", params).catch(console.error);
+    return this.apiRequest("POST", "/", params);
   }
 
   getRunnerJobsActive() {
@@ -117,7 +117,7 @@ export class API {
       client: "runner",
       fun: "jobs.active"
     };
-    return this.apiRequest("POST", "/", params).catch(console.error);
+    return this.apiRequest("POST", "/", params);
   }
 
   getRunnerJobsListJob(id) {
@@ -126,7 +126,7 @@ export class API {
       fun: "jobs.list_job",
       jid: id
     };
-    return this.apiRequest("POST", "/", params).catch(console.error);
+    return this.apiRequest("POST", "/", params);
   }
 
   getRunnerJobsListJobs() {
@@ -134,7 +134,7 @@ export class API {
       client: "runner",
       fun: "jobs.list_jobs"
     };
-    return this.apiRequest("POST", "/", params).catch(console.error);
+    return this.apiRequest("POST", "/", params);
   }
 
   getWheelConfigValues() {
@@ -142,7 +142,7 @@ export class API {
       client: "wheel",
       fun: "config.values"
     };
-    return this.apiRequest("POST", "/", params).catch(console.error);
+    return this.apiRequest("POST", "/", params);
   }
 
   getWheelKeyFinger() {
@@ -151,7 +151,7 @@ export class API {
       fun: "key.finger",
       match: "*"
     };
-    return this.apiRequest("POST", "/", params).catch(console.error);
+    return this.apiRequest("POST", "/", params);
   }
 
   getWheelKeyListAll() {
@@ -159,7 +159,7 @@ export class API {
       client: "wheel",
       fun: "key.list_all",
     };
-    return this.apiRequest("POST", "/", params).catch(console.error);
+    return this.apiRequest("POST", "/", params);
   }
 
   apiRequest(method, route, params) {

--- a/saltgui/static/scripts/CommandBox.js
+++ b/saltgui/static/scripts/CommandBox.js
@@ -121,6 +121,8 @@ export class CommandBox {
 
     func.then(response => {
       this._onRunReturn(response.return[0], command);
+    }, response => {
+      this._showError(JSON.stringify(response));
     });
   }
 
@@ -218,7 +220,7 @@ export class CommandBox {
   }
 
   _showError(message) {
-    this._onRunReturn(message, "");
+    this._onRunReturn("ERROR:\n\n" + message, "");
   }
 
   _getRunParams(tgtType, target, toRun) {
@@ -309,10 +311,6 @@ export class CommandBox {
       // { "jid": "20180718173942195461", "minions": [ ... ] }
     }
 
-    return this.api.apiRequest("POST", "/", params)
-      .catch(error => {
-        this._showError(error.message);
-        return error;
-      });
+    return this.api.apiRequest("POST", "/", params);
   }
 }

--- a/saltgui/static/scripts/Documentation.js
+++ b/saltgui/static/scripts/Documentation.js
@@ -91,9 +91,11 @@ export class Documentation {
 
     const tgtType = TargetType.menuTargetType._value;
 
-    this.commandbox._getRunParams(tgtType, target, docCommand).then(
-      response => this.commandbox._onRunReturn(response.return[0], dummyCommand)
-    );
+    this.commandbox._getRunParams(tgtType, target, docCommand).then(response => {
+      this.commandbox._onRunReturn(response.return[0], dummyCommand);
+    }, response => {
+      this.commandbox._onRunReturn("DOCUMENTATION ERROR:\n\n" + JSON.stringify(response), dummyCommand);
+    });
   }
 
 }

--- a/saltgui/static/scripts/Utils.js
+++ b/saltgui/static/scripts/Utils.js
@@ -50,4 +50,11 @@ export class Utils {
       //Utils.addToolTip(th, "Click to sort");
     }
   }
+
+  static addErrorToTableCell(td, errorMessage) {
+    const span = document.createElement("span");
+    span.innerText = "(error)";
+    Utils.addToolTip(span, errorMessage);
+    td.appendChild(span);
+  }
 }

--- a/saltgui/static/scripts/output/Output.js
+++ b/saltgui/static/scripts/output/Output.js
@@ -215,7 +215,7 @@ export class Output {
       // for the result of jobs.active
       const summaryJobsActiveSpan = document.createElement("span");
       summaryJobsActiveSpan.id = "summary_jobsactive";
-      summaryJobsActiveSpan.innerText = initialStatus + ", ";
+      summaryJobsActiveSpan.innerText = initialStatus;
 
       // for the result of jobs.list_job
       const summaryJobsListJobSpan = document.createElement("span");
@@ -224,12 +224,12 @@ export class Output {
       const cntResponses = Object.keys(response).length;
       const cntMinions = minions.length;
 
-      let txt;
+      let txt = ", ";
 
       if(cntResponses === 1) {
-        txt = cntResponses + " response";
+        txt += cntResponses + " response";
       } else {
-        txt = cntResponses + " responses";
+        txt += cntResponses + " responses";
       }
 
       const summary = { };

--- a/saltgui/static/scripts/routes/Grains.js
+++ b/saltgui/static/scripts/routes/Grains.js
@@ -9,9 +9,6 @@ export class GrainsRoute extends PageRoute {
   constructor(router) {
     super("^[\/]grains$", "Grains", "#page_grains", "#button_grains", router);
 
-    this.keysLoaded = false;
-    this.jobsLoaded = false;
-
     this._handleWheelKeyListAll = this._handleWheelKeyListAll.bind(this);
     this._updateMinion = this._updateMinion.bind(this);
 
@@ -53,14 +50,19 @@ export class GrainsRoute extends PageRoute {
     const runnerJobsListJobsPromise = this.router.api.getRunnerJobsListJobs();
     const runnerJobsActivePromise = this.router.api.getRunnerJobsActive();
 
-    return new Promise(function(resolve, reject) {
-      myThis.resolvePromise = resolve;
-      if(myThis.keysLoaded && myThis.jobsLoaded) resolve();
-      wheelKeyListAllPromise.then(myThis._handleWheelKeyListAll);
-      localGrainsItemsPromise.then(myThis._updateMinions);
-      runnerJobsListJobsPromise.then(myThis._handleRunnerJobsListJobs);
-      runnerJobsActivePromise.then(myThis._handleRunnerJobsActive);
+    wheelKeyListAllPromise.then(data => {
+      myThis._handleWheelKeyListAll(data);
+      localGrainsItemsPromise.then(data => {
+        myThis._updateMinions(data);
+      });
     });
+
+    runnerJobsListJobsPromise.then(data => {
+      myThis._handleRunnerJobsListJobs(data);
+      runnerJobsActivePromise.then(data => {
+        myThis._handleRunnerJobsActive(data);
+      });
+    }); 
   }
 
   _handleWheelKeyListAll(data) {
@@ -85,9 +87,6 @@ export class GrainsRoute extends PageRoute {
     }
 
     Utils.showTableSortable(this.getPageElement(), "minions");
-
-    this.keysLoaded = true;
-    if(this.keysLoaded && this.jobsLoaded) this.resolvePromise();
   }
 
   _updateOfflineMinion(container, hostname) {

--- a/saltgui/static/scripts/routes/Grains.js
+++ b/saltgui/static/scripts/routes/Grains.js
@@ -52,12 +52,12 @@ export class GrainsRoute extends PageRoute {
 
     wheelKeyListAllPromise.then(data1 => {
       myThis._handleWheelKeyListAll(data1);
-      localGrainsItemsPromise.then(data2 => {
-        myThis._updateMinions(data2);
-      }, data3 => {
+      localGrainsItemsPromise.then(data => {
+        myThis._updateMinions(data);
+      }, data2 => {
         const data = {"return":[{}]};
         for(const k of data1.return[0].data.return.minions)
-          data.return[0][k] = JSON.stringify(data3);
+          data.return[0][k] = JSON.stringify(data2);
         myThis._updateMinions(data);
       });
     }, data => {

--- a/saltgui/static/scripts/routes/Grains.js
+++ b/saltgui/static/scripts/routes/Grains.js
@@ -60,6 +60,8 @@ export class GrainsRoute extends PageRoute {
           data.return[0][k] = JSON.stringify(data3);
         myThis._updateMinions(data);
       });
+    }, data => {
+      myThis._handleWheelKeyListAll(JSON.stringify(data));
     });
 
     runnerJobsListJobsPromise.then(data => {
@@ -75,9 +77,20 @@ export class GrainsRoute extends PageRoute {
   }
 
   _handleWheelKeyListAll(data) {
-    const keys = data.return[0].data.return;
-
     const list = this.getPageElement().querySelector('#minions');
+
+    if(typeof data !== "object") {
+      const tr = document.createElement("tr");
+      const td = document.createElement("td");
+      td.innerText = "(error)";
+      td.colSpan = 99;
+      Utils.addToolTip(td, data);
+      tr.appendChild(td);
+      list.appendChild(tr);
+      return;
+    }
+
+    const keys = data.return[0].data.return;
 
     const hostnames = keys.minions.sort();
     for(const hostname of hostnames) {

--- a/saltgui/static/scripts/routes/Grains.js
+++ b/saltgui/static/scripts/routes/Grains.js
@@ -79,16 +79,7 @@ export class GrainsRoute extends PageRoute {
   _handleWheelKeyListAll(data) {
     const list = this.getPageElement().querySelector('#minions');
 
-    if(typeof data !== "object") {
-      const tr = document.createElement("tr");
-      const td = document.createElement("td");
-      td.innerText = "(error)";
-      td.colSpan = 99;
-      Utils.addToolTip(td, data);
-      tr.appendChild(td);
-      list.appendChild(tr);
-      return;
-    }
+    if(PageRoute.showErrorRowInstead(list, data)) return;
 
     const keys = data.return[0].data.return;
 

--- a/saltgui/static/scripts/routes/Grains.js
+++ b/saltgui/static/scripts/routes/Grains.js
@@ -129,9 +129,8 @@ export class GrainsRoute extends PageRoute {
       grainInfoTd.setAttribute("sorttable_customkey", cnt);
       element.appendChild(grainInfoTd);
     } else {
-      const grainInfoTd = Route._createTd("graininfo", "(error)");
-      grainInfoTd.setAttribute("sorttable_customkey", -1);
-      if(typeof minion === "string") Utils.addToolTip(grainInfoTd, minion);
+      const grainInfoTd = Route._createTd("", "");
+      Utils.addErrorToTableCell(grainInfoTd, minion);
       element.appendChild(grainInfoTd);
     }
 
@@ -151,8 +150,7 @@ export class GrainsRoute extends PageRoute {
           td.classList.add("grain_value");
         }
       } else {
-        td.innerText = "(error)";
-        Utils.addToolTip(td, minion);
+        Utils.addErrorToTableCell(td, minion);
       }
       element.appendChild(td);
     }

--- a/saltgui/static/scripts/routes/Grains.js
+++ b/saltgui/static/scripts/routes/Grains.js
@@ -66,7 +66,11 @@ export class GrainsRoute extends PageRoute {
       myThis._handleRunnerJobsListJobs(data);
       runnerJobsActivePromise.then(data => {
         myThis._handleRunnerJobsActive(data);
+      }, data => {
+        myThis._handleRunnerJobsActive(JSON.stringify(data));
       });
+    }, data => {
+      myThis._handleRunnerJobsListJobs(JSON.stringify(data));
     }); 
   }
 

--- a/saltgui/static/scripts/routes/Grains.js
+++ b/saltgui/static/scripts/routes/Grains.js
@@ -48,13 +48,18 @@ export class GrainsRoute extends PageRoute {
   onShow() {
     const myThis = this;
 
+    const wheelKeyListAllPromise = this.router.api.getWheelKeyListAll();
+    const localGrainsItemsPromise = this.router.api.getLocalGrainsItems(null);
+    const runnerJobsListJobsPromise = this.router.api.getRunnerJobsListJobs();
+    const runnerJobsActivePromise = this.router.api.getRunnerJobsActive();
+
     return new Promise(function(resolve, reject) {
       myThis.resolvePromise = resolve;
       if(myThis.keysLoaded && myThis.jobsLoaded) resolve();
-      myThis.router.api.getLocalGrainsItems(null).then(myThis._updateMinions);
-      myThis.router.api.getWheelKeyListAll().then(myThis._handleWheelKeyListAll);
-      myThis.router.api.getRunnerJobsListJobs().then(myThis._handleRunnerJobsListJobs);
-      myThis.router.api.getRunnerJobsActive().then(myThis._handleRunnerJobsActive);
+      wheelKeyListAllPromise.then(myThis._handleWheelKeyListAll);
+      localGrainsItemsPromise.then(myThis._updateMinions);
+      runnerJobsListJobsPromise.then(myThis._handleRunnerJobsListJobs);
+      runnerJobsActivePromise.then(myThis._handleRunnerJobsActive);
     });
   }
 

--- a/saltgui/static/scripts/routes/GrainsMinion.js
+++ b/saltgui/static/scripts/routes/GrainsMinion.js
@@ -69,7 +69,7 @@ export class GrainsMinionRoute extends PageRoute {
     // fix that by re-adding the minion list
     gmp.appendChild(container);
 
-    if(PageRoute.showErrorRowInstead(container.tBodies[0].appendChild, data)) return;
+    if(PageRoute.showErrorRowInstead(container.tBodies[0], data)) return;
 
     const grains = data.return[0][minion];
 

--- a/saltgui/static/scripts/routes/GrainsMinion.js
+++ b/saltgui/static/scripts/routes/GrainsMinion.js
@@ -9,9 +9,6 @@ export class GrainsMinionRoute extends PageRoute {
   constructor(router) {
     super("^[\/]grainsminion$", "Grains", "#page_grainsminion", "#button_grains", router);
 
-    this.keysLoaded = false;
-    this.jobsLoaded = false;
-
     this._handleLocalGrainsItems = this._handleLocalGrainsItems.bind(this);
 
     this.page_element.querySelector("#button_close_grainsminion").addEventListener("click", _ => {
@@ -31,13 +28,14 @@ export class GrainsMinionRoute extends PageRoute {
     const runnerJobsListJobsPromise = this.router.api.getRunnerJobsListJobs();
     const runnerJobsActivePromise = this.router.api.getRunnerJobsActive();
 
-    return new Promise(function(resolve, reject) {
-      myThis.resolvePromise = resolve;
-      if(myThis.keysLoaded && myThis.jobsLoaded) resolve();
-      localGrainsItemsPromise.then(myThis._handleLocalGrainsItems);
-      runnerJobsListJobsPromise.then(myThis._handleRunnerJobsListJobs);
-      runnerJobsActivePromise.then(myThis._handleRunnerJobsActive);
-    });
+    localGrainsItemsPromise.then(myThis._handleLocalGrainsItems);
+
+    runnerJobsListJobsPromise.then(data => {
+      myThis._handleRunnerJobsListJobs(data);
+      runnerJobsActivePromise.then(data => {
+        myThis._handleRunnerJobsActive(data);
+      });
+    }); 
   }
 
   _handleLocalGrainsItems(data) {

--- a/saltgui/static/scripts/routes/GrainsMinion.js
+++ b/saltgui/static/scripts/routes/GrainsMinion.js
@@ -38,7 +38,11 @@ export class GrainsMinionRoute extends PageRoute {
       myThis._handleRunnerJobsListJobs(data);
       runnerJobsActivePromise.then(data => {
         myThis._handleRunnerJobsActive(data);
+      }, data => {
+        myThis._handleRunnerJobsActive(JSON.stringify(data));
       });
+    }, data => {
+      myThis._handleRunnerJobsListJobs(JSON.stringify(data));
     }); 
   }
 

--- a/saltgui/static/scripts/routes/GrainsMinion.js
+++ b/saltgui/static/scripts/routes/GrainsMinion.js
@@ -69,16 +69,7 @@ export class GrainsMinionRoute extends PageRoute {
     // fix that by re-adding the minion list
     gmp.appendChild(container);
 
-    if(typeof data !== "object") {
-      const tr = document.createElement('tr');
-      const td = document.createElement('td');
-      td.innerText = "(error)";
-      td.colSpan = 99;
-      Utils.addToolTip(td, data);
-      tr.appendChild(td);
-      container.tBodies[0].appendChild(tr);
-      return;
-    }
+    if(PageRoute.showErrorRowInstead(container.tBodies[0].appendChild, data)) return;
 
     const grains = data.return[0][minion];
 

--- a/saltgui/static/scripts/routes/GrainsMinion.js
+++ b/saltgui/static/scripts/routes/GrainsMinion.js
@@ -72,8 +72,10 @@ export class GrainsMinionRoute extends PageRoute {
     if(typeof data !== "object") {
       const tr = document.createElement('tr');
       const td = document.createElement('td');
+      td.innerText = "(error)";
+      td.colSpan = 99;
+      Utils.addToolTip(td, data);
       tr.appendChild(td);
-      td.innerText = data;
       container.tBodies[0].appendChild(tr);
       return;
     }

--- a/saltgui/static/scripts/routes/GrainsMinion.js
+++ b/saltgui/static/scripts/routes/GrainsMinion.js
@@ -27,12 +27,16 @@ export class GrainsMinionRoute extends PageRoute {
     const title = document.getElementById("grainsminion_title");
     title.innerText = "Grains on " + minion;
 
+    const localGrainsItemsPromise = this.router.api.getLocalGrainsItems(minion);
+    const runnerJobsListJobsPromise = this.router.api.getRunnerJobsListJobs();
+    const runnerJobsActivePromise = this.router.api.getRunnerJobsActive();
+
     return new Promise(function(resolve, reject) {
       myThis.resolvePromise = resolve;
       if(myThis.keysLoaded && myThis.jobsLoaded) resolve();
-      myThis.router.api.getLocalGrainsItems(minion).then(myThis._handleLocalGrainsItems);
-      myThis.router.api.getRunnerJobsListJobs().then(myThis._handleRunnerJobsListJobs);
-      myThis.router.api.getRunnerJobsActive().then(myThis._handleRunnerJobsActive);
+      localGrainsItemsPromise.then(myThis._handleLocalGrainsItems);
+      runnerJobsListJobsPromise.then(myThis._handleRunnerJobsListJobs);
+      runnerJobsActivePromise.then(myThis._handleRunnerJobsActive);
     });
   }
 

--- a/saltgui/static/scripts/routes/Job.js
+++ b/saltgui/static/scripts/routes/Job.js
@@ -16,10 +16,14 @@ export class JobRoute extends Route {
     const myThis = this;
 
     const id = decodeURIComponent(Utils.getQueryParam("id"));
+
+    const runnerJobsListJobPromise = this.router.api.getRunnerJobsListJob(id);
+    const runnerJobsActivePromise = this.router.api.getRunnerJobsActive();
+
     return new Promise(function(resolve, reject) {
       myThis.resolvePromise = resolve;
-      myThis.router.api.getRunnerJobsListJob(id).then(myThis._handleRunnerJobsListJob);
-      myThis.router.api.getRunnerJobsActive().then(data => {
+      runnerJobsListJobPromise.then(myThis._handleRunnerJobsListJob);
+      runnerJobsActivePromise.then(data => {
         myThis._handleRunnerJobsActive(id, data);
       });
     });

--- a/saltgui/static/scripts/routes/Job.js
+++ b/saltgui/static/scripts/routes/Job.js
@@ -47,8 +47,8 @@ export class JobRoute extends Route {
 
     if(typeof data !== "object") {
       const pre = this.getPageElement().querySelector(".output");
-      pre.innerText = "(error)";
-      Utils.addToolTip(pre, data);
+      pre.innerText = "";
+      Utils.addErrorToTableCell(pre, data);
       return;
     }
 
@@ -183,7 +183,7 @@ export class JobRoute extends Route {
     if(!summaryJobsActiveSpan) return;
 
     if(typeof data !== "object") {
-      summaryJobsActiveSpan.innerText = "(error), ";
+      summaryJobsActiveSpan.innerText = "(error)";
       Utils.addToolTip(summaryJobsActiveSpan, data);
       return;
     }
@@ -192,7 +192,7 @@ export class JobRoute extends Route {
 
     // when the job is already completely done, nothing is returned
     if(!info) {
-      summaryJobsActiveSpan.innerText = "done, ";
+      summaryJobsActiveSpan.innerText = "done";
       if(this.terminateJobMenuItem) {
         // nothing left to terminate
         this.terminateJobMenuItem.style.display = "none";
@@ -208,7 +208,7 @@ export class JobRoute extends Route {
       return;
     }
 
-    summaryJobsActiveSpan.innerText = info.Running.length + " active, ";
+    summaryJobsActiveSpan.innerText = info.Running.length + " active";
 
     // update the minion details
     for(const minionInfo of info.Running) {

--- a/saltgui/static/scripts/routes/Job.js
+++ b/saltgui/static/scripts/routes/Job.js
@@ -25,7 +25,7 @@ export class JobRoute extends Route {
       runnerJobsActivePromise.then(data => {
         myThis._handleRunnerJobsActive(id, data);
       }, data => {
-        myThis._handleRunnerJobsActive(JSON.stringify(data));
+        myThis._handleRunnerJobsActive(id, JSON.stringify(data));
       });
     }, data => {
       myThis._handleRunnerJobsListJob(JSON.stringify(data));
@@ -179,10 +179,16 @@ export class JobRoute extends Route {
   }
 
   _handleRunnerJobsActive(id, data) {
-    const info = data.return[0][id];
-
     const summaryJobsActiveSpan = this.getPageElement().querySelector("pre.output span#summary_jobsactive");
     if(!summaryJobsActiveSpan) return;
+
+    if(typeof data !== "object") {
+      summaryJobsActiveSpan.innerText = "(error), ";
+      Utils.addToolTip(summaryJobsActiveSpan, data);
+      return;
+    }
+
+    const info = data.return[0][id];
 
     // when the job is already completely done, nothing is returned
     if(!info) {

--- a/saltgui/static/scripts/routes/Job.js
+++ b/saltgui/static/scripts/routes/Job.js
@@ -24,7 +24,11 @@ export class JobRoute extends Route {
       myThis._handleRunnerJobsListJob(data);
       runnerJobsActivePromise.then(data => {
         myThis._handleRunnerJobsActive(id, data);
+      }, data => {
+        myThis._handleRunnerJobsActive(JSON.stringify(data));
       });
+    }, data => {
+      myThis._handleRunnerJobsListJob(JSON.stringify(data));
     });
   }
 
@@ -37,12 +41,19 @@ export class JobRoute extends Route {
   _handleRunnerJobsListJob(data) {
     const myThis = this;
 
-    const info = data.return[0];
-    this.getPageElement().querySelector(".output").innerText = "";
-
     document.querySelector("#button_close_job").addEventListener("click", _ => {
       window.history.back();
     });
+
+    if(typeof data !== "object") {
+      const pre = this.getPageElement().querySelector(".output");
+      pre.innerText = "(error)";
+      Utils.addToolTip(pre, data);
+      return;
+    }
+
+    const info = data.return[0];
+    this.getPageElement().querySelector(".output").innerText = "";
 
     const argumentsText = this._decodeArgumentsText(info.Arguments);
     const commandText = info.Function + argumentsText;

--- a/saltgui/static/scripts/routes/Job.js
+++ b/saltgui/static/scripts/routes/Job.js
@@ -20,9 +20,8 @@ export class JobRoute extends Route {
     const runnerJobsListJobPromise = this.router.api.getRunnerJobsListJob(id);
     const runnerJobsActivePromise = this.router.api.getRunnerJobsActive();
 
-    return new Promise(function(resolve, reject) {
-      myThis.resolvePromise = resolve;
-      runnerJobsListJobPromise.then(myThis._handleRunnerJobsListJob);
+    runnerJobsListJobPromise.then(data => {
+      myThis._handleRunnerJobsListJob(data);
       runnerJobsActivePromise.then(data => {
         myThis._handleRunnerJobsActive(id, data);
       });
@@ -166,8 +165,6 @@ export class JobRoute extends Route {
       this.signalJobMenuItem.style.display = "none";
     }
     Output.addResponseOutput(output, minions, info.Result, info.Function, initialStatus);
-
-    this.resolvePromise();
   }
 
   _handleRunnerJobsActive(id, data) {

--- a/saltgui/static/scripts/routes/Jobs.js
+++ b/saltgui/static/scripts/routes/Jobs.js
@@ -23,7 +23,11 @@ export class JobsRoute extends PageRoute {
       myThis._handleRunnerJobsListJobs(data, true, 50);
       runnerJobsActivePromise.then(data => {
         myThis._handleRunnerJobsActive(data);
+      }, data => {
+        myThis._handleRunnerJobsActive(JSON.stringify(data));
       });
+    }, data => {
+      myThis._handleRunnerJobsListJobs(JSON.stringify(data));
     }); 
   }
 
@@ -109,6 +113,19 @@ export class JobsRoute extends PageRoute {
   }
 
   _handleRunnerJobsActive(data) {
+
+    if(typeof data !== "object") {
+      // update all jobs (page) with the error message
+      for(const tr of this.page_element.querySelector("table#jobs tbody").rows) {
+        const statusField = tr.querySelector("td.status span.no_status");
+        if(!statusField) continue;
+        statusField.classList.remove("no_status");
+        statusField.innerText = "(error)";
+        Utils.addToolTip(statusField, data);
+      }
+      return;
+    }
+
     const jobs = data.return[0];
 
     // update all running jobs
@@ -156,10 +173,22 @@ export class JobsRoute extends PageRoute {
 
     runnerJobsListJobPromise.then(data => {
       myThis._handleRunnerJobsListJob(jobid, data);
+    }, data => {
+      myThis._handleRunnerJobsListJob(jobid, JSON.stringify(data));
     });
   }
 
   _handleRunnerJobsListJob(jobid, data) {
+
+    if(typeof data !== "object") {
+      const detailsSpan = this.page_element.querySelector(".jobs #job" + jobid + " td.details span");
+      if(!detailsSpan) return;
+      detailsSpan.innerText = "(error)";
+      detailsSpan.classList.remove("no_status");
+      Utils.addToolTip(detailsSpan, data);
+      return;
+    }
+
     data = data.return[0];
 
     let str = "";

--- a/saltgui/static/scripts/routes/Jobs.js
+++ b/saltgui/static/scripts/routes/Jobs.js
@@ -9,7 +9,6 @@ export class JobsRoute extends PageRoute {
 
   constructor(router) {
     super("^[\/]jobs$", "Jobs", "#page_jobs", "#button_jobs", router);
-    this.jobsLoaded = false;
 
     this._getJobDetails = this._getJobDetails.bind(this);
   }
@@ -20,16 +19,12 @@ export class JobsRoute extends PageRoute {
     const runnerJobsListJobsPromise = this.router.api.getRunnerJobsListJobs();
     const runnerJobsActivePromise = this.router.api.getRunnerJobsActive();
 
-    return new Promise(function(resolve, reject) {
-      myThis.resolvePromise = resolve;
-      if(myThis.jobsLoaded) resolve();
-      runnerJobsListJobsPromise.then(data => {
-        myThis._handleRunnerJobsListJobs(data, true, 50);
-      });
+    runnerJobsListJobsPromise.then(data => {
+      myThis._handleRunnerJobsListJobs(data, true, 50);
       runnerJobsActivePromise.then(data => {
         myThis._handleRunnerJobsActive(data);
       });
-    });
+    }); 
   }
 
   _addJob(container, job) {

--- a/saltgui/static/scripts/routes/Jobs.js
+++ b/saltgui/static/scripts/routes/Jobs.js
@@ -17,13 +17,16 @@ export class JobsRoute extends PageRoute {
   onShow() {
     const myThis = this;
 
+    const runnerJobsListJobsPromise = this.router.api.getRunnerJobsListJobs();
+    const runnerJobsActivePromise = this.router.api.getRunnerJobsActive();
+
     return new Promise(function(resolve, reject) {
       myThis.resolvePromise = resolve;
       if(myThis.jobsLoaded) resolve();
-      myThis.router.api.getRunnerJobsListJobs().then(data => {
+      runnerJobsListJobsPromise.then(data => {
         myThis._handleRunnerJobsListJobs(data, true, 50);
       });
-      myThis.router.api.getRunnerJobsActive().then(data => {
+      runnerJobsActivePromise.then(data => {
         myThis._handleRunnerJobsActive(data);
       });
     });
@@ -152,9 +155,12 @@ export class JobsRoute extends PageRoute {
   }
 
   _getJobDetails(jobid) {
-    const p = this;
-    this.router.api.getRunnerJobsListJob(jobid).then(data => {
-      p._handleRunnerJobsListJob(jobid, data);
+    const myThis = this;
+
+    const runnerJobsListJobPromise = this.router.api.getRunnerJobsListJob(jobid);
+
+    runnerJobsListJobPromise.then(data => {
+      myThis._handleRunnerJobsListJob(jobid, data);
     });
   }
 

--- a/saltgui/static/scripts/routes/Keys.js
+++ b/saltgui/static/scripts/routes/Keys.js
@@ -7,8 +7,6 @@ export class KeysRoute extends PageRoute {
 
   constructor(router) {
     super("^[\/]keys$", "Keys", "#page_keys", "#button_keys", router);
-    this.keysLoaded = false;
-    this.jobsLoaded = false;
 
     this._handleWheelKeyListAll = this._handleWheelKeyListAll.bind(this);
     this._handleWheelKeyFinger = this._handleWheelKeyFinger.bind(this);
@@ -22,20 +20,19 @@ export class KeysRoute extends PageRoute {
     const runnerJobsListJobsPromise = this.router.api.getRunnerJobsListJobs();
     const runnerJobsActivePromise = this.router.api.getRunnerJobsActive();
 
-    Promise.all([wheelKeyListAllPromise, wheelKeyFingerPromise])
-      .then(function(data){
-        // process result of 1st promise
-        myThis._handleWheelKeyListAll(data[0]);
-        // process result of 2nd promise
-        myThis._handleWheelKeyFinger(data[1]);
+    wheelKeyListAllPromise.then(data => {
+      myThis._handleWheelKeyListAll(data);
+      wheelKeyFingerPromise.then(data => {
+        myThis._handleWheelKeyFinger(data);
       });
-
-    return new Promise(function(resolve, reject) {
-      myThis.resolvePromise = resolve;
-      if(myThis.keysLoaded && myThis.jobsLoaded) resolve();
-      runnerJobsListJobsPromise.then(myThis._handleRunnerJobsListJobs);
-      runnerJobsActivePromise.then(myThis._handleRunnerJobsActive);
     });
+
+    runnerJobsListJobsPromise.then(data => {
+      myThis._handleRunnerJobsListJobs(data);
+      runnerJobsActivePromise.then(data => {
+        myThis._handleRunnerJobsActive(data);
+      });
+    }); 
   }
 
   _handleWheelKeyFinger(data) {
@@ -107,9 +104,6 @@ export class KeysRoute extends PageRoute {
     }
 
     Utils.showTableSortable(this.getPageElement(), "minions");
-
-    this.keysLoaded = true;
-    if(this.keysLoaded && this.jobsLoaded) this.resolvePromise();
   }
 
   _updateOfflineMinion(container, hostname) {

--- a/saltgui/static/scripts/routes/Keys.js
+++ b/saltgui/static/scripts/routes/Keys.js
@@ -36,7 +36,11 @@ export class KeysRoute extends PageRoute {
       myThis._handleRunnerJobsListJobs(data);
       runnerJobsActivePromise.then(data => {
         myThis._handleRunnerJobsActive(data);
+      }, data => {
+        myThis._handleRunnerJobsActive(JSON.stringify(data));
       });
+    }, data => {
+      myThis._handleRunnerJobsListJobs(JSON.stringify(data));
     }); 
   }
 

--- a/saltgui/static/scripts/routes/Keys.js
+++ b/saltgui/static/scripts/routes/Keys.js
@@ -79,16 +79,7 @@ export class KeysRoute extends PageRoute {
   _handleWheelKeyListAll(data) {
     const list = this.getPageElement().querySelector("#minions");
 
-    if(typeof data !== "object") {
-      const tr = document.createElement("tr");
-      const td = document.createElement("td");
-      td.innerText = "(error)";
-      td.colSpan = 99;
-      Utils.addToolTip(td, data);
-      tr.appendChild(td);
-      list.appendChild(tr);
-      return;
-    }
+    if(PageRoute.showErrorRowInstead(list, data)) return;
 
     const keys = data.return[0].data.return;
 

--- a/saltgui/static/scripts/routes/Keys.js
+++ b/saltgui/static/scripts/routes/Keys.js
@@ -20,9 +20,14 @@ export class KeysRoute extends PageRoute {
     const runnerJobsListJobsPromise = this.router.api.getRunnerJobsListJobs();
     const runnerJobsActivePromise = this.router.api.getRunnerJobsActive();
 
-    wheelKeyListAllPromise.then(data => {
-      myThis._handleWheelKeyListAll(data);
-      wheelKeyFingerPromise.then(data => {
+    wheelKeyListAllPromise.then(data1 => {
+      myThis._handleWheelKeyListAll(data1);
+      wheelKeyFingerPromise.then(data2 => {
+        myThis._handleWheelKeyFinger(data2);
+      }, data3 => {
+        const data = {"return":[{}]};
+        for(const k of data1.return[0].data.return.minions)
+          data.return[0][k] = JSON.stringify(data3);
         myThis._handleWheelKeyFinger(data);
       });
     });

--- a/saltgui/static/scripts/routes/Keys.js
+++ b/saltgui/static/scripts/routes/Keys.js
@@ -67,8 +67,7 @@ export class KeysRoute extends PageRoute {
         const fingerprint = hosts[hostname];
         if(!fingerprintElement) continue;
         if(!fingerprint.match(this.fingerprintPattern)) {
-          fingerprintElement.innerText = "(error)";
-          Utils.addToolTip(fingerprintElement, fingerprint);
+          Utils.addErrorToTableCell(fingerprintElement, fingerprint);
           continue;
         }
         fingerprintElement.innerText = fingerprint;

--- a/saltgui/static/scripts/routes/Keys.js
+++ b/saltgui/static/scripts/routes/Keys.js
@@ -25,11 +25,13 @@ export class KeysRoute extends PageRoute {
       wheelKeyFingerPromise.then(data2 => {
         myThis._handleWheelKeyFinger(data2);
       }, data3 => {
-        const data = {"return":[{}]};
+        const data = {"return":[{"data":{"return":{"minions":{}}}}]};
         for(const k of data1.return[0].data.return.minions)
-          data.return[0][k] = JSON.stringify(data3);
+          data.return[0]["data"]["return"]["minions"][k] = JSON.stringify(data3);
         myThis._handleWheelKeyFinger(data);
       });
+    }, data => {
+      myThis._handleWheelKeyListAll(JSON.stringify(data));
     });
 
     runnerJobsListJobsPromise.then(data => {
@@ -61,14 +63,32 @@ export class KeysRoute extends PageRoute {
         // update td.fingerprint with fingerprint value
         const fingerprintElement = this.page_element.querySelector("#" + hostname + " .fingerprint");
         const fingerprint = hosts[hostname];
-        if(fingerprintElement) fingerprintElement.innerText = fingerprint;
+        if(!fingerprintElement) continue;
+        if(fingerprint.startsWith("{")) {
+          fingerprintElement.innerText = "(error)";
+          Utils.addToolTip(fingerprintElement, fingerprint);
+          continue;
+        }
+        fingerprintElement.innerText = fingerprint;
       }
     }
   }
 
   _handleWheelKeyListAll(data) {
-    const keys = data.return[0].data.return;
     const list = this.getPageElement().querySelector("#minions");
+
+    if(typeof data !== "object") {
+      const tr = document.createElement("tr");
+      const td = document.createElement("td");
+      td.innerText = "(error)";
+      td.colSpan = 99;
+      Utils.addToolTip(td, data);
+      tr.appendChild(td);
+      list.appendChild(tr);
+      return;
+    }
+
+    const keys = data.return[0].data.return;
 
     // Unaccepted goes first because that is where the user must decide
     const hostnames_pre = keys.minions_pre.sort();

--- a/saltgui/static/scripts/routes/Keys.js
+++ b/saltgui/static/scripts/routes/Keys.js
@@ -17,21 +17,24 @@ export class KeysRoute extends PageRoute {
   onShow() {
     const myThis = this;
 
-    const p1 = this.router.api.getWheelKeyListAll();
-    const p2 = this.router.api.getWheelKeyFinger();
+    const wheelKeyListAllPromise = this.router.api.getWheelKeyListAll();
+    const wheelKeyFingerPromise = this.router.api.getWheelKeyFinger();
+    const runnerJobsListJobsPromise = this.router.api.getRunnerJobsListJobs();
+    const runnerJobsActivePromise = this.router.api.getRunnerJobsActive();
 
-    Promise.all([p1, p2])
+    Promise.all([wheelKeyListAllPromise, wheelKeyFingerPromise])
       .then(function(data){
         // process result of 1st promise
         myThis._handleWheelKeyListAll(data[0]);
         // process result of 2nd promise
         myThis._handleWheelKeyFinger(data[1]);
       });
+
     return new Promise(function(resolve, reject) {
       myThis.resolvePromise = resolve;
       if(myThis.keysLoaded && myThis.jobsLoaded) resolve();
-      myThis.router.api.getRunnerJobsListJobs().then(myThis._handleRunnerJobsListJobs);
-      myThis.router.api.getRunnerJobsActive().then(myThis._handleRunnerJobsActive);
+      runnerJobsListJobsPromise.then(myThis._handleRunnerJobsListJobs);
+      runnerJobsActivePromise.then(myThis._handleRunnerJobsActive);
     });
   }
 

--- a/saltgui/static/scripts/routes/Keys.js
+++ b/saltgui/static/scripts/routes/Keys.js
@@ -8,6 +8,8 @@ export class KeysRoute extends PageRoute {
   constructor(router) {
     super("^[\/]keys$", "Keys", "#page_keys", "#button_keys", router);
 
+    this.fingerprintPattern = /^[0-9a-f:]+$/i;
+
     this._handleWheelKeyListAll = this._handleWheelKeyListAll.bind(this);
     this._handleWheelKeyFinger = this._handleWheelKeyFinger.bind(this);
   }
@@ -64,7 +66,7 @@ export class KeysRoute extends PageRoute {
         const fingerprintElement = this.page_element.querySelector("#" + hostname + " .fingerprint");
         const fingerprint = hosts[hostname];
         if(!fingerprintElement) continue;
-        if(fingerprint.startsWith("{")) {
+        if(!fingerprint.match(this.fingerprintPattern)) {
           fingerprintElement.innerText = "(error)";
           Utils.addToolTip(fingerprintElement, fingerprint);
           continue;

--- a/saltgui/static/scripts/routes/Keys.js
+++ b/saltgui/static/scripts/routes/Keys.js
@@ -22,12 +22,12 @@ export class KeysRoute extends PageRoute {
 
     wheelKeyListAllPromise.then(data1 => {
       myThis._handleWheelKeyListAll(data1);
-      wheelKeyFingerPromise.then(data2 => {
-        myThis._handleWheelKeyFinger(data2);
-      }, data3 => {
+      wheelKeyFingerPromise.then(data => {
+        myThis._handleWheelKeyFinger(data);
+      }, data2 => {
         const data = {"return":[{"data":{"return":{"minions":{}}}}]};
         for(const k of data1.return[0].data.return.minions)
-          data.return[0]["data"]["return"]["minions"][k] = JSON.stringify(data3);
+          data.return[0]["data"]["return"]["minions"][k] = JSON.stringify(data2);
         myThis._handleWheelKeyFinger(data);
       });
     }, data => {

--- a/saltgui/static/scripts/routes/Minions.js
+++ b/saltgui/static/scripts/routes/Minions.js
@@ -7,8 +7,6 @@ export class MinionsRoute extends PageRoute {
 
   constructor(router) {
     super("^[\/]$", "Minions", "#page_minions", "#button_minions", router);
-    this.keysLoaded = false;
-    this.jobsLoaded = false;
 
     this._handleWheelKeyListAll = this._handleWheelKeyListAll.bind(this);
   }
@@ -23,16 +21,22 @@ export class MinionsRoute extends PageRoute {
     //we need these functions to populate the dropdown boxes
     const wheelConfigValuesPromise = this.router.api.getWheelConfigValues();
 
-    return new Promise(function(resolve, reject) {
-      myThis.resolvePromise = resolve;
-      if(myThis.keysLoaded && myThis.jobsLoaded) resolve();
-      wheelKeyListAllPromise.then(myThis._handleWheelKeyListAll);
-      localGrainsItemsPromise.then(myThis._updateMinions);
-      runnerJobsListJobsPromise.then(myThis._handleRunnerJobsListJobs);
-      runnerJobsActivePromise.then(myThis._handleRunnerJobsActive);
-      //we need these functions to populate the dropdown boxes
-      wheelConfigValuesPromise.then(myThis._handleWheelConfigValues);
+    wheelKeyListAllPromise.then(data => {
+      myThis._handleWheelKeyListAll(data);
+      localGrainsItemsPromise.then(data => {
+        myThis._updateMinions(data);
+      });
     });
+
+    runnerJobsListJobsPromise.then(data => {
+      myThis._handleRunnerJobsListJobs(data);
+      runnerJobsActivePromise.then(data => {
+        myThis._handleRunnerJobsActive(data);
+      });
+    }); 
+
+    //we need these functions to populate the dropdown boxes
+    wheelConfigValuesPromise.then(myThis._handleWheelConfigValues);
   }
 
   _handleWheelConfigValues(data) {
@@ -76,9 +80,6 @@ export class MinionsRoute extends PageRoute {
     }
 
     Utils.showTableSortable(this.getPageElement(), "minions");
-
-    this.keysLoaded = true;
-    if(this.keysLoaded && this.jobsLoaded) this.resolvePromise();
   }
 
   _updateOfflineMinion(container, hostname) {

--- a/saltgui/static/scripts/routes/Minions.js
+++ b/saltgui/static/scripts/routes/Minions.js
@@ -31,6 +31,8 @@ export class MinionsRoute extends PageRoute {
           data.return[0][k] = JSON.stringify(data3);
         myThis._updateMinions(data);
       });
+    }, data => {
+      myThis._handleWheelKeyListAll(JSON.stringify(data));
     });
 
     runnerJobsListJobsPromise.then(data => {
@@ -45,7 +47,11 @@ export class MinionsRoute extends PageRoute {
     }); 
 
     //we need these functions to populate the dropdown boxes
-    wheelConfigValuesPromise.then(myThis._handleWheelConfigValues);
+    wheelConfigValuesPromise.then(data => {
+      myThis._handleWheelConfigValues(data);
+    }, data => {
+      // never mind
+    });
   }
 
   _handleWheelConfigValues(data) {
@@ -72,9 +78,20 @@ export class MinionsRoute extends PageRoute {
   }
 
   _handleWheelKeyListAll(data) {
-    const keys = data.return[0].data.return;
-
     const list = this.getPageElement().querySelector("#minions");
+
+    if(typeof data !== "object") {
+      const tr = document.createElement("tr");
+      const td = document.createElement("td");
+      td.innerText = "(error)";
+      td.colSpan = 99;
+      Utils.addToolTip(td, data);
+      tr.appendChild(td);
+      list.appendChild(tr);
+      return;
+    }
+
+    const keys = data.return[0].data.return;
 
     const hostnames = keys.minions.sort();
     for(const hostname of hostnames) {

--- a/saltgui/static/scripts/routes/Minions.js
+++ b/saltgui/static/scripts/routes/Minions.js
@@ -37,7 +37,11 @@ export class MinionsRoute extends PageRoute {
       myThis._handleRunnerJobsListJobs(data);
       runnerJobsActivePromise.then(data => {
         myThis._handleRunnerJobsActive(data);
+      }, data => {
+        myThis._handleRunnerJobsActive(JSON.stringify(data));
       });
+    }, data => {
+      myThis._handleRunnerJobsListJobs(JSON.stringify(data));
     }); 
 
     //we need these functions to populate the dropdown boxes

--- a/saltgui/static/scripts/routes/Minions.js
+++ b/saltgui/static/scripts/routes/Minions.js
@@ -16,15 +16,22 @@ export class MinionsRoute extends PageRoute {
   onShow() {
     const myThis = this;
 
+    const wheelKeyListAllPromise = this.router.api.getWheelKeyListAll();
+    const localGrainsItemsPromise = this.router.api.getLocalGrainsItems(null);
+    const runnerJobsListJobsPromise = this.router.api.getRunnerJobsListJobs();
+    const runnerJobsActivePromise = this.router.api.getRunnerJobsActive();
+    //we need these functions to populate the dropdown boxes
+    const wheelConfigValuesPromise = this.router.api.getWheelConfigValues();
+
     return new Promise(function(resolve, reject) {
       myThis.resolvePromise = resolve;
       if(myThis.keysLoaded && myThis.jobsLoaded) resolve();
-      myThis.router.api.getLocalGrainsItems(null).then(myThis._updateMinions);
-      myThis.router.api.getWheelKeyListAll().then(myThis._handleWheelKeyListAll);
-      myThis.router.api.getRunnerJobsListJobs().then(myThis._handleRunnerJobsListJobs);
-      myThis.router.api.getRunnerJobsActive().then(myThis._handleRunnerJobsActive);
+      wheelKeyListAllPromise.then(myThis._handleWheelKeyListAll);
+      localGrainsItemsPromise.then(myThis._updateMinions);
+      runnerJobsListJobsPromise.then(myThis._handleRunnerJobsListJobs);
+      runnerJobsActivePromise.then(myThis._handleRunnerJobsActive);
       //we need these functions to populate the dropdown boxes
-      myThis.router.api.getWheelConfigValues().then(myThis._handleWheelConfigValues);
+      wheelConfigValuesPromise.then(myThis._handleWheelConfigValues);
     });
   }
 

--- a/saltgui/static/scripts/routes/Minions.js
+++ b/saltgui/static/scripts/routes/Minions.js
@@ -80,16 +80,7 @@ export class MinionsRoute extends PageRoute {
   _handleWheelKeyListAll(data) {
     const list = this.getPageElement().querySelector("#minions");
 
-    if(typeof data !== "object") {
-      const tr = document.createElement("tr");
-      const td = document.createElement("td");
-      td.innerText = "(error)";
-      td.colSpan = 99;
-      Utils.addToolTip(td, data);
-      tr.appendChild(td);
-      list.appendChild(tr);
-      return;
-    }
+    if(PageRoute.showErrorRowInstead(list, data)) return;
 
     const keys = data.return[0].data.return;
 

--- a/saltgui/static/scripts/routes/Minions.js
+++ b/saltgui/static/scripts/routes/Minions.js
@@ -21,9 +21,14 @@ export class MinionsRoute extends PageRoute {
     //we need these functions to populate the dropdown boxes
     const wheelConfigValuesPromise = this.router.api.getWheelConfigValues();
 
-    wheelKeyListAllPromise.then(data => {
-      myThis._handleWheelKeyListAll(data);
-      localGrainsItemsPromise.then(data => {
+    wheelKeyListAllPromise.then(data1 => {
+      myThis._handleWheelKeyListAll(data1);
+      localGrainsItemsPromise.then(data2 => {
+        myThis._updateMinions(data2);
+      }, data3 => {
+        const data = {"return":[{}]};
+        for(const k of data1.return[0].data.return.minions)
+          data.return[0][k] = JSON.stringify(data3);
         myThis._updateMinions(data);
       });
     });

--- a/saltgui/static/scripts/routes/Minions.js
+++ b/saltgui/static/scripts/routes/Minions.js
@@ -23,12 +23,12 @@ export class MinionsRoute extends PageRoute {
 
     wheelKeyListAllPromise.then(data1 => {
       myThis._handleWheelKeyListAll(data1);
-      localGrainsItemsPromise.then(data2 => {
-        myThis._updateMinions(data2);
-      }, data3 => {
+      localGrainsItemsPromise.then(data => {
+        myThis._updateMinions(data);
+      }, data2 => {
         const data = {"return":[{}]};
         for(const k of data1.return[0].data.return.minions)
-          data.return[0][k] = JSON.stringify(data3);
+          data.return[0][k] = JSON.stringify(data2);
         myThis._updateMinions(data);
       });
     }, data => {

--- a/saltgui/static/scripts/routes/Page.js
+++ b/saltgui/static/scripts/routes/Page.js
@@ -240,15 +240,22 @@ export class PageRoute extends Route {
     }
 
     let saltversion = "---";
-    if(minion && minion.saltversion) saltversion = minion.saltversion;
-    if(minion) element.appendChild(Route._createTd("saltversion", saltversion));
+    if(typeof minion === "string") saltversion = "(error)";
+    else if(minion && minion.saltversion) saltversion = minion.saltversion;
+    if(minion) {
+      const td = Route._createTd("saltversion", saltversion);
+      if(typeof minion === "string") Utils.addToolTip(td, minion);
+      element.appendChild(td);
+    }
 
     let os = "---";
-    if(minion && minion.os && minion.osrelease) os = minion.os + " " + minion.osrelease;
+    if(typeof minion === "string") os = "(error)";
+    else if(minion && minion.os && minion.osrelease) os = minion.os + " " + minion.osrelease;
     else if(minion && minion.os) os = minion.os;
     if(minion) {
       const td = Route._createTd("os", os);
-      if(minion.os) {
+      if(typeof minion === "string") Utils.addToolTip(td, minion);
+      if(minion.os && typeof minion !== "string") {
         const img = document.createElement("img");
         img.setAttribute("src", "static/images/os-" + minion.os.replace(" ", "-").toLowerCase() + ".png");
         img.classList.add("osimage");

--- a/saltgui/static/scripts/routes/Page.js
+++ b/saltgui/static/scripts/routes/Page.js
@@ -240,21 +240,21 @@ export class PageRoute extends Route {
     }
 
     let saltversion = "---";
-    if(typeof minion === "string") saltversion = "(error)";
+    if(typeof minion === "string") saltversion = "";
     else if(minion && minion.saltversion) saltversion = minion.saltversion;
     if(minion) {
       const td = Route._createTd("saltversion", saltversion);
-      if(typeof minion === "string") Utils.addToolTip(td, minion);
+      if(typeof minion === "string") Utils.addErrorToTableCell(td, minion);
       element.appendChild(td);
     }
 
     let os = "---";
-    if(typeof minion === "string") os = "(error)";
+    if(typeof minion === "string") os = "";
     else if(minion && minion.os && minion.osrelease) os = minion.os + " " + minion.osrelease;
     else if(minion && minion.os) os = minion.os;
     if(minion) {
       const td = Route._createTd("os", os);
-      if(typeof minion === "string") Utils.addToolTip(td, minion);
+      if(typeof minion === "string") Utils.addErrorToTableCell(td, minion);
       if(minion.os && typeof minion !== "string") {
         const img = document.createElement("img");
         img.setAttribute("src", "static/images/os-" + minion.os.replace(" ", "-").toLowerCase() + ".png");
@@ -524,9 +524,11 @@ export class PageRoute extends Route {
     }
 
     const td = document.createElement("td");
-    td.innerText = "(error)";
     td.colSpan = 99;
-    Utils.addToolTip(td, data);
+    const span = document.createElement("span");
+    span.innerText = "(error)";
+    Utils.addToolTip(span, data);
+    td.appendChild(span);
 
     const tr = document.createElement("tr");
     tr.appendChild(td);

--- a/saltgui/static/scripts/routes/Page.js
+++ b/saltgui/static/scripts/routes/Page.js
@@ -307,10 +307,7 @@ export class PageRoute extends Route {
       const tr = document.createElement("tr");
       const td = document.createElement("td");
       td.innerText = "(error)";
-      // colSpan=7 for Jobs page
-      // colSpan=1 is sufficient for orther pages,
-      // but too much is also good
-      td.colSpan = "7";
+      td.colSpan = 99;
       Utils.addToolTip(td, data);
       tr.appendChild(td);
       jobContainer.appendChild(tr);

--- a/saltgui/static/scripts/routes/Page.js
+++ b/saltgui/static/scripts/routes/Page.js
@@ -303,16 +303,7 @@ export class PageRoute extends Route {
   _handleRunnerJobsListJobs(data, hasHeader = false, numberOfJobs = 7) {
     const jobContainer = this.getPageElement().querySelector(".jobs tbody");
 
-    if(typeof data !== "object") {
-      const tr = document.createElement("tr");
-      const td = document.createElement("td");
-      td.innerText = "(error)";
-      td.colSpan = 99;
-      Utils.addToolTip(td, data);
-      tr.appendChild(td);
-      jobContainer.appendChild(tr);
-      return;
-    }
+    if(PageRoute.showErrorRowInstead(jobContainer, data)) return;
 
     const jobs = this._jobsToArray(data.return[0]);
     this._sortJobs(jobs);
@@ -526,4 +517,22 @@ export class PageRoute extends Route {
     Utils.addToolTip(target, "Click to copy");
   }
 
+  static showErrorRowInstead(table, data) {
+    if(typeof data === "object") {
+      // not an error
+      return false;
+    }
+
+    const td = document.createElement("td");
+    td.innerText = "(error)";
+    td.colSpan = 99;
+    Utils.addToolTip(td, data);
+
+    const tr = document.createElement("tr");
+    tr.appendChild(td);
+
+    table.appendChild(tr);
+
+    return true;
+  }
 }

--- a/saltgui/static/scripts/routes/Page.js
+++ b/saltgui/static/scripts/routes/Page.js
@@ -351,9 +351,6 @@ export class PageRoute extends Route {
     if(hasHeader) {
       Utils.showTableSortable(this.getPageElement(), "jobs", true);
     }
-
-    this.jobsLoaded = true;
-    if(this.keysLoaded && this.jobsLoaded) this.resolvePromise();
   }
 
   _handleRunnerJobsActive(data) {

--- a/saltgui/static/scripts/routes/Page.js
+++ b/saltgui/static/scripts/routes/Page.js
@@ -302,6 +302,21 @@ export class PageRoute extends Route {
 
   _handleRunnerJobsListJobs(data, hasHeader = false, numberOfJobs = 7) {
     const jobContainer = this.getPageElement().querySelector(".jobs tbody");
+
+    if(typeof data !== "object") {
+      const tr = document.createElement("tr");
+      const td = document.createElement("td");
+      td.innerText = "(error)";
+      // colSpan=7 for Jobs page
+      // colSpan=1 is sufficient for orther pages,
+      // but too much is also good
+      td.colSpan = "7";
+      Utils.addToolTip(td, data);
+      tr.appendChild(td);
+      jobContainer.appendChild(tr);
+      return;
+    }
+
     const jobs = this._jobsToArray(data.return[0]);
     this._sortJobs(jobs);
 
@@ -361,7 +376,19 @@ export class PageRoute extends Route {
   }
 
   _handleRunnerJobsActive(data) {
-    const jobs = data.return[0];
+
+    if(typeof data !== "object") {
+      for(const tr of this.page_element.querySelector("table.jobs tbody").rows) {
+        const statusSpan = tr.querySelector("span.status");
+        if(!statusSpan) continue;
+        statusSpan.classList.remove("no_status");
+        statusSpan.innerText = "(error)";
+        // we show the tooltip here so that the user is invited to click on this
+        // the user then sees other rows being updated without becoming invisible
+        Utils.addToolTip(statusSpan, data);
+      }
+      return;
+    }
 
     // mark all jobs as done, then re-update the running jobs
     for(const tr of this.page_element.querySelector("table.jobs tbody").rows) {
@@ -373,6 +400,8 @@ export class PageRoute extends Route {
       // the user then sees other rows being updated without becoming invisible
       Utils.addToolTip(statusSpan, "Click to refresh");
     }
+
+    const jobs = data.return[0];
 
     // update all running jobs
     for(const k in jobs)
@@ -451,6 +480,8 @@ export class PageRoute extends Route {
 
     this.router.api.getRunnerJobsActive().then(data => {
       myThis._handleRunnerJobsActive(data);
+    }, data => {
+      myThis._handleRunnerJobsActive(JSON.stringify(data));
     });
   }
 

--- a/saltgui/static/scripts/routes/Pillars.js
+++ b/saltgui/static/scripts/routes/Pillars.js
@@ -8,9 +8,6 @@ export class PillarsRoute extends PageRoute {
   constructor(router) {
     super("^[\/]pillars$", "Pillars", "#page_pillars", "#button_pillars", router);
 
-    this.keysLoaded = false;
-    this.jobsLoaded = false;
-
     this._handleWheelKeyListAll = this._handleWheelKeyListAll.bind(this);
     this._updateMinion = this._updateMinion.bind(this);
   }
@@ -23,14 +20,16 @@ export class PillarsRoute extends PageRoute {
     const runnerJobsListJobsPromise = this.router.api.getRunnerJobsListJobs();
     const runnerJobsActivePromise = this.router.api.getRunnerJobsActive();
 
-    return new Promise(function(resolve, reject) {
-      myThis.resolvePromise = resolve;
-      if(myThis.keysLoaded && myThis.jobsLoaded) resolve();
-      wheelKeyListAllPromise.then(myThis._handleWheelKeyListAll);
-      localPillarObfuscatePromise.then(myThis._updateMinions);
-      runnerJobsListJobsPromise.then(myThis._handleRunnerJobsListJobs);
-      runnerJobsActivePromise.then(myThis._handleRunnerJobsActive);
-    });
+    wheelKeyListAllPromise.then(myThis._handleWheelKeyListAll);
+
+    localPillarObfuscatePromise.then(myThis._updateMinions);
+
+    runnerJobsListJobsPromise.then(data => {
+      myThis._handleRunnerJobsListJobs(data);
+      runnerJobsActivePromise.then(data => {
+        myThis._handleRunnerJobsActive(data);
+      });
+    }); 
   }
 
   _handleWheelKeyListAll(data) {
@@ -51,9 +50,6 @@ export class PillarsRoute extends PageRoute {
     }
 
     Utils.showTableSortable(this.getPageElement(), "minions");
-
-    this.keysLoaded = true;
-    if(this.keysLoaded && this.jobsLoaded) this.resolvePromise();
   }
 
   _updateOfflineMinion(container, hostname) {

--- a/saltgui/static/scripts/routes/Pillars.js
+++ b/saltgui/static/scripts/routes/Pillars.js
@@ -20,9 +20,17 @@ export class PillarsRoute extends PageRoute {
     const runnerJobsListJobsPromise = this.router.api.getRunnerJobsListJobs();
     const runnerJobsActivePromise = this.router.api.getRunnerJobsActive();
 
-    wheelKeyListAllPromise.then(myThis._handleWheelKeyListAll);
-
-    localPillarObfuscatePromise.then(myThis._updateMinions);
+    wheelKeyListAllPromise.then(data1 => {
+      myThis._handleWheelKeyListAll(data1);
+      localPillarObfuscatePromise.then(data2 => {
+        myThis._updateMinions(data2);
+      }, data3 => {
+        const data = {"return":[{}]};
+        for(const k of data1.return[0].data.return.minions)
+          data.return[0][k] = JSON.stringify(data3);
+        myThis._updateMinions(data);
+      });
+    });
 
     runnerJobsListJobsPromise.then(data => {
       myThis._handleRunnerJobsListJobs(data);
@@ -67,17 +75,26 @@ export class PillarsRoute extends PageRoute {
 
     const element = document.getElementById(hostname);
 
-    const cnt = Object.keys(minion).length;
+    let cnt;
     let pillarInfoText;
-    if(cnt === 0) {
-      pillarInfoText = "No pillars";
-    } else if(cnt === 1) {
-      pillarInfoText = cnt + " pillar";
+    if(typeof minion === "object") {
+      cnt = Object.keys(minion).length;
+      if(cnt === 0) {
+        pillarInfoText = "No pillars";
+      } else if(cnt === 1) {
+        pillarInfoText = cnt + " pillar";
+      } else {
+        pillarInfoText = cnt + " pillars";
+      }
     } else {
-      pillarInfoText = cnt + " pillars";
+      cnt = -1;
+      pillarInfoText = "(error)";
     }
     const pillarInfoTd = Route._createTd("pillarinfo", pillarInfoText);
     pillarInfoTd.setAttribute("sorttable_customkey", cnt);
+    if(typeof minion !== "object") {
+      Utils.addToolTip(pillarInfoTd, minion);
+    }
     element.appendChild(pillarInfoTd);
 
     const menu = new DropDownMenu(element);

--- a/saltgui/static/scripts/routes/Pillars.js
+++ b/saltgui/static/scripts/routes/Pillars.js
@@ -22,12 +22,12 @@ export class PillarsRoute extends PageRoute {
 
     wheelKeyListAllPromise.then(data1 => {
       myThis._handleWheelKeyListAll(data1);
-      localPillarObfuscatePromise.then(data2 => {
-        myThis._updateMinions(data2);
-      }, data3 => {
+      localPillarObfuscatePromise.then(data => {
+        myThis._updateMinions(data);
+      }, data2 => {
         const data = {"return":[{}]};
         for(const k of data1.return[0].data.return.minions)
-          data.return[0][k] = JSON.stringify(data3);
+          data.return[0][k] = JSON.stringify(data2);
         myThis._updateMinions(data);
       });
     }, data => {

--- a/saltgui/static/scripts/routes/Pillars.js
+++ b/saltgui/static/scripts/routes/Pillars.js
@@ -36,7 +36,11 @@ export class PillarsRoute extends PageRoute {
       myThis._handleRunnerJobsListJobs(data);
       runnerJobsActivePromise.then(data => {
         myThis._handleRunnerJobsActive(data);
+      }, data => {
+        myThis._handleRunnerJobsActive(JSON.stringify(data));
       });
+    }, data => {
+      myThis._handleRunnerJobsListJobs(JSON.stringify(data));
     }); 
   }
 

--- a/saltgui/static/scripts/routes/Pillars.js
+++ b/saltgui/static/scripts/routes/Pillars.js
@@ -30,6 +30,8 @@ export class PillarsRoute extends PageRoute {
           data.return[0][k] = JSON.stringify(data3);
         myThis._updateMinions(data);
       });
+    }, data => {
+      myThis._handleWheelKeyListAll(JSON.stringify(data));
     });
 
     runnerJobsListJobsPromise.then(data => {
@@ -45,9 +47,20 @@ export class PillarsRoute extends PageRoute {
   }
 
   _handleWheelKeyListAll(data) {
-    const keys = data.return[0].data.return;
-
     const list = this.getPageElement().querySelector('#minions');
+
+    if(typeof data !== "object") {
+      const tr = document.createElement("tr");
+      const td = document.createElement("td");
+      td.innerText = "(error)";
+      td.colSpan = 99;
+      Utils.addToolTip(td, data);
+      tr.appendChild(td);
+      list.appendChild(tr);
+      return;
+    }
+
+    const keys = data.return[0].data.return;
 
     const hostnames = keys.minions.sort();
     for(const hostname of hostnames) {

--- a/saltgui/static/scripts/routes/Pillars.js
+++ b/saltgui/static/scripts/routes/Pillars.js
@@ -96,12 +96,12 @@ export class PillarsRoute extends PageRoute {
       }
     } else {
       cnt = -1;
-      pillarInfoText = "(error)";
+      pillarInfoText = "";
     }
     const pillarInfoTd = Route._createTd("pillarinfo", pillarInfoText);
     pillarInfoTd.setAttribute("sorttable_customkey", cnt);
     if(typeof minion !== "object") {
-      Utils.addToolTip(pillarInfoTd, minion);
+      Utils.addErrorToTableCell(pillarInfoTd, minion);
     }
     element.appendChild(pillarInfoTd);
 

--- a/saltgui/static/scripts/routes/Pillars.js
+++ b/saltgui/static/scripts/routes/Pillars.js
@@ -18,13 +18,18 @@ export class PillarsRoute extends PageRoute {
   onShow() {
     const myThis = this;
 
+    const wheelKeyListAllPromise = this.router.api.getWheelKeyListAll();
+    const localPillarObfuscatePromise = this.router.api.getLocalPillarObfuscate(null);
+    const runnerJobsListJobsPromise = this.router.api.getRunnerJobsListJobs();
+    const runnerJobsActivePromise = this.router.api.getRunnerJobsActive();
+
     return new Promise(function(resolve, reject) {
       myThis.resolvePromise = resolve;
       if(myThis.keysLoaded && myThis.jobsLoaded) resolve();
-      myThis.router.api.getLocalPillarObfuscate(null).then(myThis._updateMinions);
-      myThis.router.api.getWheelKeyListAll().then(myThis._handleWheelKeyListAll);
-      myThis.router.api.getRunnerJobsListJobs().then(myThis._handleRunnerJobsListJobs);
-      myThis.router.api.getRunnerJobsActive().then(myThis._handleRunnerJobsActive);
+      wheelKeyListAllPromise.then(myThis._handleWheelKeyListAll);
+      localPillarObfuscatePromise.then(myThis._updateMinions);
+      runnerJobsListJobsPromise.then(myThis._handleRunnerJobsListJobs);
+      runnerJobsActivePromise.then(myThis._handleRunnerJobsActive);
     });
   }
 

--- a/saltgui/static/scripts/routes/Pillars.js
+++ b/saltgui/static/scripts/routes/Pillars.js
@@ -49,16 +49,7 @@ export class PillarsRoute extends PageRoute {
   _handleWheelKeyListAll(data) {
     const list = this.getPageElement().querySelector('#minions');
 
-    if(typeof data !== "object") {
-      const tr = document.createElement("tr");
-      const td = document.createElement("td");
-      td.innerText = "(error)";
-      td.colSpan = 99;
-      Utils.addToolTip(td, data);
-      tr.appendChild(td);
-      list.appendChild(tr);
-      return;
-    }
+    if(PageRoute.showErrorRowInstead(list, data)) return;
 
     const keys = data.return[0].data.return;
 

--- a/saltgui/static/scripts/routes/PillarsMinion.js
+++ b/saltgui/static/scripts/routes/PillarsMinion.js
@@ -28,7 +28,11 @@ export class PillarsMinionRoute extends PageRoute {
     const runnerJobsListJobsPromise = this.router.api.getRunnerJobsListJobs();
     const runnerJobsActivePromise = this.router.api.getRunnerJobsActive();
 
-    localPillarItemsPromise.then(myThis._handleLocalPillarItems);
+    localPillarItemsPromise.then(data => {
+      myThis._handleLocalPillarItems(data);
+    }, data => {
+      myThis._handleLocalPillarItems(JSON.stringify(data));
+    });
 
     runnerJobsListJobsPromise.then(data => {
       myThis._handleRunnerJobsListJobs(data);
@@ -40,8 +44,6 @@ export class PillarsMinionRoute extends PageRoute {
 
   _handleLocalPillarItems(data) {
     const minion = decodeURIComponent(Utils.getQueryParam("minion"));
-
-    const pillars = data.return[0][minion];
 
     const pmp = document.getElementById("pillarsminion_page");
     const menu = new DropDownMenu(pmp);
@@ -57,7 +59,16 @@ export class PillarsMinionRoute extends PageRoute {
       container.tBodies[0].deleteRow(0);
     }
 
-    if(!pillars) return;
+    if(typeof data !== "object") {
+      const tr = document.createElement('tr');
+      const td = document.createElement('td');
+      tr.appendChild(td);
+      td.innerText = data;
+      container.tBodies[0].appendChild(tr);
+      return;
+    }
+
+    const pillars = data.return[0][minion];
 
     // collect the public pillars and compile their regexps
     let publicPillarsText = window.localStorage.getItem("public_pillars");

--- a/saltgui/static/scripts/routes/PillarsMinion.js
+++ b/saltgui/static/scripts/routes/PillarsMinion.js
@@ -27,12 +27,16 @@ export class PillarsMinionRoute extends PageRoute {
     const title = document.getElementById("pillarsminion_title");
     title.innerText = "Pillars on " + minion;
 
+    const localPillarItemsPromise = this.router.api.getLocalPillarItems(minion);
+    const runnerJobsListJobsPromise = this.router.api.getRunnerJobsListJobs();
+    const runnerJobsActivePromise = this.router.api.getRunnerJobsActive();
+
     return new Promise(function(resolve, reject) {
       myThis.resolvePromise = resolve;
       if(myThis.keysLoaded && myThis.jobsLoaded) resolve();
-      myThis.router.api.getLocalPillarItems(minion).then(myThis._handleLocalPillarItems);
-      myThis.router.api.getRunnerJobsListJobs().then(myThis._handleRunnerJobsListJobs);
-      myThis.router.api.getRunnerJobsActive().then(myThis._handleRunnerJobsActive);
+      localPillarItemsPromise.then(myThis._handleLocalPillarItems);
+      runnerJobsListJobsPromise.then(myThis._handleRunnerJobsListJobs);
+      runnerJobsActivePromise.then(myThis._handleRunnerJobsActive);
     });
   }
 

--- a/saltgui/static/scripts/routes/PillarsMinion.js
+++ b/saltgui/static/scripts/routes/PillarsMinion.js
@@ -66,8 +66,10 @@ export class PillarsMinionRoute extends PageRoute {
     if(typeof data !== "object") {
       const tr = document.createElement('tr');
       const td = document.createElement('td');
+      td.innerText = "(error)";
+      td.colSpan = 99;
+      Utils.addToolTip(td, data);
       tr.appendChild(td);
-      td.innerText = data;
       container.tBodies[0].appendChild(tr);
       return;
     }

--- a/saltgui/static/scripts/routes/PillarsMinion.js
+++ b/saltgui/static/scripts/routes/PillarsMinion.js
@@ -63,16 +63,7 @@ export class PillarsMinionRoute extends PageRoute {
       container.tBodies[0].deleteRow(0);
     }
 
-    if(typeof data !== "object") {
-      const tr = document.createElement('tr');
-      const td = document.createElement('td');
-      td.innerText = "(error)";
-      td.colSpan = 99;
-      Utils.addToolTip(td, data);
-      tr.appendChild(td);
-      container.tBodies[0].appendChild(tr);
-      return;
-    }
+    if(PageRoute.showErrorRowInstead(container.tBodies[0], data)) return;
 
     const pillars = data.return[0][minion];
 

--- a/saltgui/static/scripts/routes/PillarsMinion.js
+++ b/saltgui/static/scripts/routes/PillarsMinion.js
@@ -9,9 +9,6 @@ export class PillarsMinionRoute extends PageRoute {
   constructor(router) {
     super("^[\/]pillarsminion$", "Pillars", "#page_pillarsminion", "#button_pillars", router);
 
-    this.keysLoaded = false;
-    this.jobsLoaded = false;
-
     this._handleLocalPillarItems = this._handleLocalPillarItems.bind(this);
 
     this.page_element.querySelector("#button_close_pillarsminion").addEventListener("click", _ => {
@@ -31,13 +28,14 @@ export class PillarsMinionRoute extends PageRoute {
     const runnerJobsListJobsPromise = this.router.api.getRunnerJobsListJobs();
     const runnerJobsActivePromise = this.router.api.getRunnerJobsActive();
 
-    return new Promise(function(resolve, reject) {
-      myThis.resolvePromise = resolve;
-      if(myThis.keysLoaded && myThis.jobsLoaded) resolve();
-      localPillarItemsPromise.then(myThis._handleLocalPillarItems);
-      runnerJobsListJobsPromise.then(myThis._handleRunnerJobsListJobs);
-      runnerJobsActivePromise.then(myThis._handleRunnerJobsActive);
-    });
+    localPillarItemsPromise.then(myThis._handleLocalPillarItems);
+
+    runnerJobsListJobsPromise.then(data => {
+      myThis._handleRunnerJobsListJobs(data);
+      runnerJobsActivePromise.then(data => {
+        myThis._handleRunnerJobsActive(data);
+      });
+    }); 
   }
 
   _handleLocalPillarItems(data) {

--- a/saltgui/static/scripts/routes/PillarsMinion.js
+++ b/saltgui/static/scripts/routes/PillarsMinion.js
@@ -38,7 +38,11 @@ export class PillarsMinionRoute extends PageRoute {
       myThis._handleRunnerJobsListJobs(data);
       runnerJobsActivePromise.then(data => {
         myThis._handleRunnerJobsActive(data);
+      }, data => {
+        myThis._handleRunnerJobsActive(JSON.stringify(data));
       });
+    }, data => {
+      myThis._handleRunnerJobsListJobs(JSON.stringify(data));
     }); 
   }
 

--- a/saltgui/static/scripts/routes/Schedules.js
+++ b/saltgui/static/scripts/routes/Schedules.js
@@ -30,6 +30,8 @@ export class SchedulesRoute extends PageRoute {
           data.return[0][k] = JSON.stringify(data3);
         myThis._updateMinions(data);
       });
+    }, data => {
+      myThis._handleWheelKeyListAll(JSON.stringify(data));
     });
 
     runnerJobsListJobsPromise.then(data => {
@@ -64,9 +66,20 @@ export class SchedulesRoute extends PageRoute {
   }
 
   _handleWheelKeyListAll(data) {
-    const keys = data.return[0].data.return;
-
     const list = this.getPageElement().querySelector('#minions');
+
+    if(typeof data !== "object") {
+      const tr = document.createElement("tr");
+      const td = document.createElement("td");
+      td.innerText = "(error)";
+      td.colSpan = 99;
+      Utils.addToolTip(td, data);
+      tr.appendChild(td);
+      list.appendChild(tr);
+      return;
+    }
+
+    const keys = data.return[0].data.return;
 
     const hostnames = keys.minions.sort();
     for(const hostname of hostnames) {

--- a/saltgui/static/scripts/routes/Schedules.js
+++ b/saltgui/static/scripts/routes/Schedules.js
@@ -36,7 +36,11 @@ export class SchedulesRoute extends PageRoute {
       myThis._handleRunnerJobsListJobs(data);
       runnerJobsActivePromise.then(data => {
         myThis._handleRunnerJobsActive(data);
+      }, data => {
+        myThis._handleRunnerJobsActive(JSON.stringify(data));
       });
+    }, data => {
+      myThis._handleRunnerJobsListJobs(JSON.stringify(data));
     }); 
   }
 

--- a/saltgui/static/scripts/routes/Schedules.js
+++ b/saltgui/static/scripts/routes/Schedules.js
@@ -22,12 +22,12 @@ export class SchedulesRoute extends PageRoute {
 
     wheelKeyListAllPromise.then(data1 => {
       myThis._handleWheelKeyListAll(data1);
-      localScheduleListPromise.then(data2 => {
-        myThis._updateMinions(data2);
-      }, data3 => {
+      localScheduleListPromise.then(data => {
+        myThis._updateMinions(data);
+      }, data2 => {
         const data = {"return":[{}]};
         for(const k of data1.return[0].data.return.minions)
-          data.return[0][k] = JSON.stringify(data3);
+          data.return[0][k] = JSON.stringify(data2);
         myThis._updateMinions(data);
       });
     }, data => {

--- a/saltgui/static/scripts/routes/Schedules.js
+++ b/saltgui/static/scripts/routes/Schedules.js
@@ -7,8 +7,6 @@ export class SchedulesRoute extends PageRoute {
 
   constructor(router) {
     super("^[\/]schedules$", "Schedules", "#page_schedules", "#button_schedules", router);
-    this.keysLoaded = false;
-    this.jobsLoaded = false;
 
     this._handleWheelKeyListAll = this._handleWheelKeyListAll.bind(this);
     this._updateMinion = this._updateMinion.bind(this);
@@ -22,14 +20,19 @@ export class SchedulesRoute extends PageRoute {
     const runnerJobsListJobsPromise = this.router.api.getRunnerJobsListJobs();
     const runnerJobsActivePromise = this.router.api.getRunnerJobsActive();
 
-    return new Promise(function(resolve, reject) {
-      myThis.resolvePromise = resolve;
-      if(myThis.keysLoaded && myThis.jobsLoaded) resolve();
-      wheelKeyListAllPromise.then(myThis._handleWheelKeyListAll);
-      localScheduleListPromise.then(myThis._updateMinions, myThis._updateMinions);
-      runnerJobsListJobsPromise.then(myThis._handleRunnerJobsListJobs);
-      runnerJobsActivePromise.then(myThis._handleRunnerJobsActive);
+    wheelKeyListAllPromise.then(data => {
+      myThis._handleWheelKeyListAll(data);
+      localScheduleListPromise.then(data => {
+        myThis._updateMinions(data);
+      });
     });
+
+    runnerJobsListJobsPromise.then(data => {
+      myThis._handleRunnerJobsListJobs(data);
+      runnerJobsActivePromise.then(data => {
+        myThis._handleRunnerJobsActive(data);
+      });
+    }); 
   }
 
   // This one has some historic ballast:
@@ -68,9 +71,6 @@ export class SchedulesRoute extends PageRoute {
     }
 
     Utils.showTableSortable(this.getPageElement(), "minions");
-
-    this.keysLoaded = true;
-    if(this.keysLoaded && this.jobsLoaded) this.resolvePromise();
   }
 
   _updateOfflineMinion(container, hostname) {

--- a/saltgui/static/scripts/routes/Schedules.js
+++ b/saltgui/static/scripts/routes/Schedules.js
@@ -118,12 +118,12 @@ export class SchedulesRoute extends PageRoute {
         scheduleinfo += " (disabled)";
     } else {
       cnt = -1;
-      scheduleinfo = "(error)";
+      scheduleinfo = "";
     }
 
     const td = Route._createTd("scheduleinfo", scheduleinfo);
     if(typeof minion !== "object") {
-      Utils.addToolTip(td, minion);
+      Utils.addErrorToTableCell(td, minion);
     }
     td.setAttribute("sorttable_customkey", cnt);
     element.appendChild(td);

--- a/saltgui/static/scripts/routes/Schedules.js
+++ b/saltgui/static/scripts/routes/Schedules.js
@@ -68,16 +68,7 @@ export class SchedulesRoute extends PageRoute {
   _handleWheelKeyListAll(data) {
     const list = this.getPageElement().querySelector('#minions');
 
-    if(typeof data !== "object") {
-      const tr = document.createElement("tr");
-      const td = document.createElement("td");
-      td.innerText = "(error)";
-      td.colSpan = 99;
-      Utils.addToolTip(td, data);
-      tr.appendChild(td);
-      list.appendChild(tr);
-      return;
-    }
+    if(PageRoute.showErrorRowInstead(list, data)) return;
 
     const keys = data.return[0].data.return;
 

--- a/saltgui/static/scripts/routes/Schedules.js
+++ b/saltgui/static/scripts/routes/Schedules.js
@@ -17,14 +17,18 @@ export class SchedulesRoute extends PageRoute {
   onShow() {
     const myThis = this;
 
+    const wheelKeyListAllPromise = this.router.api.getWheelKeyListAll();
+    const localScheduleListPromise = this.router.api.getLocalScheduleList(null);
+    const runnerJobsListJobsPromise = this.router.api.getRunnerJobsListJobs();
+    const runnerJobsActivePromise = this.router.api.getRunnerJobsActive();
+
     return new Promise(function(resolve, reject) {
       myThis.resolvePromise = resolve;
       if(myThis.keysLoaded && myThis.jobsLoaded) resolve();
-      myThis.router.api.getLocalScheduleList(null)
-        .then(myThis._updateMinions, myThis._updateMinions);
-      myThis.router.api.getWheelKeyListAll().then(myThis._handleWheelKeyListAll);
-      myThis.router.api.getRunnerJobsListJobs().then(myThis._handleRunnerJobsListJobs);
-      myThis.router.api.getRunnerJobsActive().then(myThis._handleRunnerJobsActive);
+      wheelKeyListAllPromise.then(myThis._handleWheelKeyListAll);
+      localScheduleListPromise.then(myThis._updateMinions, myThis._updateMinions);
+      runnerJobsListJobsPromise.then(myThis._handleRunnerJobsListJobs);
+      runnerJobsActivePromise.then(myThis._handleRunnerJobsActive);
     });
   }
 

--- a/saltgui/static/scripts/routes/Schedules.js
+++ b/saltgui/static/scripts/routes/Schedules.js
@@ -101,8 +101,16 @@ export class SchedulesRoute extends PageRoute {
 
     minion = SchedulesRoute._fixMinion(minion);
 
-    let scheduleinfo;
+    const element = this._getElement(container, hostname);
+
+    element.appendChild(Route._createTd("hostname", hostname));
+
+    const statusDiv = Route._createTd("status", "accepted");
+    statusDiv.classList.add("accepted");
+    element.appendChild(statusDiv);
+
     let cnt;
+    let scheduleinfo;
     if(typeof minion === "object") {
       cnt = Object.keys(minion.schedules).length;
       scheduleinfo = cnt + " schedule" + (cnt === 1 ? "" : "s");
@@ -112,24 +120,6 @@ export class SchedulesRoute extends PageRoute {
       cnt = -1;
       scheduleinfo = "(error)";
     }
-
-    let element = document.getElementById(hostname);
-    if(element === null) {
-      // offline minion not found on screen...
-      // construct a basic element that can be updated here
-      element = document.createElement('tr');
-      element.id = hostname;
-      container.appendChild(element);
-    }
-    while(element.firstChild) {
-      element.removeChild(element.firstChild);
-    }
-
-    element.appendChild(Route._createTd("hostname", hostname));
-
-    const statusDiv = Route._createTd("status", "accepted");
-    statusDiv.classList.add("accepted");
-    element.appendChild(statusDiv);
 
     const td = Route._createTd("scheduleinfo", scheduleinfo);
     if(typeof minion !== "object") {

--- a/saltgui/static/scripts/routes/SchedulesMinion.js
+++ b/saltgui/static/scripts/routes/SchedulesMinion.js
@@ -29,12 +29,16 @@ export class SchedulesMinionRoute extends PageRoute {
     const title = document.getElementById("schedulesminion_title");
     title.innerText = "Schedules on " + minion;
 
+    const localScheduleListPromise = this.router.api.getLocalScheduleList(minion);
+    const runnerJobsListJobsPromise = this.router.api.getRunnerJobsListJobs();
+    const runnerJobsActivePromise = this.router.api.getRunnerJobsActive();
+
     return new Promise(function(resolve, reject) {
       myThis.resolvePromise = resolve;
       if(myThis.keysLoaded && myThis.jobsLoaded) resolve();
-      myThis.router.api.getLocalScheduleList(minion).then(myThis._handleLocalScheduleList);
-      myThis.router.api.getRunnerJobsListJobs().then(myThis._handleRunnerJobsListJobs);
-      myThis.router.api.getRunnerJobsActive().then(myThis._handleRunnerJobsActive);
+      localScheduleListPromise.then(myThis._handleLocalScheduleList);
+      runnerJobsListJobsPromise.then(myThis._handleRunnerJobsListJobs);
+      runnerJobsActivePromise.then(myThis._handleRunnerJobsActive);
     });
   }
 

--- a/saltgui/static/scripts/routes/SchedulesMinion.js
+++ b/saltgui/static/scripts/routes/SchedulesMinion.js
@@ -40,7 +40,11 @@ export class SchedulesMinionRoute extends PageRoute {
       myThis._handleRunnerJobsListJobs(data);
       runnerJobsActivePromise.then(data => {
         myThis._handleRunnerJobsActive(data);
+      }, data => {
+        myThis._handleRunnerJobsActive(JSON.stringify(data));
       });
+    }, data => {
+      myThis._handleRunnerJobsListJobs(JSON.stringify(data));
     }); 
   }
 

--- a/saltgui/static/scripts/routes/SchedulesMinion.js
+++ b/saltgui/static/scripts/routes/SchedulesMinion.js
@@ -68,16 +68,7 @@ export class SchedulesMinionRoute extends PageRoute {
       container.tBodies[0].deleteRow(0);
     }
 
-    if(typeof data !== "object") {
-      const tr = document.createElement('tr');
-      const td = document.createElement('td');
-      td.innerText = "(error)";
-      td.colSpan = 99;
-      Utils.addToolTip(td, data);
-      tr.appendChild(td);
-      container.tBodies[0].appendChild(tr);
-      return;
-    }
+    if(PageRoute.showErrorRowInstead(container.tBodies[0], data)) return;
 
     let schedules = data.return[0][minion];
     schedules = SchedulesRoute._fixMinion(schedules);

--- a/saltgui/static/scripts/routes/SchedulesMinion.js
+++ b/saltgui/static/scripts/routes/SchedulesMinion.js
@@ -10,9 +10,6 @@ export class SchedulesMinionRoute extends PageRoute {
   constructor(router) {
     super("^[\/]schedulesminion$", "Schedules", "#page_schedulesminion", "#button_schedules", router);
 
-    this.keysLoaded = false;
-    this.jobsLoaded = false;
-
     this._handleLocalScheduleList = this._handleLocalScheduleList.bind(this);
 
     this.page_element.querySelector("#button_close_schedulesminion").addEventListener("click", _ => {
@@ -33,13 +30,14 @@ export class SchedulesMinionRoute extends PageRoute {
     const runnerJobsListJobsPromise = this.router.api.getRunnerJobsListJobs();
     const runnerJobsActivePromise = this.router.api.getRunnerJobsActive();
 
-    return new Promise(function(resolve, reject) {
-      myThis.resolvePromise = resolve;
-      if(myThis.keysLoaded && myThis.jobsLoaded) resolve();
-      localScheduleListPromise.then(myThis._handleLocalScheduleList);
-      runnerJobsListJobsPromise.then(myThis._handleRunnerJobsListJobs);
-      runnerJobsActivePromise.then(myThis._handleRunnerJobsActive);
-    });
+    localScheduleListPromise.then(myThis._handleLocalScheduleList);
+
+    runnerJobsListJobsPromise.then(data => {
+      myThis._handleRunnerJobsListJobs(data);
+      runnerJobsActivePromise.then(data => {
+        myThis._handleRunnerJobsActive(data);
+      });
+    }); 
   }
 
   _handleLocalScheduleList(data) {

--- a/saltgui/static/scripts/routes/SchedulesMinion.js
+++ b/saltgui/static/scripts/routes/SchedulesMinion.js
@@ -30,7 +30,11 @@ export class SchedulesMinionRoute extends PageRoute {
     const runnerJobsListJobsPromise = this.router.api.getRunnerJobsListJobs();
     const runnerJobsActivePromise = this.router.api.getRunnerJobsActive();
 
-    localScheduleListPromise.then(myThis._handleLocalScheduleList);
+    localScheduleListPromise.then(data => {
+      myThis._handleLocalScheduleList(data);
+    }, data => {
+      myThis._handleLocalScheduleList(JSON.stringify(data));
+    });
 
     runnerJobsListJobsPromise.then(data => {
       myThis._handleRunnerJobsListJobs(data);
@@ -42,14 +46,6 @@ export class SchedulesMinionRoute extends PageRoute {
 
   _handleLocalScheduleList(data) {
     const minion = decodeURIComponent(Utils.getQueryParam("minion"));
-
-    let schedules = data.return[0][minion];
-    schedules = SchedulesRoute._fixMinion(schedules);
-
-    const title = document.getElementById("schedulesminion_title");
-    let txt = "Schedules on " + minion;
-    if(!schedules.enabled) txt += " (disabled)";
-    title.innerText = txt;
 
     const page = document.getElementById("schedulesminion_page");
 
@@ -68,8 +64,22 @@ export class SchedulesMinionRoute extends PageRoute {
       container.tBodies[0].deleteRow(0);
     }
 
+    if(typeof data !== "object") {
+      const tr = document.createElement('tr');
+      const td = document.createElement('td');
+      tr.appendChild(td);
+      td.innerText = data;
+      container.tBodies[0].appendChild(tr);
+      return;
+    }
 
-    if(!schedules) return;
+    let schedules = data.return[0][minion];
+    schedules = SchedulesRoute._fixMinion(schedules);
+
+    const title = document.getElementById("schedulesminion_title");
+    let txt = "Schedules on " + minion;
+    if(!schedules.enabled) txt += " (disabled)";
+    title.innerText = txt;
 
     const keys = Object.keys(schedules.schedules).sort();
     for(const k of keys) {

--- a/saltgui/static/scripts/routes/SchedulesMinion.js
+++ b/saltgui/static/scripts/routes/SchedulesMinion.js
@@ -71,8 +71,10 @@ export class SchedulesMinionRoute extends PageRoute {
     if(typeof data !== "object") {
       const tr = document.createElement('tr');
       const td = document.createElement('td');
+      td.innerText = "(error)";
+      td.colSpan = 99;
+      Utils.addToolTip(td, data);
       tr.appendChild(td);
-      td.innerText = data;
       container.tBodies[0].appendChild(tr);
       return;
     }

--- a/saltgui/static/scripts/routes/Templates.js
+++ b/saltgui/static/scripts/routes/Templates.js
@@ -7,7 +7,6 @@ export class TemplatesRoute extends PageRoute {
 
   constructor(router) {
     super("^[\/]templates$", "Templates", "#page_templates", "#button_templates", router);
-    this.jobsLoaded = false;
 
     this._handleWheelConfigValues = this._handleWheelConfigValues.bind(this);
     this._applyTemplate = this._applyTemplate.bind(this);
@@ -20,12 +19,13 @@ export class TemplatesRoute extends PageRoute {
     const runnerJobsListJobsPromise = this.router.api.getRunnerJobsListJobs();
     const runnerJobsActivePromise = this.router.api.getRunnerJobsActive();
 
-    return new Promise(function(resolve, reject) {
-      myThis.resolvePromise = resolve;
-      if(myThis.jobsLoaded) resolve();
-      wheelConfigValuesPromise.then(myThis._handleWheelConfigValues);
-      runnerJobsListJobsPromise.then(myThis._handleRunnerJobsListJobs);
-      runnerJobsActivePromise.then(myThis._handleRunnerJobsActive);
+    wheelConfigValuesPromise.then(myThis._handleWheelConfigValues);
+
+    runnerJobsListJobsPromise.then(data => {
+      myThis._handleRunnerJobsListJobs(data);
+      runnerJobsActivePromise.then(data => {
+        myThis._handleRunnerJobsActive(data);
+      });
     });
   }
 

--- a/saltgui/static/scripts/routes/Templates.js
+++ b/saltgui/static/scripts/routes/Templates.js
@@ -25,7 +25,11 @@ export class TemplatesRoute extends PageRoute {
       myThis._handleRunnerJobsListJobs(data);
       runnerJobsActivePromise.then(data => {
         myThis._handleRunnerJobsActive(data);
+      }, data => {
+        myThis._handleRunnerJobsActive(JSON.stringify(data));
       });
+    }, data => {
+      myThis._handleRunnerJobsListJobs(JSON.stringify(data));
     });
   }
 

--- a/saltgui/static/scripts/routes/Templates.js
+++ b/saltgui/static/scripts/routes/Templates.js
@@ -16,12 +16,16 @@ export class TemplatesRoute extends PageRoute {
   onShow() {
     const myThis = this;
 
+    const wheelConfigValuesPromise = this.router.api.getWheelConfigValues();
+    const runnerJobsListJobsPromise = this.router.api.getRunnerJobsListJobs();
+    const runnerJobsActivePromise = this.router.api.getRunnerJobsActive();
+
     return new Promise(function(resolve, reject) {
       myThis.resolvePromise = resolve;
       if(myThis.jobsLoaded) resolve();
-      myThis.router.api.getRunnerJobsListJobs().then(myThis._handleRunnerJobsListJobs);
-      myThis.router.api.getRunnerJobsActive().then(myThis._handleRunnerJobsActive);
-      myThis.router.api.getWheelConfigValues().then(myThis._handleWheelConfigValues);
+      wheelConfigValuesPromise.then(myThis._handleWheelConfigValues);
+      runnerJobsListJobsPromise.then(myThis._handleRunnerJobsListJobs);
+      runnerJobsActivePromise.then(myThis._handleRunnerJobsActive);
     });
   }
 

--- a/saltgui/static/scripts/routes/Templates.js
+++ b/saltgui/static/scripts/routes/Templates.js
@@ -19,7 +19,11 @@ export class TemplatesRoute extends PageRoute {
     const runnerJobsListJobsPromise = this.router.api.getRunnerJobsListJobs();
     const runnerJobsActivePromise = this.router.api.getRunnerJobsActive();
 
-    wheelConfigValuesPromise.then(myThis._handleWheelConfigValues);
+    wheelConfigValuesPromise.then(data => {
+      myThis._handleWheelConfigValues(data);
+    }, data => {
+      myThis._handleWheelConfigValues(JSON.stringify(data));
+    });
 
     runnerJobsListJobsPromise.then(data => {
       myThis._handleRunnerJobsListJobs(data);
@@ -35,7 +39,18 @@ export class TemplatesRoute extends PageRoute {
 
   _handleWheelConfigValues(data) {
     const container = this.getPageElement().querySelector(".templates");
-    
+
+    if(typeof data != "object") {
+      const tr = document.createElement("tr");
+      const td = document.createElement("td");
+      td.innerText = "(error)";
+      td.colSpan = 99;
+      Utils.addToolTip(td, data);
+      tr.appendChild(td);
+      container.appendChild(tr);
+      return;
+    }
+
     // should we update it or just use from cache (see commandbox) ?
     const templates = data.return[0].data.return.saltgui_templates;
     window.localStorage.setItem("templates", JSON.stringify(templates));

--- a/saltgui/static/scripts/routes/Templates.js
+++ b/saltgui/static/scripts/routes/Templates.js
@@ -40,16 +40,7 @@ export class TemplatesRoute extends PageRoute {
   _handleWheelConfigValues(data) {
     const container = this.getPageElement().querySelector(".templates");
 
-    if(typeof data != "object") {
-      const tr = document.createElement("tr");
-      const td = document.createElement("td");
-      td.innerText = "(error)";
-      td.colSpan = 99;
-      Utils.addToolTip(td, data);
-      tr.appendChild(td);
-      container.appendChild(tr);
-      return;
-    }
+    if(PageRoute.showErrorRowInstead(container, data)) return;
 
     // should we update it or just use from cache (see commandbox) ?
     const templates = data.return[0].data.return.saltgui_templates;


### PR DESCRIPTION
closes #195 

Problems:
* code involving promises looks bad
* code involving promises uses its own administration (e.g. `keysLoaded`)
* promises are used in multiple layers
* sequence of promises is not guaranteed

Work done:
* Once created, each promise is first created as a constant with a standardized name
* no extra promise layer is used
* sequence of promises is now managed
* extra administration is removed
* added error handling for technical errors from normal salt commands
* added error handling for technical errors from RUNNER salt commands
* added error handling for technical errors from WHEEL salt commands

TODO:
* only allow tooltips from SPANs, not from TDs