### PR TITLE
Timeout

### DIFF
--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -66,7 +66,7 @@
       <div class='route' id='page-login'>
         <form method='post' id='login-form'>
           <h1>SaltGUI</h1>
-          <div class='notice-wrapper'>
+          <div id='notice-wrapper'>
           </div>
           <input id='username' type='text' placeholder='Username' autofocus />
           <input id='password' type='password' placeholder='Password' />

--- a/saltgui/static/scripts/Api.js
+++ b/saltgui/static/scripts/Api.js
@@ -210,7 +210,7 @@ export class API {
         if(pResponse.ok) return pResponse.json();
         // fetch does not reject on > 300 http status codes,
         // so let's do it ourselves
-        if(pResponse.status === 401) {
+        if(pResponse.status === 401 && pRoute !== "/login") {
           const loginResponseStr = window.sessionStorage.getItem("login-response");
           if(!loginResponseStr) {
             myThis.logout().then(() =>

--- a/saltgui/static/scripts/Api.js
+++ b/saltgui/static/scripts/Api.js
@@ -8,7 +8,10 @@ export class HTTPError extends Error {
 
 export class API {
   constructor(pRouter) {
-    //this.getEvents = this.getEvents.bind(this);
+    this.apiRequest = this.apiRequest.bind(this);
+    this.login = this.login.bind(this);
+    this.logout = this.logout.bind(this);
+
     this.getEvents(pRouter);
   }
 
@@ -201,6 +204,7 @@ export class API {
 
     if(pMethod === "POST") options.body = JSON.stringify(pParams);
 
+    const myThis = this;
     return fetch(location, options)
       .then(pResponse => {
         if(pResponse.ok) return pResponse.json();
@@ -209,7 +213,9 @@ export class API {
         if(pResponse.status === 401) {
           const loginResponseStr = window.sessionStorage.getItem("login-response");
           if(!loginResponseStr) {
-            this.logout().then(() =>
+            myThis.logout().then(() =>
+              window.location.replace("/login?reason=no-session")
+            , () =>
               window.location.replace("/login?reason=no-session")
             );
             return null;
@@ -221,7 +227,9 @@ export class API {
             const now = Date.now() / 1000;
             const expireValue = loginResponse.expire;
             if(now > expireValue) {
-              this.logout().then(() =>
+              myThis.logout().then(() =>
+                window.location.replace("/login?reason=expired-session")
+              , () =>
                 window.location.replace("/login?reason=expired-session")
               );
               return null;

--- a/saltgui/static/scripts/Api.js
+++ b/saltgui/static/scripts/Api.js
@@ -33,7 +33,8 @@ export class API {
           // This may happen e.g. for accounts that are in PAM,
           // but not in the 'master' file.
           // Don't give the user an empty screen full of errors
-          throw new HTTPError(403, "Unauthorized");
+          // just like 403 Unauthorized
+          throw new HTTPError(-1, "No permissions");
         }
         window.sessionStorage.setItem("login-response", JSON.stringify(response));
         window.sessionStorage.setItem("token", response.token);

--- a/saltgui/static/scripts/CommandBox.js
+++ b/saltgui/static/scripts/CommandBox.js
@@ -124,7 +124,8 @@ export class CommandBox {
     output.innerText = "Loading...";
 
     func.then(pResponse => {
-      this._onRunReturn(pResponse.return[0], commandValue);
+      if(pResponse) this._onRunReturn(pResponse.return[0], commandValue);
+      else this._showError("null response");
     }, pResponse => {
       this._showError(JSON.stringify(pResponse));
     });

--- a/saltgui/static/scripts/Router.js
+++ b/saltgui/static/scripts/Router.js
@@ -139,13 +139,13 @@ export class Router {
 
     document.querySelector("#button-logout1")
       .addEventListener("click", pClickEvent => {
-        this.api.logout();
-        window.location.replace("/login?reason=logout");
+        this.api.logout().then(
+          _ => window.location.replace("/login?reason=logout"));
       });
     document.querySelector("#button-logout2")
       .addEventListener("click", pClickEvent => {
-        this.api.logout();
-        window.location.replace("/login?reason=logout");
+        this.api.logout().then(
+          _ => window.location.replace("/login?reason=logout"));
       });
   }
 

--- a/saltgui/static/scripts/Router.js
+++ b/saltgui/static/scripts/Router.js
@@ -51,13 +51,7 @@ export class Router {
 
     this._registerEventListeners();
 
-    this.api.isAuthenticated()
-      .then(valid_session => this.goTo(
-        valid_session ? window.location.pathname + window.location.search : "/login"))
-      .catch(error => {
-        console.error(error);
-        this.goTo("/login");
-      });
+    this.goTo(window.location.pathname + window.location.search);
   }
 
   _registerEventListeners() {
@@ -172,6 +166,9 @@ export class Router {
       this.showRoute(route);
       return;
     }
+    // route could not be found
+    // just go to the main page
+    this.goTo("/");
   }
 
   showRoute(pRoute) {

--- a/saltgui/static/scripts/Router.js
+++ b/saltgui/static/scripts/Router.js
@@ -139,15 +139,13 @@ export class Router {
 
     document.querySelector("#button-logout1")
       .addEventListener("click", pClickEvent => {
-        this.api.logout().then(_ =>
-          window.location.replace("/")
-        );
+        this.api.logout();
+        window.location.replace("/login?reason=logout");
       });
     document.querySelector("#button-logout2")
       .addEventListener("click", pClickEvent => {
-        this.api.logout().then(_ =>
-          window.location.replace("/")
-        );
+        this.api.logout();
+        window.location.replace("/login?reason=logout");
       });
   }
 

--- a/saltgui/static/scripts/Router.js
+++ b/saltgui/static/scripts/Router.js
@@ -21,7 +21,7 @@ export class Router {
   constructor() {
     this.logoutTimer = this.logoutTimer.bind(this);
 
-    this.api = new API(this);
+    this.api = new API();
     this.commandbox = new CommandBox(this.api);
     this.currentRoute = undefined;
     this.routes = [];
@@ -223,6 +223,10 @@ export class Router {
     this.switchingRoute = true;
 
     pRoute.onShow();
+
+    // start the event-pipe (again)
+    // it is either not started, or needs restarting
+    this.api.getEvents(this);
 
     if(myThis.currentRoute) {
       myThis.hideRoute(myThis.currentRoute);

--- a/saltgui/static/scripts/Router.js
+++ b/saltgui/static/scripts/Router.js
@@ -19,6 +19,8 @@ import {TemplatesRoute} from './routes/Templates.js';
 export class Router {
 
   constructor() {
+    this.logoutTimer = this.logoutTimer.bind(this);
+
     this.api = new API(this);
     this.commandbox = new CommandBox(this.api);
     this.currentRoute = undefined;
@@ -147,6 +149,21 @@ export class Router {
         this.api.logout().then(
           _ => window.location.replace("/login?reason=logout"));
       });
+
+    // don't verify the session too often
+    setInterval(this.logoutTimer, 60000);
+  }
+
+  logoutTimer() {
+    // are we logged in?
+    const token = window.sessionStorage.getItem("token");
+    if(!token) return;
+
+    // just a random lightweight api call
+    const wheelConfigValuesPromise = this.api.getWheelConfigValues();
+    // don't act in the callbacks
+    // Api.apiRequest will do all the work
+    wheelConfigValuesPromise.then(data => { }, data => { });
   }
 
   registerRoute(pRoute) {

--- a/saltgui/static/scripts/routes/Job.js
+++ b/saltgui/static/scripts/routes/Job.js
@@ -116,6 +116,8 @@ export class JobRoute extends Route {
       JobRoute.hideShowOutputSearchBar(output)
     );
 
+    if(!pData) return;
+
     if(typeof pData !== "object") {
       output.innerText = "";
       Utils.addErrorToTableCell(output, pData);

--- a/saltgui/static/scripts/routes/Jobs.js
+++ b/saltgui/static/scripts/routes/Jobs.js
@@ -184,6 +184,8 @@ export class JobsRoute extends PageRoute {
 
   _handleRunnerJobsActive(pData) {
 
+    if(!pData) return;
+
     if(typeof pData !== "object") {
       // update all jobs (page) with the error message
       const tbody = this.pageElement.querySelector("table#jobs tbody");

--- a/saltgui/static/scripts/routes/Keys.js
+++ b/saltgui/static/scripts/routes/Keys.js
@@ -32,8 +32,9 @@ export class KeysRoute extends PageRoute {
         myThis._handleWheelKeyFinger(pData);
       }, pData2 => {
         const pData = {"return":[{"data":{"return":{"minions":{}}}}]};
-        for(const k of pData1.return[0].data.return.minions)
-          pData.return[0]["data"]["return"]["minions"][k] = JSON.stringify(pData2);
+        if(pData1)
+          for(const k of pData1.return[0].data.return.minions)
+            pData.return[0]["data"]["return"]["minions"][k] = JSON.stringify(pData2);
         myThis._handleWheelKeyFinger(pData);
       });
     }, pData => {
@@ -53,6 +54,8 @@ export class KeysRoute extends PageRoute {
   }
 
   _handleWheelKeyFinger(pData) {
+    if(!pData) return;
+
     const allKeys = pData.return[0].data.return;
 
     for(const property of Object.keys(allKeys)) {
@@ -81,6 +84,8 @@ export class KeysRoute extends PageRoute {
   }
 
   _handleWheelKeyListAll(pData) {
+    if(!pData) return;
+
     const table = this.getPageElement().querySelector("#minions");
 
     if(PageRoute.showErrorRowInstead(table, pData)) return;

--- a/saltgui/static/scripts/routes/Login.js
+++ b/saltgui/static/scripts/routes/Login.js
@@ -128,10 +128,20 @@ export class LoginRoute extends Route {
     window.localStorage.setItem("tooltip_mode", toolTipMode);
   }
 
-  onLoginFailure() {
+  onLoginFailure(error) {
     this.toggleForm(true);
 
-    this.showNoticeText("#F44336", "Authentication failed");
+    if(error && error.status === 503) {
+      // Service Unavailable
+      // e.g. salt-api running but salt-master not running
+      this.showNoticeText("#F44336", error.message);
+    } else if(error && error.status === -1) {
+      // No permissions: login valid, but no api functions executable
+      // e.g. PAM says OK and /etc/salt/master says NO
+      this.showNoticeText("#F44336", error.message);
+    } else {
+      this.showNoticeText("#F44336", "Authentication failed");
+    }
   }
 
   toggleForm(pAllowSubmit) {

--- a/saltgui/static/scripts/routes/Login.js
+++ b/saltgui/static/scripts/routes/Login.js
@@ -22,7 +22,8 @@ export class LoginRoute extends Route {
     let reason = decodeURIComponent(Utils.getQueryParam("reason"));
     if(!reason || reason === "undefined") return;
     if(reason === "no-session") reason = "Not logged in!";
-    if(reason === "expired-session") reason = "Automatic logout!";
+    if(reason === "expired-session") reason = "Session expired!";
+    if(reason === "logout") reason = "Logout!";
     const noticeDiv = this.pageElement.querySelector(".notice-wrapper");
 
     const reasonDiv = Route._createDiv("notice", reason);

--- a/saltgui/static/scripts/routes/Login.js
+++ b/saltgui/static/scripts/routes/Login.js
@@ -14,40 +14,55 @@ export class LoginRoute extends Route {
     this.registerEventListeners();
   }
 
+  registerEventListeners() {
+    const submit = document.getElementById("login-form");
+    submit.addEventListener("submit", this.onLogin);
+  }
+
+  showNoticeText(pBackgroundColour, pText) {
+    // create a new child every time to restart the animation
+    const noticeDiv = Route._createDiv("", pText);
+    noticeDiv.id = "notice";
+    noticeDiv.style.backgroundColor = pBackgroundColour;
+    const noticeWrapperDiv = document.getElementById("notice-wrapper");
+    noticeWrapperDiv.replaceChild(noticeDiv, noticeWrapperDiv.firstChild);
+  }
+
   onShow() {
-    const eauthSelector = this.pageElement.querySelector("#login-form #eauth");
+    const eauthSelector = document.getElementById("eauth");
     const eauthValue = window.localStorage.getItem("eauth");
     eauthSelector.value = eauthValue ? eauthValue : "pam";
 
-    let reason = decodeURIComponent(Utils.getQueryParam("reason"));
-    if(!reason || reason === "undefined") return;
-    if(reason === "no-session") reason = "Not logged in!";
-    if(reason === "expired-session") reason = "Session expired!";
-    if(reason === "logout") reason = "Logout!";
-    const noticeDiv = this.pageElement.querySelector(".notice-wrapper");
-
-    const reasonDiv = Route._createDiv("notice", reason);
-    reasonDiv.style.backgroundColor = "black";
-    noticeDiv.replaceChild(reasonDiv, noticeDiv.firstChild);
-    noticeDiv.className = "notice-wrapper";
-    noticeDiv.focus(); //Used to trigger a reflow (to restart animation)
-    noticeDiv.className = "notice-wrapper show";
-  }
-
-  registerEventListeners() {
-    const submit = this.pageElement.querySelector("#login-form");
-    submit.addEventListener("submit", this.onLogin);
+    const reason = decodeURIComponent(Utils.getQueryParam("reason"));
+    switch(reason){
+    case null:
+    case "":
+    case "undefined":
+      break;
+    case "no-session":
+      this.showNoticeText("#F44336", "Not logged in");
+      break;
+    case "expired-session":
+      this.showNoticeText("#F44336", "Session expired");
+      break;
+    case "logout":
+      this.showNoticeText("gray", "Logout");
+      break;
+    default:
+      // should not occur
+      this.showNoticeText("#F44336", reason);
+    }
   }
 
   onLogin(pSubmitEvent) {
     pSubmitEvent.preventDefault();
     if(this.loginPending) return; //Don't continue if waiting on a request
 
-    const userNameField = this.pageElement.querySelector("#username");
+    const userNameField = document.getElementById("username");
     const userName = userNameField.value;
-    const passWordField = this.pageElement.querySelector("#password");
+    const passWordField = document.getElementById("password");
     const passWord = passWordField.value;
-    const eauthField = this.pageElement.querySelector("#eauth");
+    const eauthField = document.getElementById("eauth");
     const eauth = eauthField.value;
 
     this.toggleForm(false);
@@ -58,22 +73,14 @@ export class LoginRoute extends Route {
   onLoginSuccess() {
     this.toggleForm(true);
 
-    const noticeDiv = this.pageElement.querySelector(".notice-wrapper");
-
-    const success = Route._createDiv("notice", "Please wait...");
-    success.style.backgroundColor = "#4CAF50";
-    noticeDiv.replaceChild(success, noticeDiv.firstChild);
-
-    const userNameField = this.pageElement.querySelector("#username");
+    const userNameField = document.getElementById("username");
     userNameField.disabled = true;
-    const passWordField = this.pageElement.querySelector("#password");
+    const passWordField = document.getElementById("password");
     passWordField.disabled = true;
-    const eauthField = this.pageElement.querySelector("#eauth");
+    const eauthField = document.getElementById("eauth");
     eauthField.disabled = true;
 
-    noticeDiv.className = "notice-wrapper";
-    noticeDiv.focus(); //Used to trigger a reflow (to restart animation)
-    noticeDiv.className = "notice-wrapper show";
+    this.showNoticeText("#4CAF50", "Please wait...");
 
     //we need these functions to populate the dropdown boxes
     const wheelConfigValuesPromise = this.router.api.getWheelConfigValues();
@@ -124,15 +131,7 @@ export class LoginRoute extends Route {
   onLoginFailure() {
     this.toggleForm(true);
 
-    const noticeDiv = this.pageElement.querySelector(".notice-wrapper");
-
-    const authFailed = Route._createDiv("notice", "Authentication failed");
-    authFailed.style.backgroundColor = "#F44336";
-
-    noticeDiv.replaceChild(authFailed, noticeDiv.firstChild);
-    noticeDiv.className = "notice-wrapper";
-    noticeDiv.focus(); //Used to trigger a reflow (to restart animation)
-    noticeDiv.className = "notice-wrapper show";
+    this.showNoticeText("#F44336", "Authentication failed");
   }
 
   toggleForm(pAllowSubmit) {

--- a/saltgui/static/scripts/routes/Login.js
+++ b/saltgui/static/scripts/routes/Login.js
@@ -40,12 +40,14 @@ export class LoginRoute extends Route {
     case "undefined":
       break;
     case "no-session":
-      this.showNoticeText("#F44336", "Not logged in");
+      // gray because we cannot prove that the user was/wasnt logged in
+      this.showNoticeText("gray", "Not logged in");
       break;
     case "expired-session":
       this.showNoticeText("#F44336", "Session expired");
       break;
     case "logout":
+      // gray because this is the result of a user action
       this.showNoticeText("gray", "Logout");
       break;
     default:

--- a/saltgui/static/scripts/routes/Login.js
+++ b/saltgui/static/scripts/routes/Login.js
@@ -1,4 +1,5 @@
 import {Route} from './Route.js';
+import {Utils} from '../Utils.js';
 
 export class LoginRoute extends Route {
 
@@ -17,6 +18,19 @@ export class LoginRoute extends Route {
     const eauthSelector = this.pageElement.querySelector("#login-form #eauth");
     const eauthValue = window.localStorage.getItem("eauth");
     eauthSelector.value = eauthValue ? eauthValue : "pam";
+
+    let reason = decodeURIComponent(Utils.getQueryParam("reason"));
+    if(!reason || reason === "undefined") return;
+    if(reason === "no-session") reason = "Not logged in!";
+    if(reason === "expired-session") reason = "Automatic logout!";
+    const noticeDiv = this.pageElement.querySelector(".notice-wrapper");
+
+    const reasonDiv = Route._createDiv("notice", reason);
+    reasonDiv.style.backgroundColor = "black";
+    noticeDiv.replaceChild(reasonDiv, noticeDiv.firstChild);
+    noticeDiv.className = "notice-wrapper";
+    noticeDiv.focus(); //Used to trigger a reflow (to restart animation)
+    noticeDiv.className = "notice-wrapper show";
   }
 
   registerEventListeners() {
@@ -43,11 +57,11 @@ export class LoginRoute extends Route {
   onLoginSuccess() {
     this.toggleForm(true);
 
-    const notice = this.pageElement.querySelector(".notice-wrapper");
+    const noticeDiv = this.pageElement.querySelector(".notice-wrapper");
 
     const success = Route._createDiv("notice", "Please wait...");
     success.style.backgroundColor = "#4CAF50";
-    notice.replaceChild(success, notice.firstChild);
+    noticeDiv.replaceChild(success, noticeDiv.firstChild);
 
     const userNameField = this.pageElement.querySelector("#username");
     userNameField.disabled = true;
@@ -56,9 +70,9 @@ export class LoginRoute extends Route {
     const eauthField = this.pageElement.querySelector("#eauth");
     eauthField.disabled = true;
 
-    notice.className = "notice-wrapper";
-    notice.focus(); //Used to trigger a reflow (to restart animation)
-    notice.className = "notice-wrapper show";
+    noticeDiv.className = "notice-wrapper";
+    noticeDiv.focus(); //Used to trigger a reflow (to restart animation)
+    noticeDiv.className = "notice-wrapper show";
 
     //we need these functions to populate the dropdown boxes
     const wheelConfigValuesPromise = this.router.api.getWheelConfigValues();
@@ -109,15 +123,15 @@ export class LoginRoute extends Route {
   onLoginFailure() {
     this.toggleForm(true);
 
-    const notice = this.pageElement.querySelector(".notice-wrapper");
+    const noticeDiv = this.pageElement.querySelector(".notice-wrapper");
 
     const authFailed = Route._createDiv("notice", "Authentication failed");
     authFailed.style.backgroundColor = "#F44336";
 
-    notice.replaceChild(authFailed, notice.firstChild);
-    notice.className = "notice-wrapper";
-    notice.focus(); //Used to trigger a reflow (to restart animation)
-    notice.className = "notice-wrapper show";
+    noticeDiv.replaceChild(authFailed, noticeDiv.firstChild);
+    noticeDiv.className = "notice-wrapper";
+    noticeDiv.focus(); //Used to trigger a reflow (to restart animation)
+    noticeDiv.className = "notice-wrapper show";
   }
 
   toggleForm(pAllowSubmit) {

--- a/saltgui/static/scripts/routes/Minions.js
+++ b/saltgui/static/scripts/routes/Minions.js
@@ -25,8 +25,9 @@ export class MinionsRoute extends PageRoute {
         myThis._updateMinions(pData);
       }, pData2 => {
         const pData = {"return":[{}]};
-        for(const k of pData1.return[0].data.return.minions)
-          pData.return[0][k] = JSON.stringify(pData2);
+        if(pData1)
+          for(const k of pData1.return[0].data.return.minions)
+            pData.return[0][k] = JSON.stringify(pData2);
         myThis._updateMinions(pData);
       });
     }, pData => {

--- a/saltgui/static/scripts/routes/Page.js
+++ b/saltgui/static/scripts/routes/Page.js
@@ -17,6 +17,8 @@ export class PageRoute extends Route {
   }
 
   _updateMinions(pData) {
+    if(!pData) return;
+
     const minions = pData.return[0];
 
     const table = this.getPageElement().querySelector("#minions");
@@ -428,6 +430,8 @@ export class PageRoute extends Route {
 
   _handleRunnerJobsActive(pData) {
 
+    if(!pData) return;
+
     if(typeof pData !== "object") {
       const tbody = this.pageElement.querySelector("table.jobs tbody");
       for(const tr of tbody.rows) {
@@ -597,6 +601,12 @@ export class PageRoute extends Route {
   }
 
   static showErrorRowInstead(pTable, pData) {
+
+    if(pData === null) {
+      // not an error, but also nothing to show
+      return true;
+    }
+
     if(typeof pData === "object") {
       // not an error
       return false;

--- a/saltgui/static/stylesheets/login.css
+++ b/saltgui/static/stylesheets/login.css
@@ -63,29 +63,41 @@
   width: 25px;
 }
 
-.notice-wrapper {
-  height: 0;
-  overflow-y: hidden;
+#notice-wrapper {
   margin-bottom: 15px;
 }
 
-.notice-wrapper.show {
+#notice {
+  height: 0;
+  overflow-y: hidden;
+  color: white;
+  padding: 0;
+  border-radius: 2px;
+  text-align: center;
+  font-size: 15px;
   animation-name: show-notice;
   animation-iteration-count: 1;
   animation-duration: 5s;
 }
 
 @keyframes show-notice {
-  0% { height: 0; }
-  20% { height: 38px; }
-  80% { height: 38px; }
-  100% { height: 0; }
-}
+  0% {
+    height: 0;
+    padding: 0;
+  }
 
-.notice {
-  color: white;
-  padding: 9px 0;
-  border-radius: 2px;
-  text-align: center;
-  font-size: 15px;
+  20% {
+    height: 38px;
+    padding: 9px 0;
+  }
+
+  80% {
+    height: 38px;
+    padding: 9px 0;
+  }
+
+  100% {
+    height: 0;
+    padding: 0;
+  }
 }


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
When there is a session timeout, most API calls end with "401 Unauthorized".
SaltGUI carries on because it may not have access to a single API call (or range of API calls).

**Describe the solution you'd like**
When a 401 is received, the current time should be compared with the session-end time as received at login. When the current time is past that, it is safe to conclude that the whole session has expired. The logout procedure should be triggered so that cached information is removed and the screen reverts to the login screen.
Function `isAuthenticated` can be retired.

closes #251 