### PR TITLE
show beacon values

### DIFF
--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -280,7 +280,7 @@
             <h1 id="beaconsminion_title">Beacons on ...</h1>
             <table id="beaconsminion_list" class='beacons highlightrows sortable'>
               <thead>
-                <tr><th>Name</th><th class="sorttable_nosort"></th><th>Value</th></tr>
+                <tr><th>Name</th><th class="sorttable_nosort"></th><th>Config</th><th>Value</th></tr>
               </thead>
               <tbody>
               </tbody>

--- a/saltgui/static/scripts/routes/BeaconsMinion.js
+++ b/saltgui/static/scripts/routes/BeaconsMinion.js
@@ -106,11 +106,15 @@ export class BeaconsMinionRoute extends PageRoute {
       this._addMenuItemBeaconsDelete(menu, minion, k);
 
       // menu comes before this data on purpose
-      const beacon_value = Output.formatObject(beacon);
-      const value = Route._createTd("beacon_value", beacon_value);
+      const beacon_config = Output.formatObject(beacon);
+      const value = Route._createTd("beacon_config", beacon_config);
       if(beacons.enabled === false) value.classList.add("disabled_beacon");
       if(beacon.enabled === false) value.classList.add("disabled_beacon");
       tr.appendChild(value);
+
+      const beacon_value = Route._createTd("beacon_value", "(waiting)");
+      beacon_value.classList.add("waiting");
+      tr.appendChild(beacon_value);
 
       container.tBodies[0].appendChild(tr);
 
@@ -178,5 +182,30 @@ export class BeaconsMinionRoute extends PageRoute {
     menu.addMenuItem("Delete&nbsp;beacon...", function(evt) {
       this._runCommand(evt, minion, "beacons.delete " + key);
     }.bind(this));
+  }
+
+  static handleEvent(tag, data) {
+    const minion = decodeURIComponent(Utils.getQueryParam("minion"));
+    const prefix = "salt/beacon/" + minion + "/";
+    if(!tag.startsWith(prefix)) return;
+    const table = document.getElementById("beaconsminion_list");
+    let name = tag.substring(prefix.length);
+    if(name.endsWith("/")) name = name.substring(0, name.length-1);
+    for(const row of table.tBodies[0].rows) {
+      if(row.getElementsByTagName("td")[0].innerText !== name) continue;
+      let txt = "";
+      if(data["_stamp"]) {
+        txt += Output.dateTimeStr(data["_stamp"]) + "\n";
+        delete data["_stamp"];
+      }
+      if(data["id"] === minion) {
+        delete data["id"];
+      }
+      txt += Output.formatObject(data);
+      const td = row.getElementsByTagName("td")[3];
+      td.classList.remove("waiting");
+      td.innerText = txt;
+      break;
+    }
   }
 }

--- a/saltgui/static/stylesheets/beacons.css
+++ b/saltgui/static/stylesheets/beacons.css
@@ -1,3 +1,7 @@
+td.beacon_config {
+  white-space: pre;
+}
+
 td.beacon_value {
   white-space: pre-wrap;
 }
@@ -10,6 +14,7 @@ td.beacon_value {
   padding: 0;
 }
 
-td.disabled_beacon {
+td.disabled_beacon,
+td.waiting {
   color: gray;
 }


### PR DESCRIPTION
closes #225 
The current system shows the definitions of the beacons on each minion.
But the beacon values are available on the event bus.
The proposal is to listen for the specific event messages,
When a match is found for a minion+beacon, display the value on screen.
Any previous value is overwritten.
User must have patience until the first beacon is seen.