### PR TITLE
use prediction of liveliness of the minions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A new open source web interface for managing a SaltStack server. Built using van
 - View the values for pillars for a particular minion
 - View the beacons for a particular minion
 - Match list of minions against reference list
+- Match status of minions against reference list
 
 
 ## Quick start using PAM as authentication method
@@ -183,10 +184,15 @@ The only other allowed value is "none", with the effect that no tooltips are sho
 In situations like cloud hosting, hosts may be deleted or shutdown frequently.
 But Salt remembers the key status from both.
 SaltGUI can compare the list of keys against a reference list.
-The reference list is maintained as a text file, one minion-name per line.
+The reference list is maintained as a text file, one minion per line.
+First column is the minion name.
+Second column is 'false' when the minion is known to be absent due to machine shutdown.
+It should be 'true' otherwise.
+When the second column is missing, this validation is not performed.
 Lines starting with '#' are comment lines.
 The filename is `saltgui/static/minions.txt`.
-All differences with this file are highlighted on the Keys page.
+Differences with this file are highlighted on the Keys page.
+Minions that are unexpectedly down are highlighted on the Minions page.
 When the file is absent or empty, no such validation is done.
 It is suggested that the file is generated from a central source,
 e.g. the Azure, AWS or similar cloud portals; or from a company asset management list.

--- a/saltgui/static/scripts/routes/Beacons.js
+++ b/saltgui/static/scripts/routes/Beacons.js
@@ -110,8 +110,8 @@ export class BeaconsRoute extends PageRoute {
     msgDiv.innerText = txt;
   }
 
