### PR TITLE
add table search function

### DIFF
--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -41,6 +41,7 @@
       <div class='fab' id='button_manualrun'>&gt;_</div>
       <div class="minimenu">
         <div class="dropdown">
+          <!-- 2261 = MATHEMATICAL OPERATOR IDENTICAL TO (aka "hamburger") -->
           <div class="menu_item">&#x2261;</div>
           <div class="dropdown-content">
             <div class="run-command-button menu_item" id="button_minions2">minions</div>

--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -310,6 +310,8 @@
 
     <!-- see https://www.kryogenix.org/code/browser/sorttable/ -->
     <script src="static/sorttable/sorttable.js"></script>
+    <!-- see https://www.the-art-of-web.com/javascript/search-highlight/ -->
+    <script src="static/hilitor/hilitor.js"></script>
     <script src="static/scripts/index.js" type='module'></script>
   </body>
 

--- a/saltgui/static/hilitor/hilitor.js
+++ b/saltgui/static/hilitor/hilitor.js
@@ -1,0 +1,132 @@
+// Original JavaScript code by Chirp Internet: www.chirp.com.au
+// Please acknowledge use of this code by including this header.
+
+function Hilitor(id, tag)
+{
+
+  // private variables
+  var targetNode = document.getElementById(id) || document.body;
+  var hiliteTag = tag || "MARK";
+  var skipTags = new RegExp("^(?:" + hiliteTag + "|SCRIPT|FORM|SPAN)$");
+  var colors = ["#ff6", "#a0ffff", "#9f9", "#f99", "#f6f"];
+  var wordColor = [];
+  var colorIdx = 0;
+  var matchRegExp = "";
+  var openLeft = false;
+  var openRight = false;
+
+  // characters to strip from start and end of the input string
+  var endRegExp = new RegExp('^[^\\w]+|[^\\w]+$', "g");
+
+  // characters used to break up the input string into words
+  var breakRegExp = new RegExp('[^\\w\'-]+', "g");
+
+  this.setEndRegExp = function(regex) {
+    endRegExp = regex;
+    return endRegExp;
+  };
+
+  this.setBreakRegExp = function(regex) {
+    breakRegExp = regex;
+    return breakRegExp;
+  };
+
+  this.setMatchType = function(type)
+  {
+    switch(type)
+    {
+      case "left":
+        this.openLeft = false;
+        this.openRight = true;
+        break;
+
+      case "right":
+        this.openLeft = true;
+        this.openRight = false;
+        break;
+
+      case "open":
+        this.openLeft = this.openRight = true;
+        break;
+
+      default:
+        this.openLeft = this.openRight = false;
+
+    }
+  };
+
+  this.setRegex = function(input)
+  {
+    input = input.replace(endRegExp, "");
+    input = input.replace(breakRegExp, "|");
+    input = input.replace(/^\||\|$/g, "");
+    if(input) {
+      var re = "(" + input + ")";
+      if(!this.openLeft) re = "\\b" + re;
+      if(!this.openRight) re = re + "\\b";
+      matchRegExp = new RegExp(re, "i");
+      return matchRegExp;
+    }
+    return false;
+  };
+
+  this.getRegex = function()
+  {
+    var retval = matchRegExp.toString();
+    retval = retval.replace(/(^\/(\\b)?|\(|\)|(\\b)?\/i$)/g, "");
+    retval = retval.replace(/\|/g, " ");
+    return retval;
+  };
+
+  // recursively apply word highlighting
+  this.hiliteWords = function(node)
+  {
+    if(node === undefined || !node) return;
+    if(!matchRegExp) return;
+    if(skipTags.test(node.nodeName)) return;
+
+    if(node.hasChildNodes()) {
+      for(var i=0; i < node.childNodes.length; i++)
+        this.hiliteWords(node.childNodes[i]);
+    }
+    if(node.nodeType == 3) { // NODE_TEXT
+      if((nv = node.nodeValue) && (regs = matchRegExp.exec(nv))) {
+        if(!wordColor[regs[0].toLowerCase()]) {
+          wordColor[regs[0].toLowerCase()] = colors[colorIdx++ % colors.length];
+        }
+
+        var match = document.createElement(hiliteTag);
+        match.appendChild(document.createTextNode(regs[0]));
+        match.style.backgroundColor = wordColor[regs[0].toLowerCase()];
+        match.style.color = "#000";
+
+        var after = node.splitText(regs.index);
+        after.nodeValue = after.nodeValue.substring(regs[0].length);
+        node.parentNode.insertBefore(match, after);
+      }
+    };
+  };
+
+  // remove highlighting
+  this.remove = function()
+  {
+    var arr = document.getElementsByTagName(hiliteTag);
+    while(arr.length && (el = arr[0])) {
+      var parent = el.parentNode;
+      parent.replaceChild(el.firstChild, el);
+      parent.normalize();
+    }
+  };
+
+  // start highlighting at target node
+  this.apply = function(input)
+  {
+    this.remove();
+    if(input === undefined || !input) return;
+    if(this.setRegex(input)) {
+      this.hiliteWords(targetNode);
+    }
+    return matchRegExp;
+  };
+
+}

