### PR TITLE
refresh job without reload

### DIFF
--- a/saltgui/static/scripts/Utils.js
+++ b/saltgui/static/scripts/Utils.js
@@ -455,10 +455,12 @@ export class Utils {
     return false;
   }
 
-  static createJobStatusSpan (pJobId) {
+  static createJobStatusSpan (pJobId, pInitialDisplay) {
     const span = Utils.createSpan("", "", "status" + pJobId);
     span.innerText = Character.CLOCKWISE_OPEN_CIRCLE_ARROW + Character.NO_BREAK_SPACE;
-    span.style.display = "none";
+    if (!pInitialDisplay) {
+      span.style.display = "none";
+    }
     span.style.fontWeight = "bold";
     return span;
   }

--- a/saltgui/static/scripts/panels/Job.js
+++ b/saltgui/static/scripts/panels/Job.js
@@ -1,4 +1,4 @@
-/* global document window */
+/* global document */
 
 import {DropDownMenu} from "../DropDown.js";
 import {Output} from "../output/Output.js";
@@ -440,7 +440,9 @@ export class JobPanel extends Panel {
     summaryJobsActiveSpan.innerText = info.Running.length + " active";
     summaryJobsActiveSpan.insertBefore(Utils.createJobStatusSpan(pJobId, true), summaryJobsActiveSpan.firstChild);
     summaryJobsActiveSpan.addEventListener("click", () => {
-      window.location.reload();
+      this.output.innerText = "loading...";
+      this.onShow();
+      this.panelMenu.verifyAll();
     });
     summaryJobsActiveSpan.style.cursor = "pointer";
     Utils.addToolTip(summaryJobsActiveSpan, "Click to refresh", "bottom-left");

--- a/saltgui/static/scripts/panels/Job.js
+++ b/saltgui/static/scripts/panels/Job.js
@@ -438,7 +438,7 @@ export class JobPanel extends Panel {
     this.jobIsTerminated = false;
 
     summaryJobsActiveSpan.innerText = info.Running.length + " active";
-    summaryJobsActiveSpan.insertBefore(Utils.createJobStatusSpan(pJobId), summaryJobsActiveSpan.firstChild);
+    summaryJobsActiveSpan.insertBefore(Utils.createJobStatusSpan(pJobId, true), summaryJobsActiveSpan.firstChild);
     summaryJobsActiveSpan.addEventListener("click", () => {
       window.location.reload();
     });

--- a/saltgui/static/scripts/panels/Jobs.js
+++ b/saltgui/static/scripts/panels/Jobs.js
@@ -92,7 +92,7 @@ export class JobsPanel extends Panel {
       }
       targetField.classList.remove("no-job-status");
       targetField.innerText = targetText;
-      targetField.insertBefore(Utils.createJobStatusSpan(jobId), targetField.firstChild);
+      targetField.insertBefore(Utils.createJobStatusSpan(jobId, true), targetField.firstChild);
       Utils.addToolTip(targetField, "Click to refresh column");
     }
 

--- a/saltgui/static/scripts/panels/JobsDetails.js
+++ b/saltgui/static/scripts/panels/JobsDetails.js
@@ -257,7 +257,8 @@ export class JobsDetailsPanel extends JobsPanel {
     }
 
     detailsSpan.innerText = "";
-    detailsSpan.appendChild(Utils.createJobStatusSpan(pJobId));
+    const span = Utils.createJobStatusSpan(pJobId, keyCount !== pData.Minions.length);
+    detailsSpan.appendChild(span);
     const statusSpan = Utils.createSpan();
     statusSpan.innerHTML = detailsHTML;
     detailsSpan.appendChild(statusSpan);


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
When viewing a job that has not completely finished, one can click on the first few words from the output to refresh the screen. this refreshed the whole screen.

**Describe the solution you'd like**
Refresh only the output area without reloading the page.

**Additional context**
See also #346.