-  updateOfflineMinion(pContainer, pMinionId) {
-    super.updateOfflineMinion(pContainer, pMinionId);
+  updateOfflineMinion(pContainer, pMinionId, pMinionTxt) {
+    super.updateOfflineMinion(pContainer, pMinionId, pMinionTxt);
 
     const minionTr = pContainer.querySelector("#" + Utils.getIdFromMinionId(pMinionId));
 

--- a/saltgui/static/scripts/routes/Grains.js
+++ b/saltgui/static/scripts/routes/Grains.js
@@ -106,8 +106,8 @@ export class GrainsRoute extends PageRoute {
     msgDiv.innerText = txt;
   }
 
-  updateOfflineMinion(pContainer, pMinionId) {
-    super.updateOfflineMinion(pContainer, pMinionId);
+  updateOfflineMinion(pContainer, pMinionId, pMinionTxt) {
+    super.updateOfflineMinion(pContainer, pMinionId, pMinionTxt);
 
     const minionTr = pContainer.querySelector("#" + Utils.getIdFromMinionId(pMinionId));
 

--- a/saltgui/static/scripts/routes/Keys.js
+++ b/saltgui/static/scripts/routes/Keys.js
@@ -25,18 +25,8 @@ export class KeysRoute extends PageRoute {
     const wheelKeyFingerPromise = this.router.api.getWheelKeyFinger();
     const runnerJobsListJobsPromise = this.router.api.getRunnerJobsListJobs();
     const runnerJobsActivePromise = this.router.api.getRunnerJobsActive();
-    const staticMinionsTxtPromise = this.router.api.getStaticMinionsTxt();
 
-    staticMinionsTxtPromise.then(pStaticMinionsTxt => {
-      if(!pStaticMinionsTxt)
-        window.sessionStorage.setItem("minions-txt", "[]");
-      else {
-        const lines = pStaticMinionsTxt.trim().split(/\r?\n/).filter(item => !item.startsWith("#"));
-        window.sessionStorage.setItem("minions-txt", JSON.stringify(lines));
-      }
-    }, pStaticMinionsTxt => {
-      window.sessionStorage.setItem("minions-txt", "[]");
-    });
+    this.loadMinionsTxt();
 
     wheelKeyListAllPromise.then(pWheelKeyListAllData => {
       myThis._handleKeysWheelKeyListAll(pWheelKeyListAllData);
@@ -127,7 +117,7 @@ export class KeysRoute extends PageRoute {
       this._addRejectedMinion(table, minionId, minionsTxt);
     }
 
-    for(const minionId of minionsTxt) {
+    for(const minionId of Object.keys(minionsTxt)) {
       if(table.querySelector("#" + Utils.getIdFromMinionId(minionId))) continue;
       const minionTr = this.getElement(table, Utils.getIdFromMinionId(minionId), "UNKNOWN");
 
@@ -188,7 +178,7 @@ export class KeysRoute extends PageRoute {
     const minionIdTd = Route.createTd("", "");
     const minionIdSpan = Route.createSpan("minion-id", pMinionId);
     minionIdTd.appendChild(minionIdSpan);
-    if(pMinionsTxt && pMinionsTxt.length && !pMinionsTxt.includes(pMinionId)) {
+    if(Object.keys(pMinionsTxt).length && !Object.keys(pMinionsTxt).includes(pMinionId)) {
       Utils.addToolTip(minionIdSpan, "Unexpected entry\nThis entry may need to be rejected!\nUpdate file 'minions.txt' when needed", "bottom-left");
       minionIdTd.style.color = "red";
       minionIdTd.style.fontWeight = "bold";
@@ -216,7 +206,7 @@ export class KeysRoute extends PageRoute {
     const minionIdTd = Route.createTd("", "");
     const minionIdSpan = Route.createSpan("minion-id", pMinionId);
     minionIdTd.appendChild(minionIdSpan);
-    if(pMinionsTxt.length && !pMinionsTxt.includes(pMinionId)) {
+    if(Object.keys(pMinionsTxt).length && !Object.keys(pMinionsTxt).includes(pMinionId)) {
       Utils.addToolTip(minionIdSpan, "Unexpected entry\nBut it is already rejected\nUpdate file 'minions.txt' when needed", "bottom-left");
       minionIdTd.style.color = "red";
     }
@@ -245,7 +235,7 @@ export class KeysRoute extends PageRoute {
     const minionIdTd = Route.createTd("", "");
     const minionIdSpan = Route.createSpan("minion-id", pMinionId);
     minionIdTd.appendChild(minionIdSpan);
-    if(pMinionsTxt.length && !pMinionsTxt.includes(pMinionId)) {
+    if(Object.keys(pMinionsTxt).length && !Object.keys(pMinionsTxt).includes(pMinionId)) {
       Utils.addToolTip(minionIdSpan, "Unexpected entry\nBut it is already denied\nUpdate file 'minions.txt' when needed", "bottom-left");
       minionIdTd.style.color = "red";
     }
@@ -275,7 +265,7 @@ export class KeysRoute extends PageRoute {
     const minionIdTd = Route.createTd("", "");
     const minionIdSpan = Route.createSpan("minion-id", pMinionId);
     minionIdTd.appendChild(minionIdSpan);
-    if(pMinionsTxt.length && !pMinionsTxt.includes(pMinionId)) {
+    if(Object.keys(pMinionsTxt).length && !Object.keys(pMinionsTxt).includes(pMinionId)) {
       Utils.addToolTip(minionIdSpan, "Unexpected entry\nDo not accept this entry without proper verification!\nUpdate file 'minions.txt' when needed", "bottom-left");
       minionIdTd.style.color = "red";
       minionIdTd.style.fontWeight = "bold";

--- a/saltgui/static/scripts/routes/Minions.js
+++ b/saltgui/static/scripts/routes/Minions.js
@@ -22,6 +22,8 @@ export class MinionsRoute extends PageRoute {
     const runnerJobsListJobsPromise = this.router.api.getRunnerJobsListJobs();
     const runnerJobsActivePromise = this.router.api.getRunnerJobsActive();
 
+    this.loadMinionsTxt();
+
     wheelKeyListAllPromise.then(pWheelKeyListAllData => {
       myThis._handleMinionsWheelKeyListAll(pWheelKeyListAllData);
       localGrainsItemsPromise.then(pLocalGrainsItemsData => {
@@ -77,8 +79,8 @@ export class MinionsRoute extends PageRoute {
     msgDiv.innerText = txt;
   }
 
-  updateOfflineMinion(pContainer, pMinionId) {
-    super.updateOfflineMinion(pContainer, pMinionId);
+  updateOfflineMinion(pContainer, pMinionId, pMinionTxt) {
+    super.updateOfflineMinion(pContainer, pMinionId, pMinionTxt);
 
     const minionTr = pContainer.querySelector("#" + Utils.getIdFromMinionId(pMinionId));
 

--- a/saltgui/static/scripts/routes/Page.js
+++ b/saltgui/static/scripts/routes/Page.js
@@ -23,6 +23,8 @@ export class PageRoute extends Route {
     const table = this.getPageElement().querySelector("#minions");
     const minionIds = Object.keys(minions).sort();
 
+    const minionsTxt = JSON.parse(window.sessionStorage.getItem("minions-txt"));
+
     // save for the autocompletion
     // This callback will also be called after LOGOUT due to the regular error handling
     // Do not store the information in that case
@@ -39,7 +41,7 @@ export class PageRoute extends Route {
 
       // minions can be offline, then the info will be false
       if(minionInfo === false) {
-        this.updateOfflineMinion(table, minionId);
+        this.updateOfflineMinion(table, minionId, minionsTxt);
         cntOffline++;
       } else {
         this.updateMinion(table, minionInfo, minionId, minions);
@@ -78,12 +80,21 @@ export class PageRoute extends Route {
     return minionTr;
   }
 
-  updateOfflineMinion(pContainer, pMinionId) {
+  updateOfflineMinion(pContainer, pMinionId, pMinionsTxt) {
     const minionTr = this.getElement(pContainer, Utils.getIdFromMinionId(pMinionId));
 
     minionTr.appendChild(Route.createTd("minion-id", pMinionId));
 
     const offline = Route.createTd("status", "offline");
+    // add an opinion when we have one
+    if(pMinionId in pMinionsTxt) {
+      if (pMinionsTxt[pMinionId] === "true") {
+        Utils.addToolTip(offline, "Minion is offline\nIs the host running and is the salt-minion installed and started?\nUpdate file 'minions.txt' when needed", "bottom-left");
+        offline.style.color = "red";
+      } else {
+        Utils.addToolTip(offline, "Minion is offline\nSince it is reported as inactive in file 'minions.txt', that should be OK", "bottom-left");
+      }
+    }
     offline.classList.add("offline");
     minionTr.appendChild(offline);
   }
@@ -625,5 +636,28 @@ export class PageRoute extends Route {
     if(msgDiv !== null) msgDiv.style.display = "none";
 
     return true;
+  }
+
+  loadMinionsTxt() {
+    const staticMinionsTxtPromise = this.router.api.getStaticMinionsTxt();
+
+    staticMinionsTxtPromise.then(pStaticMinionsTxt => {
+      if(!pStaticMinionsTxt)
+        window.sessionStorage.setItem("minions-txt", "{}");
+      else {
+        const lines = pStaticMinionsTxt.trim().split(/\r?\n/).filter(item => !item.startsWith("#"));
+        const minions = { };
+        for(const line of lines) {
+          const fields = line.split("\t");
+          if(fields.length === 1)
+            minions[fields[0]] = "true";
+          else
+            minions[fields[0]] = fields[1];
+        }
+        window.sessionStorage.setItem("minions-txt", JSON.stringify(minions));
+      }
+    }, pStaticMinionsTxt => {
+      window.sessionStorage.setItem("minions-txt", "{}");
+    });
   }
 }

--- a/saltgui/static/scripts/routes/Pillars.js
+++ b/saltgui/static/scripts/routes/Pillars.js
@@ -76,8 +76,8 @@ export class PillarsRoute extends PageRoute {
     msgDiv.innerText = txt;
   }
 
-  updateOfflineMinion(pContainer, pMinionId) {
-    super.updateOfflineMinion(pContainer, pMinionId);
+  updateOfflineMinion(pContainer, pMinionId, pMinionTxt) {
+    super.updateOfflineMinion(pContainer, pMinionId, pMinionTxt);
 
     const minionTr = pContainer.querySelector("#" + Utils.getIdFromMinionId(pMinionId));
 

--- a/saltgui/static/scripts/routes/Schedules.js
+++ b/saltgui/static/scripts/routes/Schedules.js
@@ -107,8 +107,8 @@ export class SchedulesRoute extends PageRoute {
     msgDiv.innerText = txt;
   }
 
-  updateOfflineMinion(pContainer, pMinionId) {
-    super.updateOfflineMinion(pContainer, pMinionId);
+  updateOfflineMinion(pContainer, pMinionId, pMinionTxt) {
+    super.updateOfflineMinion(pContainer, pMinionId, pMinionTxt);
 
     const minionTr = pContainer.querySelector("#" + Utils.getIdFromMinionId(pMinionId));
 


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
In a cloud environment, hosts (containing salt minions) may be shut down to save money.
But Salt (and thus SaltGUI) cannot see the difference between a deleted node and a node that is shutdown.

**Describe the solution you'd like**
Use the `minions.txt` file also to register whether the machine is running or not.
That information is then used as additional information for the presentation.
A new optional second column can be added that gives a clue about the status of the machine.
true=alive, false=shutdown(or known to unreachable, etc).
SaltGUI adjusts its complaints based on this.

**Describe alternatives you've considered**
* direct api on cloud provider. this is too much work and administration. must be constantly updated. it needs a specific solution per cloud provider.
* do nothing