### PR TITLE
actions for jobs now in dropdown

### DIFF
--- a/saltgui/static/scripts/DropDown.js
+++ b/saltgui/static/scripts/DropDown.js
@@ -18,21 +18,21 @@ export class DropDownMenu {
 
     this.menuDropdown = Route.createDiv("run-command-button", "");
 
-    switch (pParentElement.id) {
-    case "cmd-box":
+    if(pParentElement.id === "cmd-box") {
       // 1F4D6 (D83D+DCD6) = A BOOK
       this.menuButton = Route.createDiv("menu-dropdown", "\uD83D\uDCD6");
-      // hide the menu until it receives menu-items
-      this.verifyAll();
-      break;
-
-    default:
+    } else if(pParentElement.classList && pParentElement.classList.contains("minion-output")) {
+      // 1F4D6 (D83D+DCD6) = A BOOK
+      this.menuButton = Route._createSpan("menu-dropdown", "\u2261");
+    } else {
       // 2261 = MATHEMATICAL OPERATOR IDENTICAL TO (aka "hamburger")
       // assume it will be a command menu
-      this.menuButton = Route.createDiv("menu-dropdown", "\u2261");
-      // hide the menu until it receives menu-items
-      this.verifyAll();
+      this.menuButton = Route._createDiv("menu-dropdown", "\u2261");
     }
+
+    // hide the menu until it receives menu-items
+    this.verifyAll();
+
     this.menuDropdown.appendChild(this.menuButton);
     this.menuDropdownContent = Route.createDiv("menu-dropdown-content", "");
     this.menuDropdown.appendChild(this.menuDropdownContent);

--- a/saltgui/static/scripts/routes/Job.js
+++ b/saltgui/static/scripts/routes/Job.js
@@ -383,39 +383,19 @@ export class JobRoute extends Route {
         // show that this minion is still active on the request
         noResponseSpan.innerText = "(active) ";
 
-        const linkPsProcInfo = document.createElement("a");
-        linkPsProcInfo.innerText = "info";
-        linkPsProcInfo.addEventListener("click", pClickEvent =>
-          this.runFullCommand(pClickEvent, "list", minionId, "ps.proc_info " + pid)
-        );
-        noResponseSpan.appendChild(linkPsProcInfo);
-
-        noResponseSpan.appendChild(document.createTextNode(" "));
-
-        const linkPsTermPid = document.createElement("a");
-        linkPsTermPid.innerText = "term";
-        linkPsTermPid.addEventListener("click", pClickEvent =>
-          this.runFullCommand(pClickEvent, "list", minionId, "ps.kill_pid " + pid + " signal=15")
-        );
-        noResponseSpan.appendChild(linkPsTermPid);
-
-        noResponseSpan.appendChild(document.createTextNode(" "));
-
-        const linkPsKillPid = document.createElement("a");
-        linkPsKillPid.innerText = "kill";
-        linkPsKillPid.addEventListener("click", pClickEvent =>
-          this.runFullCommand(pClickEvent, "list", minionId, "ps.kill_pid " + pid + " signal=9")
-        );
-        noResponseSpan.appendChild(linkPsKillPid);
-
-        noResponseSpan.appendChild(document.createTextNode(" "));
-
-        const linkPsSignalPid = document.createElement("a");
-        linkPsSignalPid.innerText = "signal";
-        linkPsSignalPid.addEventListener("click", pClickEvent =>
-          this.runFullCommand(pClickEvent, "list", minionId, "ps.kill_pid " + pid + " signal=<signalnumber>")
-        );
-        noResponseSpan.appendChild(linkPsSignalPid);
+        const menu = new DropDownMenu(noResponseSpan);
+        menu.addMenuItem("Show&nbsp;process&nbsp;info...", function(pClickEvent) {
+          this.runFullCommand(pClickEvent, "list", minionId, "ps.proc_info " + pid);
+        }.bind(this));
+        menu.addMenuItem("Terminate&nbsp;process...", function(pClickEvent) {
+          this.runFullCommand(pClickEvent, "list", minionId, "ps.kill_pid " + pid + " signal=15");
+        }.bind(this));
+        menu.addMenuItem("Kill&nbsp;process...", function(pClickEvent) {
+          this.runFullCommand(pClickEvent, "list", minionId, "ps.kill_pid " + pid + " signal=9");
+        }.bind(this));
+        menu.addMenuItem("Signal&nbsp;process...", function(pClickEvent) {
+          this.runFullCommand(pClickEvent, "list", minionId, "ps.kill_pid " + pid + " signal=<signalnumber>");
+        }.bind(this));
 
         noResponseSpan.classList.remove("noresponse");
         noResponseSpan.classList.add("active");

--- a/saltgui/static/stylesheets/dropdown.css
+++ b/saltgui/static/stylesheets/dropdown.css
@@ -26,6 +26,7 @@
   clear: both;
   width: 100%;
   padding: 15px 30px 15px 30px;
+  margin: 0;
   -webkit-transition: all 0.2s ease-in-out;
   -moz-transition: all 0.2s ease-in-out;
   transition: all 0.2s ease-in-out;
@@ -46,6 +47,25 @@
 .run-command-button:hover .menu-dropdown {
   background: rgba(0, 0, 0, 0.15);
   color: #4caf50;
+}
+
+pre.output span.menu-dropdown {
+  color: white;
+  font-weight: normal;
+}
+
+pre.output div.menu-dropdown-content {
+  font-family: Roboto, Helvetica, Arial, sans-serif;
+  font-weight: normal;
+}
+
+pre.output .run-command-button {
+  margin-bottom: 0;
+}
+
+pre.output .run-command-button:hover .menu-dropdown {
+  background-color: #f9f9f9;
+  color: black;
 }
 
 .dropdown {


### PR DESCRIPTION
closes #219 

When viewing job, 4 links are shown for each running process within that job.
The titles are `info`, `term`, `kill` and `signal`

These links are now organized in a drop-down menu.
The titles should be `Show process info`, `Terminate process`, `Kill process` and `Signal process`