### PR TITLE
asynchronous updates for KEYS

### DIFF
--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -127,6 +127,9 @@
         <div class='dashboard'>
           <div class='panel minion-list'>
             <h1>Keys</h1>
+            <!-- 2753 = BLACK QUESTION MARK ORNAMENT -->
+            <!-- FE0E = VARIATION SELECTOR-15 (render as text) -->
+            <span id="help" style="float: right; cursor: help">&#x2753;&#xFE0E;</span>
             <input style="display: none" class="filtertext" list="listkeys" placeholder="&#x1F50D;">
             <table id="minions" class='minions sortable'>
               <thead>

--- a/saltgui/static/scripts/CommandBox.js
+++ b/saltgui/static/scripts/CommandBox.js
@@ -231,9 +231,6 @@ export class CommandBox {
       "schedule.enable_job",
       "schedule.modify",
       "schedule.run_job",
-      "wheel.key.accept",
-      "wheel.key.delete",
-      "wheel.key.reject",
     ];
     if(screenModifyingCommands.includes(command) && output !== "Waiting for command...") {
       location.reload();

--- a/saltgui/static/scripts/Router.js
+++ b/saltgui/static/scripts/Router.js
@@ -18,14 +18,15 @@ import {TemplatesRoute} from './routes/Templates.js';
 export class Router {
 
   constructor() {
-    this.api = new API();
+    this.api = new API(this);
     this.commandbox = new CommandBox(this.api);
     this.currentRoute = undefined;
     this.routes = [];
 
     this.registerRoute(new LoginRoute(this));
     this.registerRoute(new MinionsRoute(this));
-    this.registerRoute(new KeysRoute(this));
+    this.keysRoute = new KeysRoute(this);
+    this.registerRoute(this.keysRoute);
     this.registerRoute(new GrainsRoute(this));
     this.registerRoute(new GrainsMinionRoute(this));
     this.registerRoute(new SchedulesRoute(this));
@@ -33,7 +34,8 @@ export class Router {
     this.registerRoute(new PillarsRoute(this));
     this.registerRoute(new PillarsMinionRoute(this));
     this.registerRoute(new BeaconsRoute(this));
-    this.registerRoute(new BeaconsMinionRoute(this));
+    this.beaconsMinionRoute = new BeaconsMinionRoute(this);
+    this.registerRoute(this.beaconsMinionRoute);
     this.registerRoute(new JobRoute(this));
     this.registerRoute(new JobsRoute(this));
     this.registerRoute(new TemplatesRoute(this));

--- a/saltgui/static/scripts/Utils.js
+++ b/saltgui/static/scripts/Utils.js
@@ -88,6 +88,12 @@ export class Utils {
     table.parentElement.insertBefore(button_search, table);
   }
 
+  static addTableHelp(startElement, txt) {
+    const button_help = startElement.querySelector("#help");
+    button_help.classList.add("search");
+    Utils.addToolTip(button_help, txt);
+  }
+
   static hideShowTableSearchBar(startElement) {
     // remove all highlights
     const hilitor = new Hilitor(startElement, "table tbody");

--- a/saltgui/static/scripts/Utils.js
+++ b/saltgui/static/scripts/Utils.js
@@ -51,6 +51,12 @@ export class Utils {
     }
   }
 
+  static tableReSort(startElement) {
+    const th = startElement.querySelector("table th");
+    sorttable.innerSortFunction.apply(th, []);
+    sorttable.innerSortFunction.apply(th, []);
+  }
+
   static addErrorToTableCell(td, errorMessage) {
     const span = document.createElement("span");
     span.innerText = "(error)";

--- a/saltgui/static/scripts/routes/BeaconsMinion.js
+++ b/saltgui/static/scripts/routes/BeaconsMinion.js
@@ -184,7 +184,7 @@ export class BeaconsMinionRoute extends PageRoute {
     }.bind(this));
   }
 
-  static handleEvent(tag, data) {
+  handleSaltBeaconEvent(tag, data) {
     const minion = decodeURIComponent(Utils.getQueryParam("minion"));
     const prefix = "salt/beacon/" + minion + "/";
     if(!tag.startsWith(prefix)) return;

--- a/saltgui/static/scripts/routes/Keys.js
+++ b/saltgui/static/scripts/routes/Keys.js
@@ -105,6 +105,7 @@ export class KeysRoute extends PageRoute {
 
     this.updateTableSummary(list);
 
+    Utils.addTableHelp(this.getPageElement(), "The content of this page is\nautomatically refreshed.");
     Utils.showTableSortable(this.getPageElement());
     Utils.makeTableSearchable(this.getPageElement());
   }

--- a/saltgui/static/scripts/routes/Keys.js
+++ b/saltgui/static/scripts/routes/Keys.js
@@ -57,9 +57,9 @@ export class KeysRoute extends PageRoute {
       for(const hostname of Object.keys(hosts)) {
         const item = this.page_element.querySelector("#" + hostname + " .os");
         if(item) {
-          // remove td.os for accepted minions and add td.fingerprint
-          item.parentElement.insertBefore(Route._createTd("fingerprint", ""), item);
-          item.parentElement.removeChild(item);
+          // remove td.os for known minions and add td.fingerprint
+          item.classList.remove("os");
+          item.classList.add("fingerprint");
         }
 
         // update td.fingerprint with fingerprint value
@@ -90,13 +90,7 @@ export class KeysRoute extends PageRoute {
 
     const hostnames_accepted = keys.minions.sort();
     for(const hostname of hostnames_accepted) {
-      this._addMinion(list, hostname, 1);
-
-      // preliminary dropdown menu
-      const element = document.getElementById(hostname);
-      const menu = new DropDownMenu(element);
-      this._addMenuItemRejectKey(menu, hostname, " include_accepted=true");
-      this._addMenuItemDeleteKey(menu, hostname, "");
+      this._addAcceptedMinion(list, hostname);
     }
 
     const hostnames_denied = keys.minions_denied.sort();
@@ -109,32 +103,47 @@ export class KeysRoute extends PageRoute {
       this._addRejectedMinion(list, hostname);
     }
 
-    let summary = "";
-    summary += ", " + Utils.txtZeroOneMany(hostnames_pre.length,
-      "no unaccepted keys", "{0} unaccepted key", "{0} unaccepted keys");
-    summary += ", " + Utils.txtZeroOneMany(hostnames_accepted.length,
-      "no accepted keys", "{0} accepted key", "{0} accepted keys");
-    summary += ", " + Utils.txtZeroOneMany(hostnames_denied.length,
-      "no denied keys", "{0} denied key", "{0} denied keys");
-    summary += ", " + Utils.txtZeroOneMany(hostnames_rejected.length,
-      "no rejected keys", "{0} rejected key", "{0} rejected keys");
-    const msg = this.getPageElement().querySelector(".minion-list .msg");
-    // remove the first comma and capitalize the first word
-    msg.innerText = summary.replace(/^, no/, "No");
+    this.updateTableSummary(list);
 
     Utils.showTableSortable(this.getPageElement());
     Utils.makeTableSearchable(this.getPageElement());
   }
 
-  _updateOfflineMinion(container, hostname) {
-    super._updateOfflineMinion(container, hostname);
+  updateTableSummary(list) {
+    const cnt = { };
+    cnt["unaccepted"] = 0;
+    cnt["accepted"] = 0;
+    cnt["denied"] = 0;
+    cnt["rejected"] = 0;
+    const tbody = list.querySelector("table tbody");
+    for(const tr of tbody.children) {
+      const statusText = tr.querySelector("td.status").innerText;  
+      if(cnt[statusText] === undefined) cnt[statusText] = 0;
+      cnt[statusText]++;
+    }
 
+    let summary = "";
+    for(const key of Object.keys(cnt).sort()) {
+      summary += ", " + Utils.txtZeroOneMany(cnt[key],
+        "no " + key + " keys",
+        "{0} " + key + " key",
+        "{0} " + key + " keys");
+    }
+
+    // remove the first comma
+    summary = summary.replace(/^, /, "");
+    // capitalize the first word (can only be "no")
+    summary = summary.replace(/^no/, "No");
+
+    const msg = this.getPageElement().querySelector(".minion-list .msg");
+    msg.innerText = summary;
+  }
+
+  _addAcceptedMinion(container, hostname) {
+    this._addMinion(container, hostname, 1);
+
+    // preliminary dropdown menu
     const element = container.querySelector("#" + hostname);
-
-    // force same columns on all rows
-    element.appendChild(Route._createTd("fingerprint", ""));
-
-    // final dropdownmenu
     const menu = new DropDownMenu(element);
     this._addMenuItemRejectKey(menu, hostname, " include_accepted=true");
     this._addMenuItemDeleteKey(menu, hostname, "");
@@ -150,7 +159,8 @@ export class KeysRoute extends PageRoute {
     element.appendChild(rejected);
 
     // force same columns on all rows
-    element.appendChild(Route._createTd("fingerprint", ""));
+    // do not use class "fingerprint" yet
+    element.appendChild(Route._createTd("os", "loading..."));
 
     // final dropdownmenu
     const menu = new DropDownMenu(element);
@@ -170,7 +180,8 @@ export class KeysRoute extends PageRoute {
     element.appendChild(denied);
 
     // force same columns on all rows
-    element.appendChild(Route._createTd("fingerprint", ""));
+    // do not use class "fingerprint" yet
+    element.appendChild(Route._createTd("os", "loading..."));
 
     // final dropdownmenu
     const menu = new DropDownMenu(element);
@@ -191,7 +202,8 @@ export class KeysRoute extends PageRoute {
     element.appendChild(pre);
 
     // force same columns on all rows
-    element.appendChild(Route._createTd("fingerprint", ""));
+    // do not use class "fingerprint" yet
+    element.appendChild(Route._createTd("os", "loading..."));
 
     // final dropdownmenu
     const menu = new DropDownMenu(element);
@@ -218,5 +230,63 @@ export class KeysRoute extends PageRoute {
     menu.addMenuItem("Delete&nbsp;key...", function(evt) {
       this._runCommand(evt, hostname, "wheel.key.delete" + extra);
     }.bind(this));
+  }
+
+  handleSaltAuthEvent(tag, data) {
+    const page = document.getElementById("page_keys");
+    const list = page.querySelector("#minions");
+    const tr = page.querySelector("table tr#" + data.id);
+    if(tr) {
+      const status = tr.querySelector(".status");
+      // drop all other classes (accepted, rejected, etc)
+      if(data.act === "accept") {
+        status.className = "status";
+        status.classList.add("accepted");
+        status.innerText = "accepted";
+      } else if(data.act === "reject") {
+        status.className = "status";
+        status.classList.add("rejected");
+        status.innerText = "rejected";
+      } else if(data.act === "pend") {
+        status.className = "status";
+        status.classList.add("unaccepted");
+        status.innerText = "unaccepted";
+      } else if(data.act === "delete") {
+        // "-1" due to the <tr> for the header that is inside <thead>
+        tr.parentNode.deleteRow(tr.rowIndex - 1);
+      } else {
+        // unknown status
+        // do not update screen
+      }
+      // keep the fingerprint
+    } else {
+      if(data.act === "pend") {
+        this._addPreMinion(list, data.id);
+        Utils.tableReSort(this.getPageElement());
+      } else if(data.act === "accept") {
+        this._addAcceptedMinion(list, data.id);
+        Utils.tableReSort(this.getPageElement());
+      } else if(data.act === "reject") {
+        this._addRejectedMinion(list, data.id);
+        Utils.tableReSort(this.getPageElement());
+      } else if(data.act === "delete") {
+        // delete of an unknown minion, never mind
+      } else {
+        // unknown status
+        // do not update screen
+      }
+      // we do not have the fingerprint yet
+      // pre-fill with a dummy value and then retrieve the actual value
+      const fingerprintSpan = page.querySelector("table tr#" + data.id + " .fingerprint");
+      if(fingerprintSpan) fingerprintSpan.innerText = "(refresh page for fingerprint)";
+      const wheelKeyFingerPromise = this.router.api.getWheelKeyFinger(data.id);
+      wheelKeyFingerPromise.then(this._handleWheelKeyFinger);
+    }
+
+    this.updateTableSummary(list);
+  }
+
+  handleSaltKeyEvent(tag, data) {
+    this.handleSaltAuthEvent(tag, data);
   }
 }

--- a/saltgui/static/sorttable/sorttable.js
+++ b/saltgui/static/sorttable/sorttable.js
@@ -133,12 +133,22 @@ sorttable = {
           sortrevind = document.getElementById('sorttable_sortrevind');
           if (sortrevind) { sortrevind.parentNode.removeChild(sortrevind); }
 
-          this.className += ' sorttable_sorted';
-          sortfwdind = document.createElement('span');
-          sortfwdind.id = "sorttable_sortfwdind";
-          // u2193 = DOWNWARDS ARROW
-          sortfwdind.innerHTML = stIsIE ? '&nbsp<font face="webdings">6</font>' : '&nbsp;\u2193';
-          this.appendChild(sortfwdind);
+          const reverse = sortfwdind !== null;
+          if(sortfwdind) {
+            this.className += ' sorttable_sorted_reverse';
+            sortrevind = document.createElement('span');
+            sortrevind.id = "sorttable_sortrevind";
+            // u2191 = UPWARDS ARROW
+            sortrevind.innerHTML = stIsIE ? '&nbsp;<font face="webdings">5</font>' : '&nbsp;\u2191';
+            this.appendChild(sortrevind);
+          } else {
+            this.className += ' sorttable_sorted';
+            sortfwdind = document.createElement('span');
+            sortfwdind.id = "sorttable_sortfwdind";
+            // u2193 = DOWNWARDS ARROW
+            sortfwdind.innerHTML = stIsIE ? '&nbsp;<font face="webdings">6</font>' : '&nbsp;\u2193';
+            this.appendChild(sortfwdind);
+          }
 
 	        // build an array to sort. This is a Schwartzian transform thing,
 	        // i.e., we "decorate" each row with the actual sort key,
@@ -154,6 +164,7 @@ sorttable = {
 	        //sorttable.shaker_sort(row_array, this.sorttable_sortfunction);
 	        /* and comment out this one */
 	        row_array.sort(this.sorttable_sortfunction);
+          if(reverse) row_array.reverse();
 
 	        tb = this.sorttable_tbody;
 	        for (var j=0; j<row_array.length; j++) {

--- a/saltgui/static/sorttable/sorttable.js
+++ b/saltgui/static/sorttable/sorttable.js
@@ -91,7 +91,7 @@ sorttable = {
 	      headrow[i].sorttable_tbody = table.tBodies[0];
 	      dean_addEvent(headrow[i],"click", sorttable.innerSortFunction = function(e) {
 
-          if (this.className.search(/\bsorttable_sorted\b/) != -1) {
+          if (false && this.className.search(/\bsorttable_sorted\b/) != -1) {
             // if we're already sorted by this column, just
             // reverse the table, which is quicker
             sorttable.reverse(this.sorttable_tbody);
@@ -105,7 +105,7 @@ sorttable = {
             this.appendChild(sortrevind);
             return;
           }
-          if (this.className.search(/\bsorttable_sorted_reverse\b/) != -1) {
+          if (false && this.className.search(/\bsorttable_sorted_reverse\b/) != -1) {
             // if we're already sorted by this column in reverse, just
             // re-reverse the table, which is quicker
             sorttable.reverse(this.sorttable_tbody);

--- a/saltgui/static/stylesheets/tooltip.css
+++ b/saltgui/static/stylesheets/tooltip.css
@@ -13,6 +13,7 @@
   border-right: 5px solid transparent;
   border-left: 5px solid transparent;
   position: absolute;
+  white-space: pre;
 
   /* float the tooltip above its target */
   z-index: 1;


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
SaltGUI uses screen refreshes after many actions, This takes time on both client and server.

**Describe the solution you'd like**
Implement asynchronous updates. SaltGUI can subscribe to the relevant message streams. The messages that are received can be used to update the screen.
Use /events to subscribe to all events.

This PR provides an update for the KEYS screen. Any action on a KEY now results in a live update of this screen. It does not matter whether the update originated from SaltGUI or not.