--- a/saltgui/static/hilitor/hilitor.js
+++ b/saltgui/static/hilitor/hilitor.js
@@ -1,11 +1,13 @@
 // Original JavaScript code by Chirp Internet: www.chirp.com.au
 // Please acknowledge use of this code by including this header.
 
-function Hilitor(id, tag)
+//function Hilitor(id, tag)
+function Hilitor(start, id, tag)
 {
 
   // private variables
-  var targetNode = document.getElementById(id) || document.body;
+  //var targetNode = document.getElementById(id) || document.body;
+  const targetNode = start.querySelector(id);
   var hiliteTag = tag || "MARK";
   var skipTags = new RegExp("^(?:" + hiliteTag + "|SCRIPT|FORM|SPAN)$");
   var colors = ["#ff6", "#a0ffff", "#9f9", "#f99", "#f6f"];

--- a/saltgui/static/hilitor/hilitor.js
+++ b/saltgui/static/hilitor/hilitor.js
@@ -87,6 +87,9 @@ function Hilitor(start, id, tag)
     if(!matchRegExp) return;
     if(skipTags.test(node.nodeName)) return;
 
+    // dont highlight inside dropdown menus
+    if(node.classList && node.classList.contains("run-command-button")) return;
+
     if(node.hasChildNodes()) {
       for(var i=0; i < node.childNodes.length; i++)
         this.hiliteWords(node.childNodes[i]);
@@ -112,7 +115,8 @@ function Hilitor(start, id, tag)
   // remove highlighting
   this.remove = function()
   {
-    var arr = document.getElementsByTagName(hiliteTag);
+    //var arr = document.getElementsByTagName(hiliteTag);
+    var arr = targetNode.getElementsByTagName(hiliteTag);
     while(arr.length && (el = arr[0])) {
       var parent = el.parentNode;
       parent.replaceChild(el.firstChild, el);

--- a/saltgui/static/scripts/Utils.js
+++ b/saltgui/static/scripts/Utils.js
@@ -63,9 +63,13 @@ export class Utils {
     const input = document.createElement("input");
     input.style.width = "100%";
     // D83D+DD0D = 1F50D = LEFT-POINTING MAGNIFYING GLASS
-    input.placeholder = "\uD83D\uDD0D";
+    input.placeholder = "\uD83D\uDD0D ESC to dismiss";
     input.onkeyup = ev => {
-      const txt = input.value.toUpperCase();
+      let txt = input.value.toUpperCase();
+      if(ev.keyCode === 27) {
+        // user presses ESCAPE
+        txt = "";
+      }
       for(const row of table.tBodies[0].rows) {
         let show = false;
         for(const cell of row.cells) {
@@ -79,6 +83,12 @@ export class Utils {
           row.classList.add("nofiltermatch");
       }
       const hilitor = new Hilitor(start, "." + tableClass + " tbody");
+      if(ev.keyCode === 27) {
+        // user presses ESCAPE
+        hilitor.remove();
+        input.style.display = "none";
+        return;
+      }
       hilitor.setMatchType("open");
       hilitor.setEndRegExp(/^$/);
       hilitor.setBreakRegExp(/^$/);

--- a/saltgui/static/scripts/Utils.js
+++ b/saltgui/static/scripts/Utils.js
@@ -78,6 +78,19 @@ export class Utils {
         else
           row.classList.add("nofiltermatch");
       }
+      const hilitor = new Hilitor(start, "." + tableClass + " tbody");
+      hilitor.setMatchType("open");
+      hilitor.setEndRegExp(/^$/);
+      hilitor.setBreakRegExp(/^$/);
+      // turn the text into a regexp
+      let pattern = "";
+      for(const chr of txt) {
+        if((chr >= 'A' && chr <= 'Z') || (chr >= '0' && chr <= '9'))
+          pattern += chr;
+        else
+          pattern += "\\" + chr;
+      }
+      hilitor.apply(pattern);
     };
     table.parentNode.insertBefore(input, table);
   }

--- a/saltgui/static/scripts/Utils.js
+++ b/saltgui/static/scripts/Utils.js
@@ -69,7 +69,9 @@ export class Utils {
       for(const row of table.tBodies[0].rows) {
         let show = false;
         for(const cell of row.cells) {
-          if(cell.innerText.toUpperCase().includes(txt)) show = true;
+          // do not use "innerText"
+          // that one does not handle hidden text
+          if(cell.textContent.toUpperCase().includes(txt)) show = true;
         }
         if(show)
           row.classList.remove("nofiltermatch");

--- a/saltgui/static/scripts/Utils.js
+++ b/saltgui/static/scripts/Utils.js
@@ -57,4 +57,26 @@ export class Utils {
     Utils.addToolTip(span, errorMessage);
     td.appendChild(span);
   }
+
+  static showTableSearchable(start, tableClass) {
+    const table = start.querySelector("table." + tableClass);
+    const input = document.createElement("input");
+    input.style.width = "100%";
+    // D83D+DD0D = 1F50D = LEFT-POINTING MAGNIFYING GLASS
+    input.placeholder = "\uD83D\uDD0D";
+    input.onkeyup = ev => {
+      const txt = input.value.toUpperCase();
+      for(const row of table.tBodies[0].rows) {
+        let show = false;
+        for(const cell of row.cells) {
+          if(cell.innerText.toUpperCase().includes(txt)) show = true;
+        }
+        if(show)
+          row.classList.remove("nofiltermatch");
+        else
+          row.classList.add("nofiltermatch");
+      }
+    };
+    table.parentNode.insertBefore(input, table);
+  }
 }

--- a/saltgui/static/scripts/routes/Grains.js
+++ b/saltgui/static/scripts/routes/Grains.js
@@ -100,6 +100,7 @@ export class GrainsRoute extends PageRoute {
     }
 
     Utils.showTableSortable(this.getPageElement(), "minions");
+    Utils.showTableSearchable(this.getPageElement(), "minions");
   }
 
   _updateOfflineMinion(container, hostname) {

--- a/saltgui/static/scripts/routes/Grains.js
+++ b/saltgui/static/scripts/routes/Grains.js
@@ -100,7 +100,7 @@ export class GrainsRoute extends PageRoute {
     }
 
     Utils.showTableSortable(this.getPageElement(), "minions");
-    Utils.showTableSearchable(this.getPageElement(), "minions");
+    Utils.makeTableSearchable(this.getPageElement(), "minions");
   }
 
   _updateOfflineMinion(container, hostname) {

--- a/saltgui/static/scripts/routes/GrainsMinion.js
+++ b/saltgui/static/scripts/routes/GrainsMinion.js
@@ -108,5 +108,6 @@ export class GrainsMinionRoute extends PageRoute {
     }
 
     Utils.showTableSortable(this.getPageElement(), "grains");
+    Utils.showTableSearchable(this.getPageElement(), "grains");
   }
 }

--- a/saltgui/static/scripts/routes/GrainsMinion.js
+++ b/saltgui/static/scripts/routes/GrainsMinion.js
@@ -108,6 +108,6 @@ export class GrainsMinionRoute extends PageRoute {
     }
 
     Utils.showTableSortable(this.getPageElement(), "grains");
-    Utils.showTableSearchable(this.getPageElement(), "grains");
+    Utils.makeTableSearchable(this.getPageElement(), "grains");
   }
 }

--- a/saltgui/static/scripts/routes/Keys.js
+++ b/saltgui/static/scripts/routes/Keys.js
@@ -125,6 +125,7 @@ export class KeysRoute extends PageRoute {
     }
 
     Utils.showTableSortable(this.getPageElement(), "minions");
+    Utils.showTableSearchable(this.getPageElement(), "minions");
   }
 
   _updateOfflineMinion(container, hostname) {

--- a/saltgui/static/scripts/routes/Keys.js
+++ b/saltgui/static/scripts/routes/Keys.js
@@ -125,7 +125,7 @@ export class KeysRoute extends PageRoute {
     }
 
     Utils.showTableSortable(this.getPageElement(), "minions");
-    Utils.showTableSearchable(this.getPageElement(), "minions");
+    Utils.makeTableSearchable(this.getPageElement(), "minions");
   }
 
   _updateOfflineMinion(container, hostname) {

--- a/saltgui/static/scripts/routes/Minions.js
+++ b/saltgui/static/scripts/routes/Minions.js
@@ -97,6 +97,7 @@ export class MinionsRoute extends PageRoute {
     }
 
     Utils.showTableSortable(this.getPageElement(), "minions");
+    Utils.showTableSearchable(this.getPageElement(), "minions");
   }
 
   _updateOfflineMinion(container, hostname) {

--- a/saltgui/static/scripts/routes/Minions.js
+++ b/saltgui/static/scripts/routes/Minions.js
@@ -97,7 +97,7 @@ export class MinionsRoute extends PageRoute {
     }
 
     Utils.showTableSortable(this.getPageElement(), "minions");
-    Utils.showTableSearchable(this.getPageElement(), "minions");
+    Utils.makeTableSearchable(this.getPageElement(), "minions");
   }
 
   _updateOfflineMinion(container, hostname) {

--- a/saltgui/static/scripts/routes/Page.js
+++ b/saltgui/static/scripts/routes/Page.js
@@ -361,7 +361,7 @@ export class PageRoute extends Route {
     if(hasHeader) {
       Utils.showTableSortable(this.getPageElement(), "jobs", true);
     }
-    Utils.showTableSearchable(this.getPageElement(), "jobs");
+    Utils.makeTableSearchable(this.getPageElement(), "jobs");
   }
 
   _handleRunnerJobsActive(data) {

--- a/saltgui/static/scripts/routes/Page.js
+++ b/saltgui/static/scripts/routes/Page.js
@@ -361,6 +361,7 @@ export class PageRoute extends Route {
     if(hasHeader) {
       Utils.showTableSortable(this.getPageElement(), "jobs", true);
     }
+    Utils.showTableSearchable(this.getPageElement(), "jobs");
   }
 
   _handleRunnerJobsActive(data) {

--- a/saltgui/static/scripts/routes/Pillars.js
+++ b/saltgui/static/scripts/routes/Pillars.js
@@ -66,7 +66,7 @@ export class PillarsRoute extends PageRoute {
     }
 
     Utils.showTableSortable(this.getPageElement(), "minions");
-    Utils.showTableSearchable(this.getPageElement(), "minions");
+    Utils.makeTableSearchable(this.getPageElement(), "minions");
   }
 
   _updateOfflineMinion(container, hostname) {

--- a/saltgui/static/scripts/routes/Pillars.js
+++ b/saltgui/static/scripts/routes/Pillars.js
@@ -66,6 +66,7 @@ export class PillarsRoute extends PageRoute {
     }
 
     Utils.showTableSortable(this.getPageElement(), "minions");
+    Utils.showTableSearchable(this.getPageElement(), "minions");
   }
 
   _updateOfflineMinion(container, hostname) {

--- a/saltgui/static/scripts/routes/PillarsMinion.js
+++ b/saltgui/static/scripts/routes/PillarsMinion.js
@@ -135,7 +135,7 @@ export class PillarsMinionRoute extends PageRoute {
     }
 
     Utils.showTableSortable(this.getPageElement(), "pillars");
-    Utils.showTableSearchable(this.getPageElement(), "pillars");
+    Utils.makeTableSearchable(this.getPageElement(), "pillars");
 
     if(!keys.length) {
       const noPillarsMsg = Route._createTd("msg", "No pillars found");

--- a/saltgui/static/scripts/routes/PillarsMinion.js
+++ b/saltgui/static/scripts/routes/PillarsMinion.js
@@ -135,6 +135,7 @@ export class PillarsMinionRoute extends PageRoute {
     }
 
     Utils.showTableSortable(this.getPageElement(), "pillars");
+    Utils.showTableSearchable(this.getPageElement(), "pillars");
 
     if(!keys.length) {
       const noPillarsMsg = Route._createTd("msg", "No pillars found");

--- a/saltgui/static/scripts/routes/Schedules.js
+++ b/saltgui/static/scripts/routes/Schedules.js
@@ -85,6 +85,7 @@ export class SchedulesRoute extends PageRoute {
     }
 
     Utils.showTableSortable(this.getPageElement(), "minions");
+    Utils.showTableSearchable(this.getPageElement(), "minions");
   }
 
   _updateOfflineMinion(container, hostname) {

--- a/saltgui/static/scripts/routes/Schedules.js
+++ b/saltgui/static/scripts/routes/Schedules.js
@@ -85,7 +85,7 @@ export class SchedulesRoute extends PageRoute {
     }
 
     Utils.showTableSortable(this.getPageElement(), "minions");
-    Utils.showTableSearchable(this.getPageElement(), "minions");
+    Utils.makeTableSearchable(this.getPageElement(), "minions");
   }
 
   _updateOfflineMinion(container, hostname) {

--- a/saltgui/static/scripts/routes/SchedulesMinion.js
+++ b/saltgui/static/scripts/routes/SchedulesMinion.js
@@ -136,7 +136,7 @@ export class SchedulesMinionRoute extends PageRoute {
     }
 
     Utils.showTableSortable(this.getPageElement(), "schedules");
-    Utils.showTableSearchable(this.getPageElement(), "schedules");
+    Utils.makeTableSearchable(this.getPageElement(), "schedules");
 
     if(!keys.length) {
       const noSchedulesMsg = Route._createDiv("msg", "No schedules found");

--- a/saltgui/static/scripts/routes/SchedulesMinion.js
+++ b/saltgui/static/scripts/routes/SchedulesMinion.js
@@ -136,6 +136,7 @@ export class SchedulesMinionRoute extends PageRoute {
     }
 
     Utils.showTableSortable(this.getPageElement(), "schedules");
+    Utils.showTableSearchable(this.getPageElement(), "schedules");
 
     if(!keys.length) {
       const noSchedulesMsg = Route._createDiv("msg", "No schedules found");

--- a/saltgui/static/scripts/routes/Templates.js
+++ b/saltgui/static/scripts/routes/Templates.js
@@ -52,7 +52,7 @@ export class TemplatesRoute extends PageRoute {
     }
 
     Utils.showTableSortable(this.getPageElement(), "templates");
-    Utils.showTableSearchable(this.getPageElement(), "templates");
+    Utils.makeTableSearchable(this.getPageElement(), "templates");
   }
 
   _addTemplate(container, name, template) {

--- a/saltgui/static/scripts/routes/Templates.js
+++ b/saltgui/static/scripts/routes/Templates.js
@@ -52,6 +52,7 @@ export class TemplatesRoute extends PageRoute {
     }
 
     Utils.showTableSortable(this.getPageElement(), "templates");
+    Utils.showTableSearchable(this.getPageElement(), "templates");
   }
 
   _addTemplate(container, name, template) {

--- a/saltgui/static/stylesheets/main.css
+++ b/saltgui/static/stylesheets/main.css
@@ -81,6 +81,19 @@ h1 {
   opacity: 0.8;
 }
 
+.search {
+  font-weight: bold;
+  font-size: 18px;
+  color: #888;
+  cursor: pointer;
+  margin-top: 4px;
+  margin-left: 8px;
+}
+
+.search:hover {
+  opacity: 0.8;
+}
+
 .nearlyvisiblebutton {
   display: block;
   float: right;

--- a/saltgui/static/stylesheets/page.css
+++ b/saltgui/static/stylesheets/page.css
@@ -208,6 +208,10 @@ table tr td:last-of-type {
   cursor: pointer;
 }
 
+.nofiltermatch {
+  display: none;
+}
+
 @media (max-width: 800px) {
   .minions {
     min-width: 0;


### PR DESCRIPTION
Depending on the environment, the pages may get a bit long.
A search box is added. The table will then only show the rows that somehow contain this text.

e.g.:
![afbeelding](https://user-images.githubusercontent.com/3663742/57114665-8fdacf00-6d4a-11e9-92f4-9214c0e11e81.png)

Done:
* add facility to hide/show the search boxes. initially not shown.
* fix search facility on pillar-details screen, which has some problems
* added facility to highlight the found text
* are the job list first (A) "length restricted THEN searchable" or should they be (B) "searchable and then length restricted". Currently (A) applies. (B) may be more useful. ==> the current situation (A) remains. We probably will do (B) later.