### PR TITLE
make the cmd-run button a true circle

### DIFF
--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -50,9 +50,9 @@
         <div class='menu-item' id='button-logout1'>logout</div>
       </div>
 <!-- mini menu -->
-      <svg class='fab' id='button-manual-run' width="44" height="44">
-        <circle cx="22" cy="22" r="22" fill="#4caf50" />
-        <text fill="white" font-weight="bold" font-size="25" x="8" y="27">&gt;_</text>
+      <svg class='fab' id='button-manual-run' width="36" height="36">
+        <circle cx="18" cy="18" r="18" fill="#4caf50" />
+        <text fill="white" font-weight="bold" font-size="20" x="6" y="23">&gt;_</text>
       </svg>
       <div class="minimenu">
         <div class="dropdown">

--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -50,9 +50,9 @@
         <div class='menu-item' id='button-logout1'>logout</div>
       </div>
 <!-- mini menu -->
-      <svg class='fab' id='button-manual-run' width="36" height="36">
-        <circle cx="18" cy="18" r="18" fill="#4caf50" />
-        <text fill="white" font-weight="bold" font-size="20" x="6" y="23">&gt;_</text>
+      <svg class='fab' width="36" height="36">
+        <circle id='button-manual-run'  cx="18" cy="18" r="18" fill="#4caf50" />
+        <text style='pointer-events: none' fill="white" font-weight="bold" font-size="20" x="6" y="23">&gt;_</text>
       </svg>
       <div class="minimenu">
         <div class="dropdown">

--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -50,7 +50,10 @@
         <div class='menu-item' id='button-logout1'>logout</div>
       </div>
 <!-- mini menu -->
-      <div class='fab' id='button-manual-run'>&gt;_</div>
+      <svg class='fab' id='button-manual-run' width="44" height="44">
+        <circle cx="22" cy="22" r="22" fill="#4caf50" />
+        <text fill="white" font-weight="bold" font-size="25" x="8" y="27">&gt;_</text>
+      </svg>
       <div class="minimenu">
         <div class="dropdown">
           <!-- 2261 = MATHEMATICAL OPERATOR IDENTICAL TO (aka "hamburger") -->

--- a/saltgui/static/stylesheets/main.css
+++ b/saltgui/static/stylesheets/main.css
@@ -74,14 +74,7 @@ h1 {
 }
 
 .fab {
-  background-color: #4caf50;
-  padding: 5px 18px 17px 14px;
   display: block;
-  font-weight: bold;
-  font-size: 18px;
-  border-radius: 50%;
-  color: white;
-  transform: scale(0.8) translate(23px, -2px);
   cursor: pointer;
   float: right;
   margin-top: 4px;

--- a/saltgui/static/stylesheets/main.css
+++ b/saltgui/static/stylesheets/main.css
@@ -75,14 +75,14 @@ h1 {
 
 .fab {
   display: block;
-  cursor: pointer;
   float: right;
   margin-top: 8px;
   margin-right: 8px;
 }
 
-.fab:hover {
+#button-manual-run {
   opacity: 0.8;
+  cursor: pointer;
 }
 
 .search-button {

--- a/saltgui/static/stylesheets/main.css
+++ b/saltgui/static/stylesheets/main.css
@@ -77,8 +77,8 @@ h1 {
   display: block;
   cursor: pointer;
   float: right;
-  margin-top: 4px;
-  margin-right: 20px;
+  margin-top: 8px;
+  margin-right: 8px;
 }
 
 .fab:hover {


### PR DESCRIPTION
Problem:
The current run-button is built from the text `>_`, which is given an html-border.
That border is relatively thick and seems to form a circle.
However, it is not a circle as it is just a border around `>_`.
It looks like:
![before](https://user-images.githubusercontent.com/3663742/103111839-696d5400-4651-11eb-960b-db4d5746bcc0.png)

Solution:
Style the run-button as SVG
It now looks like:
![after](https://user-images.githubusercontent.com/3663742/103111844-74c07f80-4651-11eb-9c27-6288fa3f0685.png)