### PR TITLE
Add support for creating templates from SaltGUI directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ Note that the effect is achieved by string truncation only. This is equivalent t
 ## Templates
 SaltGUI supports command templates for easier command entry into the command-box.
 The menu item for that becomes visible there when you define one or more templates
-in salt master configuration file `/etc/salt/master`.
+in salt master configuration file `/etc/salt/master` or when you have saved
+the values of the command-box as a template.
 The field `targettype` supports the values `glob`, `list`, `compound` and `nodegroup`.
 Entries will be sorted in the GUI based on their key.
 You can leave out any detail field.
@@ -138,6 +139,8 @@ saltgui_templates:
         target: dev*
         command: test.version
 ```
+Templates that are defined in the `master` file are immutable. Local templates
+are stored in the user's browser and can be created, updated and deleted.
 
 
 ## Jobs

--- a/saltgui/static/salt-templates.json
+++ b/saltgui/static/salt-templates.json
@@ -1,0 +1,17 @@
+{
+"template3": {
+  "description": "Third template",
+  "target": "#*",
+  "command": "test.fib num=10"
+  },
+"template4": {
+  "description": "Fourth template",
+  "target": "xev*",
+  "command": "test.version"
+  },
+"template5": {
+  "description": "Fifth template",
+  "target": "xev*",
+  "command": "test.version"
+  }
+}

--- a/saltgui/static/scripts/Api.js
+++ b/saltgui/static/scripts/Api.js
@@ -40,10 +40,12 @@ export class API {
   }
 
   static _cleanStorage () {
-    // clear local storage except key 'eauth'
+    // clear local storage except key 'eauth' and 'templates'
     const eauth = Utils.getStorageItem("local", "eauth");
+    const templates = Utils.getStorageItem("local", "templates");
     Utils.clearStorage("local");
     Utils.setStorageItem("local", "eauth", eauth);
+    Utils.setStorageItem("local", "templates", templates);
 
     // clear all of session storage
     Utils.clearStorage("session");

--- a/saltgui/static/scripts/CommandBox.js
+++ b/saltgui/static/scripts/CommandBox.js
@@ -4,10 +4,12 @@ import {Character} from "./Character.js";
 import {Documentation} from "./Documentation.js";
 import {DropDownMenu} from "./DropDown.js";
 import {Output} from "./output/Output.js";
+import {Panel} from "./panels/Panel.js";
 import {ParseCommandLine} from "./ParseCommandLine.js";
 import {Router} from "./Router.js";
 import {RunType} from "./RunType.js";
 import {TargetType} from "./TargetType.js";
+import {TemplatesPanel} from "./panels/Templates.js";
 import {Utils} from "./Utils.js";
 
 export class CommandBox {
@@ -17,9 +19,9 @@ export class CommandBox {
     this.api = pApi;
 
     const cmdbox = document.getElementById("cmd-box");
-    this.cmdmenu = new DropDownMenu(cmdbox);
+    CommandBox.cmdmenu = new DropDownMenu(cmdbox);
 
-    this.documentation = new Documentation(this.router, this);
+    this.documentation = new Documentation(this.router);
     this._registerCommandBoxEventListeners();
 
     RunType.createMenu();
@@ -36,27 +38,59 @@ export class CommandBox {
 
   static _populateTemplateMenu () {
     const titleElement = document.getElementById("template-menu-here");
+
     if (titleElement.childElementCount) {
       // only build one dropdown menu. cannot be done in constructor
       // since the storage-item is then not populated yet.
       return;
     }
+
     const menu = new DropDownMenu(titleElement);
-    const templatesText = Utils.getStorageItem("session", "templates", "{}");
-    const templates = JSON.parse(templatesText);
-    const keys = Object.keys(templates).sort();
-    for (const key of keys) {
-      const template = templates[key];
-      let description = template["description"];
-      if (!description) {
-        description = "(" + key + ")";
-      }
-      menu.addMenuItem(
-        description,
-        () => {
-          CommandBox._applyTemplate(template);
+
+    menu.addMenuItem(
+      () => {
+        const command = document.getElementById("command").value;
+        const cmd = ParseCommandLine.getCommandFromCommandLine(command);
+        if (cmd && typeof cmd === "string" && cmd.startsWith("#")) {
+          // do not allow internal commands to be saved as template
+          return null;
         }
-      );
+        return "Save as template";
+      }, () => {
+        const cmdArr = [
+          "#template.save",
+          "name=", "<name>",
+          "description=", "<description>",
+          "targettype=", TargetType.menuTargetType._value,
+          "target=", document.getElementById("target").value,
+          "command=", document.getElementById("command").value
+        ];
+
+        document.getElementById("target").value = "";
+        document.getElementById("command").value = Panel.makeCommandString(cmdArr);
+        TargetType.setTargetTypeDefault();
+        CommandBox.cmdmenu.verifyAll();
+      }
+    );
+
+    for (const loc of ["session", "local"]) {
+      const templatesText = Utils.getStorageItem(loc, "templates", "{}");
+      const templates = JSON.parse(templatesText);
+      const keys = Object.keys(templates).sort();
+      for (const key of keys) {
+        const template = templates[key];
+        const label = loc === "session" ? "master" : "local";
+        let description = label + ": " + template["description"];
+        if (!description) {
+          description = "(" + key + ")";
+        }
+        menu.addMenuItem(
+          description,
+          () => {
+            CommandBox._applyTemplate(template);
+          }
+        );
+      }
     }
   }
 
@@ -170,7 +204,7 @@ export class CommandBox {
 
     document.getElementById("command").
       addEventListener("input", () => {
-        this.cmdmenu.verifyAll();
+        CommandBox.cmdmenu.verifyAll();
       });
   }
 
@@ -201,6 +235,8 @@ export class CommandBox {
       const commandField = document.getElementById("command");
       commandField.value = template.command;
     }
+
+    CommandBox.cmdmenu.verifyAll();
   }
 
   static getScreenModifyingCommands () {
@@ -461,7 +497,8 @@ export class CommandBox {
     // WHEEL commands also do not have a target
     // but we use the TARGET value to form the usually required MATCH parameter
     // therefore for WHEEL commands it is still required
-    if (pTarget === "" && functionToRun !== "runners" && !functionToRun.startsWith("runners.")) {
+    // internal commands also do not need a target
+    if (pTarget === "" && functionToRun !== "runners" && !functionToRun.startsWith("runners.") && !functionToRun.startsWith("#")) {
       CommandBox._showError("'Target' field cannot be empty");
       return null;
     }
@@ -475,6 +512,27 @@ export class CommandBox {
         CommandBox._showError("Unknown nodegroup '" + pTarget + "'");
         return null;
       }
+    }
+
+    if (functionToRun.startsWith("#")) {
+      if (pTarget) {
+        CommandBox._showError("Internal commands cannot use a target value");
+        return null;
+      }
+      if (argsArray.length > 0) {
+        CommandBox._showError("Internal commands cannot use unnamed parameters");
+        return null;
+      }
+      if (functionToRun === "#template.delete") {
+        TemplatesPanel.runDelete(argsObject);
+        return null;
+      }
+      if (functionToRun === "#template.save") {
+        TemplatesPanel.runSave(argsObject);
+        return null;
+      }
+      CommandBox._showError("Unknown internal command '" + functionToRun + "'");
+      return null;
     }
 
     let params = {};

--- a/saltgui/static/scripts/Documentation.js
+++ b/saltgui/static/scripts/Documentation.js
@@ -13,17 +13,16 @@ export class Documentation {
   // formatting of the documentation is done as a regular output type
   // that is therefore in output.js
 
-  constructor (pRouter, pCommandBox) {
+  constructor (pRouter) {
     this.router = pRouter;
-    this.commandbox = pCommandBox;
 
-    pCommandBox.cmdmenu.addMenuItem(
+    CommandBox.cmdmenu.addMenuItem(
       () => Documentation._manualRunMenuSysDocPrepare(),
       () => this._manualRunMenuSysDocRun());
-    pCommandBox.cmdmenu.addMenuItem(
+    CommandBox.cmdmenu.addMenuItem(
       () => Documentation._manualRunMenuHtmlDocPrepare(),
       () => Documentation._manualRunMenuHtmlDocRun());
-    pCommandBox.cmdmenu.addMenuItem(
+    CommandBox.cmdmenu.addMenuItem(
       () => Documentation._manualRunMenuBeaconNamePrepare(),
       () => Documentation._manualRunMenuBeaconNameRun());
 
@@ -57,6 +56,11 @@ export class Documentation {
     }
 
     const cmdFragments = Documentation.getKeywordFragments(commandLine);
+
+    if (cmdFragments.length >= 2 && cmdFragments[1].startsWith("#")) {
+      // no documentation available for internal commands like '#template.save'
+      return null;
+    }
 
     const category = cmdFragments.shift();
     let arg = "";
@@ -236,6 +240,10 @@ export class Documentation {
   static _manualRunMenuHtmlDocPrepare () {
     const commandLine = document.querySelector(".run-command #command").value;
     const cmd = Documentation.getKeywordFragments(commandLine);
+    if (cmd.length >= 2 && cmd[1].startsWith("#")) {
+      // no documentation available for internal commands like '#template.save'
+      return null;
+    }
     return "Online reference for '" + cmd.join(".").replace(/^modules[.]/, "") + "'";
   }
 

--- a/saltgui/static/scripts/ParseCommandLine.js
+++ b/saltgui/static/scripts/ParseCommandLine.js
@@ -30,7 +30,7 @@ export class ParseCommandLine {
 
   static parseCommandLine (pToRun, pArgsArray, pArgsObject) {
 
-    const patPlaceHolder = /^<[a-z]+>/;
+    const patPlaceHolder = /^"?<[a-z]+>"?/;
 
     // note that "none" is not case-insensitive, but "null" is
     const patNull = /^(?:None|null|Null|NULL)$/;
@@ -64,7 +64,7 @@ export class ParseCommandLine {
       }
 
       if (patPlaceHolder.test(pToRun)) {
-        const placeHolder = pToRun.replace(/>.*/, ">");
+        const placeHolder = pToRun.replace(/.*</, "<").replace(/>.*/, ">");
         return "Must fill in all placeholders, e.g. " + placeHolder;
       }
 

--- a/saltgui/static/scripts/TargetType.js
+++ b/saltgui/static/scripts/TargetType.js
@@ -116,7 +116,7 @@ export class TargetType {
 
   static setTargetType (pTargetType) {
     TargetType.menuTargetType._value = pTargetType;
-    TargetType.menuTargetType._system = true;
+    TargetType.menuTargetType._system = false;
     TargetType._updateTargetTypeText();
   }
 

--- a/saltgui/static/scripts/panels/Panel.js
+++ b/saltgui/static/scripts/panels/Panel.js
@@ -688,7 +688,7 @@ export class Panel {
         commandString += cmd;
         continue;
       }
-      if (cmd.match(/^[a-z_][a-z0-9_]*(?:[.][a-z0-9_]+)*$/i)) {
+      if (cmd.match(/^#*[a-z_][a-z0-9_]*(?:[.][a-z0-9_]+)*$/i)) {
         // It's a simple string or a command
         commandString += cmd;
         continue;
@@ -749,7 +749,7 @@ export class Panel {
     target.value = pTargetString;
     command.value = pCommandString;
     // the menu may become (in)visible due to content of command field
-    this.router.commandbox.cmdmenu.verifyAll();
+    CommandBox.cmdmenu.verifyAll();
   }
 
   clearPanel () {

--- a/saltgui/static/scripts/panels/Templates.js
+++ b/saltgui/static/scripts/panels/Templates.js
@@ -12,7 +12,7 @@ export class TemplatesPanel extends Panel {
 
     this.addTitle("Templates");
     this.addSearchButton();
-    this.addTable(["Name", "Description", "Target", "Command", "-menu-"]);
+    this.addTable(["Name", "Location", "Description", "Target", "Command", "-menu-"]);
     this.setTableSortable("Name", "asc");
     this.setTableClickable();
     this.addMsg();
@@ -36,28 +36,36 @@ export class TemplatesPanel extends Panel {
     }
 
     // should we update it or just use from cache (see commandbox) ?
-    let templates = pWheelConfigValuesData.return[0].data.return.saltgui_templates;
-    if (templates) {
-      Utils.setStorageItem("session", "templates", JSON.stringify(templates));
+    let masterTemplates = pWheelConfigValuesData.return[0].data.return.saltgui_templates;
+    if (masterTemplates) {
+      Utils.setStorageItem("session", "templates", JSON.stringify(masterTemplates));
       Router.updateMainMenu();
     } else {
-      templates = {};
-    }
-    const keys = Object.keys(templates).sort();
-    for (const key of keys) {
-      const template = templates[key];
-      this._addTemplate(key, template);
+      masterTemplates = {};
     }
 
-    const txt = Utils.txtZeroOneMany(keys.length,
+    const masterKeys = Object.keys(masterTemplates).sort();
+    for (const key of masterKeys) {
+      const template = masterTemplates[key];
+      this._addTemplate("master", key, template);
+    }
+
+    const totalKeys = masterKeys.length;
+    let txt = Utils.txtZeroOneMany(totalKeys,
       "No templates", "{0} template", "{0} templates");
+    if (masterKeys.length > 0 && masterKeys.length !== totalKeys) {
+      txt += Utils.txtZeroOneMany(masterKeys.length,
+        "", ", {0} master template", ", {0} master templates");
+    }
     this.setMsg(txt);
   }
 
-  _addTemplate (pTemplateName, template) {
+  _addTemplate (pLocation, pTemplateName, template) {
     const tr = document.createElement("tr");
 
     tr.appendChild(Utils.createTd("name", pTemplateName));
+
+    tr.appendChild(Utils.createTd("location", pLocation));
 
     // calculate description
     const description = template["description"];


### PR DESCRIPTION
**Describe the solution you'd like**
It would be great if we could add a button "Save as template" from the command box dialog so that we could store the current command as a template in the local storage of the browser, so that the command can be easily replayed later on.  

