### PR TITLE
allow simple objects on one line

### DIFF
--- a/saltgui/static/scripts/output/Output.js
+++ b/saltgui/static/scripts/output/Output.js
@@ -472,7 +472,7 @@ export class Output {
       // an array is an object, but treat it separatelly
       if(!fndRepresentation && Array.isArray(hostResponse)) {
         hostOutput = Output.getNormalOutput(hostResponse);
-        hostMultiLine = hostResponse.length > 0;
+        hostMultiLine = hostOutput.tagName === "DIV";
         fndRepresentation = true;
       }
 
@@ -516,7 +516,7 @@ export class Output {
       // nothing special? then it is normal output
       if(!fndRepresentation) {
         hostOutput = Output.getNormalOutput(hostResponse);
-        hostMultiLine = Object.keys(hostResponse).length > 0;
+        hostMultiLine = hostOutput.includes("\n");
       }
 
       // one response does not need to be collapsible

--- a/saltgui/static/scripts/output/OutputJson.js
+++ b/saltgui/static/scripts/output/OutputJson.js
@@ -28,9 +28,19 @@ export class OutputJson {
       return "[ ]";
     }
 
+    if(Array.isArray(value) && value.length === 1 && typeof value[0] !== "object") {
+      // show the brackets for a simple array a bit wider apart
+      return "[ " + JSON.stringify(value[0]) + " ]";
+    }
+
     if(!Array.isArray(value) && Object.keys(value).length === 0) {
       // show the brackets for an empty object a bit wider apart
       return "{ }";
+    }
+
+    if(!Array.isArray(value) && Object.keys(value).length === 1 && typeof Object.values(value)[0] !== "object") {
+      // show the brackets for a simple object a bit wider apart
+      return "{ " + JSON.stringify(Object.keys(value)[0]) + ": " + JSON.stringify(Object.values(value)[0]) + " }";
     }
 
     return null;

--- a/saltgui/static/scripts/output/OutputJson.js
+++ b/saltgui/static/scripts/output/OutputJson.js
@@ -38,9 +38,10 @@ export class OutputJson {
       return "{ }";
     }
 
-    if(!Array.isArray(value) && Object.keys(value).length === 1 && typeof Object.values(value)[0] !== "object") {
+    // do not use Object.values as eslint does understand that
+    if(!Array.isArray(value) && Object.keys(value).length === 1 && typeof value[Object.keys(value)[0]] !== "object") {
       // show the brackets for a simple object a bit wider apart
-      return "{ " + JSON.stringify(Object.keys(value)[0]) + ": " + JSON.stringify(Object.values(value)[0]) + " }";
+      return "{ " + JSON.stringify(Object.keys(value)[0]) + ": " + JSON.stringify(value[Object.keys(value)[0]]) + " }";
     }
 
     return null;

--- a/tests/unit/Output.test.js
+++ b/tests/unit/Output.test.js
@@ -79,16 +79,16 @@ describe('Unittests for Output.js', function() {
     result = OutputJson.formatJSON(outputData);
     // ordered output
     assert.equal(result, 
-//      "{\n" +
-//      "    \"ip6_interfaces\": {\n" +
-//      "        \"eth0\": [\n" +
-//      "            \"fe80::20d:3aff:fe38:576b\"\n" +
-//      "        ],\n" +
-//      "        \"lo\": [\n" +
-//      "            \"::1\"\n" +
-//      "        ]\n" +
-//      "    }\n" +
-//      "}");
+      // "{\n" +
+      // "    \"ip6_interfaces\": {\n" +
+      // "        \"eth0\": [\n" +
+      // "            \"fe80::20d:3aff:fe38:576b\"\n" +
+      // "        ],\n" +
+      // "        \"lo\": [\n" +
+      // "            \"::1\"\n" +
+      // "        ]\n" +
+      // "    }\n" +
+      // "}");
       "{\n" +
       "    \"ip6_interfaces\": {\n" +
       "        \"eth0\": [ \"fe80::20d:3aff:fe38:576b\" ],\n" +

--- a/tests/unit/Output.test.js
+++ b/tests/unit/Output.test.js
@@ -34,8 +34,14 @@ describe('Unittests for Output.js', function() {
 
     outputData = [1];
     result = OutputJson.formatJSON(outputData);
-    assert.equal(result, "[\n" +
-      "    1\n" +
+    assert.equal(result, "[ 1 ]");
+
+    outputData = [1,2];
+    result = OutputJson.formatJSON(outputData);
+    assert.equal(result,
+      "[\n" +
+      "    1,\n" +
+      "    2\n" +
       "]");
 
     outputData = [1,2,3,4,5];
@@ -53,6 +59,10 @@ describe('Unittests for Output.js', function() {
     result = OutputJson.formatJSON(outputData);
     assert.equal(result, "{ }");
 
+    outputData = {"a":11};
+    result = OutputJson.formatJSON(outputData);
+    assert.equal(result, "{ \"a\": 11 }");
+
     // unordered input
     outputData = {"a":11,"c":22,"b":33};
     result = OutputJson.formatJSON(outputData);
@@ -69,14 +79,20 @@ describe('Unittests for Output.js', function() {
     result = OutputJson.formatJSON(outputData);
     // ordered output
     assert.equal(result, 
+//      "{\n" +
+//      "    \"ip6_interfaces\": {\n" +
+//      "        \"eth0\": [\n" +
+//      "            \"fe80::20d:3aff:fe38:576b\"\n" +
+//      "        ],\n" +
+//      "        \"lo\": [\n" +
+//      "            \"::1\"\n" +
+//      "        ]\n" +
+//      "    }\n" +
+//      "}");
       "{\n" +
       "    \"ip6_interfaces\": {\n" +
-      "        \"eth0\": [\n" +
-      "            \"fe80::20d:3aff:fe38:576b\"\n" +
-      "        ],\n" +
-      "        \"lo\": [\n" +
-      "            \"::1\"\n" +
-      "        ]\n" +
+      "        \"eth0\": [ \"fe80::20d:3aff:fe38:576b\" ],\n" +
+      "        \"lo\": [ \"::1\" ]\n" +
       "    }\n" +
       "}");
 


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
When simple objects are shown in a job output, the output can still be on one line.
Currently objects and arrays are always shown as multi-line.

**Describe the solution you'd like**
Show short objects and arrays as one line.