### PR TITLE
Add support for configuring which pages are displayed on SaltGUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ saltgui_pages:
     - keys
     - grains
 ```
-Note that this is NOT as security mechanism to reduce what a user can do.
+Note that this is NOT a security mechanism to reduce what a user can do.
 All pages are still accessible using their original deep-link.
 And also any command can still be issued using the command-box.
 For real security measures, use parameter `external_auth`.

--- a/README.md
+++ b/README.md
@@ -172,6 +172,27 @@ saltgui_public_pillars:
     - pub_.*
 ```
 
+## Reduced menus
+When api's are disabled using the native `external_auth` mechanism,
+SaltGUI may show menu-items that have become unuseable.
+In that case, it may be useful to reduce the menu-bar to less items.
+Variable `saltgui_pages` is read 
+from salt master configuration file `/etc/salt/master`.
+It contains the list of accessible pages per user.
+The first page in the list also becomes the landing page.
+Users that are not listed still have the full menu.
+e.g.:
+```
+saltgui_pages:
+  user1:
+    - keys
+    - grains
+```
+Note that this is NOT as security mechanism to reduce what a user can do.
+All pages are still accessible using their original deep-link.
+And also any command can still be issued using the command-box.
+For real security measures, use parameter `external_auth`.
+
 ## Performance
 SaltGUI does not have artificial restrictions.
 But displaying all data may be slow when there is a lot of data.

--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -21,7 +21,7 @@
   </head>
 
   <body>
-    <header id="header">
+    <header id="header" style="height: 53px">
       <h1 id="logo" class='logo'>SaltGUI</h1>
 <!-- full menu -->
       <div class="fullmenu"></div>

--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -24,31 +24,7 @@
     <header id="header">
       <h1 id="logo" class='logo'>SaltGUI</h1>
 <!-- full menu -->
-      <div class="fullmenu">
-        <div class="dropdown">
-          <div class="menu-item" id="button-minions1">minions</div>
-          <div class="dropdown-content">
-            <div class="run-command-button menu-item" id='button-grains1'>grains</div>
-            <div class="run-command-button menu-item" id='button-schedules1'>schedules</div>
-            <div class="run-command-button menu-item" id='button-pillars1'>pillars</div>
-            <div class="run-command-button menu-item" id='button-beacons1'>beacons</div>
-          </div>
-        </div>
-        <div class='menu-item' id='button-keys1'>keys</div>
-        <div class="dropdown">
-          <div class="menu-item" id="button-jobs1">jobs</div>
-          <div class="dropdown-content">
-            <div class='run-command-button menu-item' id='button-templates1'>templates</div>
-          </div>
-        </div>
-        <div class="dropdown">
-          <div class='menu-item' id='button-events1'>events</div>
-          <div class="dropdown-content">
-            <div class='run-command-button menu-item' id='button-reactors1'>reactors</div>
-          </div>
-        </div>
-        <div class='menu-item' id='button-logout1'>logout</div>
-      </div>
+      <div class="fullmenu"></div>
 <!-- mini menu -->
       <svg class='fab' width="36" height="36">
         <circle id='button-manual-run'  cx="18" cy="18" r="18" fill="#4caf50" />
@@ -58,19 +34,7 @@
         <div class="dropdown">
           <!-- 2261 = MATHEMATICAL OPERATOR IDENTICAL TO (aka "hamburger") -->
           <div class="menu-item">&#x2261;</div>
-          <div class="dropdown-content">
-            <div class="run-command-button menu-item" id="button-minions2">minions</div>
-            <div class="run-command-button menu-item" id='button-grains2'>-&nbsp;grains</div>
-            <div class="run-command-button menu-item" id='button-schedules2'>-&nbsp;schedules</div>
-            <div class="run-command-button menu-item" id='button-pillars2'>-&nbsp;pillars</div>
-            <div class="run-command-button menu-item" id='button-beacons2'>-&nbsp;beacons</div>
-            <div class='run-command-button menu-item' id='button-keys2'>keys</div>
-            <div class="run-command-button menu-item" id="button-jobs2">jobs</div>
-            <div class='run-command-button menu-item' id='button-templates2'>-&nbsp;templates</div>
-            <div class="run-command-button menu-item" id="button-events2">events</div>
-            <div class="run-command-button menu-item" id="button-reactors2">-&nbsp;reactors</div>
-            <div class='run-command-button menu-item' id='button-logout2'>logout</div>
-          </div>
+          <div class="dropdown-content"></div>
         </div>
       </div>
       <div id="warning" style="display: none"></div>

--- a/saltgui/static/scripts/Router.js
+++ b/saltgui/static/scripts/Router.js
@@ -153,6 +153,11 @@ export class Router {
       pQuery = {"reason": "no-session"};
     }
 
+    if (pPath === "/") {
+      // go to the concrete default page
+      pPath = "/minions";
+    }
+
     // save the details from the parent
     const parentHash = document.location.hash.replace(/^#/, "");
     const search = window.location.search;
@@ -201,6 +206,7 @@ export class Router {
       this._showPage(route);
       return;
     }
+
     // route could not be found
     // just go to the main page
     if (pHash === "") {

--- a/saltgui/static/scripts/Router.js
+++ b/saltgui/static/scripts/Router.js
@@ -119,10 +119,7 @@ export class Router {
     document.getElementById("logo").
       addEventListener("click", () => {
         if (window.event.ctrlKey) {
-          const pages = Router._getPagesList();
-          if (pages.length === 0 || pages.includes("options")) {
-            window.location.assign(config.NAV_URL + "/options");
-          }
+          window.location.assign(config.NAV_URL + "/options");
         } else {
           this.goTo("");
         }

--- a/saltgui/static/scripts/Router.js
+++ b/saltgui/static/scripts/Router.js
@@ -210,17 +210,21 @@ export class Router {
     if (pPages.length && !pPages.includes(pName)) {
       pVisible = false;
     }
+
     // still show a menu item when a child is visible
+    let hasVisibleChild = false;
     for (const page of pChildren) {
       if (pPages.includes(page)) {
-        pVisible = true;
+        hasVisibleChild = true;
         break;
       }
     }
+
     // perform the hiding/showing
     for (let nr = 1; nr <= 2; nr++) {
       const item = document.getElementById("button-" + pName + nr);
-      if (pVisible) {
+      item.style.color = !pVisible && hasVisibleChild ? "lightgray" : "black";
+      if (pVisible || hasVisibleChild) {
         item.classList.remove("menu-item-hidden");
       } else {
         item.classList.add("menu-item-hidden");

--- a/saltgui/static/scripts/Router.js
+++ b/saltgui/static/scripts/Router.js
@@ -55,7 +55,7 @@ export class Router {
 
     this._registerRouterEventListeners();
 
-    this.updateMainMenu();
+    Router.updateMainMenu();
 
     const hash = window.location.hash.replace(/^#/, "");
     const search = window.location.search;
@@ -109,7 +109,7 @@ export class Router {
         addEventListener("click", () => {
           const pages = Router._getPagesList();
           if (pUrl && (pages.length === 0 || pages.includes(pButtonId))) {
-            window.location.replace(config.NAV_URL + pUrl);
+            this.goTo(pUrl);
           }
         });
     }
@@ -119,7 +119,7 @@ export class Router {
     document.getElementById("logo").
       addEventListener("click", () => {
         if (window.event.ctrlKey) {
-          window.location.assign(config.NAV_URL + "/options");
+          this.goTo("options");
         } else {
           this.goTo("");
         }
@@ -135,7 +135,7 @@ export class Router {
       /* eslint-enable compat/compat */
     });
 
-    this._registerMenuItem(null, "minions", "");
+    this._registerMenuItem(null, "minions", "minions");
     this._registerMenuItem("minions", "grains", "grains");
     this._registerMenuItem("minions", "schedules", "schedules");
     this._registerMenuItem("minions", "pillars", "pillars");
@@ -152,22 +152,6 @@ export class Router {
     this.pages.push(pPage);
     if (pPage.onRegister) {
       pPage.onRegister();
-    }
-  }
-
-  updateMainMenu () {
-    for (const page of this.pages) {
-      const visible = page.constructor.isVisible();
-      for (const item of [page.menuItemElement1, page.menuItemElement2]) {
-        if (!item) {
-          // This page does not have a menu item
-          // e.g. login-page or grains-minion page
-        } else if (visible) {
-          item.classList.remove("menu-item-hidden");
-        } else {
-          item.classList.add("menu-item-hidden");
-        }
-      }
     }
   }
 
@@ -202,10 +186,13 @@ export class Router {
     return ret;
   }
 
-  static _showMenuItem (pPages, pName, pChildren = [], pVisible = true) {
+  static _showMenuItem (pPages, pName, pChildren = []) {
+    // assume the best
+    let visible = true;
+
     // do not show unwanted menu items
     if (pPages.length && !pPages.includes(pName)) {
-      pVisible = false;
+      visible = false;
     }
 
     // still show a menu item when a child is visible
@@ -220,8 +207,8 @@ export class Router {
     // perform the hiding/showing
     for (let nr = 1; nr <= 2; nr++) {
       const item = document.getElementById("button-" + pName + nr);
-      item.style.color = !pVisible && hasVisibleChild ? "lightgray" : "black";
-      if (pVisible || hasVisibleChild) {
+      item.style.color = !visible && hasVisibleChild ? "lightgray" : "black";
+      if (visible || hasVisibleChild) {
         item.classList.remove("menu-item-hidden");
       } else {
         item.classList.add("menu-item-hidden");
@@ -264,12 +251,12 @@ export class Router {
     }
 
     const pages = Router._getPagesList();
-    if (pPath === "/") {
+    if (!pHash) {
       // go to the concrete default page
       if (pages.length) {
-        pPath = "/" + pages[0];
+        pHash = pages[0];
       } else {
-        pPath = "/minions";
+        pHash = "minions";
       }
     }
 

--- a/saltgui/static/scripts/Router.js
+++ b/saltgui/static/scripts/Router.js
@@ -220,7 +220,7 @@ export class Router {
       menuItem.classList.remove("menu-item-active");
     });
 
-    const elem1 = pPage.menuItemElement1;
+    const elem1 = document.getElementById(pPage.menuItemElement1);
     if (elem1) {
       elem1.classList.add("menu-item-active");
       // activate also parent menu item if child element is selected
@@ -243,7 +243,7 @@ export class Router {
       }
     }
 
-    const elem2 = pPage.menuItemElement2;
+    const elem2 = document.getElementById(pPage.menuItemElement2);
     if (elem2) {
       elem2.classList.add("menu-item-active");
     }

--- a/saltgui/static/scripts/Router.js
+++ b/saltgui/static/scripts/Router.js
@@ -102,14 +102,16 @@ export class Router {
 
     // activate the menu items as needed
 
+    // conditions go inside the handler because the pages
+    // data may still being retrieved at this point
     for (const nr of ["1", "2"]) {
-      const button = document.getElementById("button-" + pButtonId + nr);
-      if (!button) {
-        continue;
-      }
-      button.addEventListener("click", () => {
-        window.location.replace(config.NAV_URL + pUrl);
-      });
+      document.getElementById("button-" + pButtonId + nr).
+        addEventListener("click", () => {
+          const pages = Router._getPagesList();
+          if (pUrl && (pages.length === 0 || pages.includes(pButtonId))) {
+            window.location.replace(config.NAV_URL + pUrl);
+          }
+        });
     }
   }
 

--- a/saltgui/static/scripts/Router.js
+++ b/saltgui/static/scripts/Router.js
@@ -232,10 +232,11 @@ export class Router {
     Router._showMenuItem(pages, "pillars");
     Router._showMenuItem(pages, "beacons");
     Router._showMenuItem(pages, "keys");
-    Router._showMenuItem(pages, "jobs", ["templates"], templatesText);
-    Router._showMenuItem(pages, "templates", [], templatesText);
-    Router._showMenuItem(pages, "events", ["reactors"], reactorsText);
-    Router._showMenuItem(pages, "reactors", [], reactorsText);
+    Router._showMenuItem(pages, "jobs", ["templates"]);
+    Router._showMenuItem(pages, "templates");
+    Router._showMenuItem(pages, "events", ["reactors"]);
+    Router._showMenuItem(pages, "reactors");
+    Router._showMenuItem(pages, "logout");
   }
 
   // pForward = 0 --> normal navigation

--- a/saltgui/static/scripts/Router.js
+++ b/saltgui/static/scripts/Router.js
@@ -222,13 +222,6 @@ export class Router {
   }
 
   static updateMainMenu () {
-
-    // show template menu item if templates defined
-    const templatesText = Utils.getStorageItem("session", "templates", "");
-
-    // show reactor menu item if reactors defined
-    const reactorsText = Utils.getStorageItem("session", "reactors", "");
-
     const pages = Router._getPagesList();
 
     Router._showMenuItem(pages, "minions", ["grains", "schedules", "pillars", "beacons"]);

--- a/saltgui/static/scripts/Router.js
+++ b/saltgui/static/scripts/Router.js
@@ -119,7 +119,10 @@ export class Router {
     document.getElementById("logo").
       addEventListener("click", () => {
         if (window.event.ctrlKey) {
-          this.goTo("options");
+          const pages = Router._getPagesList();
+          if (pages.length === 0 || pages.includes("options")) {
+            window.location.assign(config.NAV_URL + "/options");
+          }
         } else {
           this.goTo("");
         }

--- a/saltgui/static/scripts/Router.js
+++ b/saltgui/static/scripts/Router.js
@@ -103,10 +103,13 @@ export class Router {
     // activate the menu items as needed
 
     for (const nr of ["1", "2"]) {
-      document.getElementById("button-" + pButtonId + nr).
-        addEventListener("click", () => {
-          window.location.replace(config.NAV_URL + pUrl);
-        });
+      const button = document.getElementById("button-" + pButtonId + nr);
+      if (!button) {
+        continue;
+      }
+      button.addEventListener("click", () => {
+        window.location.replace(config.NAV_URL + pUrl);
+      });
     }
   }
 

--- a/saltgui/static/scripts/Router.js
+++ b/saltgui/static/scripts/Router.js
@@ -108,7 +108,7 @@ export class Router {
       document.getElementById("button-" + pButtonId + nr).
         addEventListener("click", () => {
           const pages = Router._getPagesList();
-          if (pUrl && (pages.length === 0 || pages.includes(pButtonId))) {
+          if (pUrl && (pButtonId === "logout" || pages.length === 0 || pages.includes(pButtonId))) {
             this.goTo(pUrl);
           }
         });
@@ -193,6 +193,11 @@ export class Router {
     // do not show unwanted menu items
     if (pPages.length && !pPages.includes(pName)) {
       visible = false;
+    }
+
+    // force visibility of the logout menuitem
+    if (pName === "logout") {
+      visible = true;
     }
 
     // still show a menu item when a child is visible

--- a/saltgui/static/scripts/pages/Minions.js
+++ b/saltgui/static/scripts/pages/Minions.js
@@ -7,7 +7,7 @@ import {Page} from "./Page.js";
 export class MinionsPage extends Page {
 
   constructor (pRouter) {
-    super("", "Minions", "page-minions", "button-minions", pRouter);
+    super("minions", "Minions", "page-minions", "button-minions", pRouter);
 
     this.minions = new MinionsPanel();
     super.addPanel(this.minions);

--- a/saltgui/static/scripts/pages/Page.js
+++ b/saltgui/static/scripts/pages/Page.js
@@ -23,8 +23,8 @@ export class Page {
     this.pageElement = div;
     this.router = pRouter;
     if (pMenuItemSelector) {
-      this.menuItemElement1 = document.getElementById(pMenuItemSelector + "1");
-      this.menuItemElement2 = document.getElementById(pMenuItemSelector + "2");
+      this.menuItemElement1 = pMenuItemSelector + "1";
+      this.menuItemElement2 = pMenuItemSelector + "2";
     }
 
     this.panels = [];

--- a/saltgui/static/scripts/panels/Login.js
+++ b/saltgui/static/scripts/panels/Login.js
@@ -1,6 +1,7 @@
 /* global document window */
 
 import {Panel} from "./Panel.js";
+import {Router} from "../Router.js";
 import {Utils} from "../Utils.js";
 
 export class LoginPanel extends Panel {
@@ -191,7 +192,7 @@ export class LoginPanel extends Panel {
 
     // We need these functions to populate the dropdown boxes
     wheelConfigValuesPromise.then((pWheelConfigValuesData) => {
-      this._handleLoginWheelConfigValues(pWheelConfigValuesData);
+      LoginPanel._handleLoginWheelConfigValues(pWheelConfigValuesData);
       return true;
     }, () => false);
 
@@ -204,7 +205,7 @@ export class LoginPanel extends Panel {
     }, 1000);
   }
 
-  _handleLoginWheelConfigValues (pWheelConfigValuesData) {
+  static _handleLoginWheelConfigValues (pWheelConfigValuesData) {
     const wheelConfigValuesData = pWheelConfigValuesData.return[0].data.return;
 
     // store for later use
@@ -253,7 +254,7 @@ export class LoginPanel extends Panel {
     const toolTipMode = wheelConfigValuesData.saltgui_tooltip_mode;
     Utils.setStorageItem("session", "tooltip_mode", toolTipMode);
 
-    this.router.updateMainMenu();
+    Router.updateMainMenu();
   }
 
   _onLoginFailure (error) {

--- a/saltgui/static/scripts/panels/Login.js
+++ b/saltgui/static/scripts/panels/Login.js
@@ -215,6 +215,9 @@ export class LoginPanel extends Panel {
     const reactors = wheelConfigValuesData.reactor;
     Utils.setStorageItem("session", "reactors", JSON.stringify(reactors));
 
+    const pages = wheelConfigValuesData.saltgui_pages;
+    Utils.setStorageItem("session", "pages", JSON.stringify(pages));
+
     const publicPillars = wheelConfigValuesData.saltgui_public_pillars;
     Utils.setStorageItem("session", "public_pillars", JSON.stringify(publicPillars));
 

--- a/saltgui/static/scripts/panels/Reactors.js
+++ b/saltgui/static/scripts/panels/Reactors.js
@@ -2,6 +2,7 @@
 
 import {Output} from "../output/Output.js";
 import {Panel} from "./Panel.js";
+import {Router} from "../Router.js";
 import {Utils} from "../Utils.js";
 
 export class ReactorsPanel extends Panel {
@@ -37,7 +38,7 @@ export class ReactorsPanel extends Panel {
     let reactors = pWheelConfigValuesData.return[0].data.return.reactor;
     if (reactors) {
       Utils.setStorageItem("session", "reactors", JSON.stringify(reactors));
-      this.router.updateMainMenu();
+      Router.updateMainMenu();
     } else {
       reactors = {};
     }

--- a/saltgui/static/scripts/panels/Templates.js
+++ b/saltgui/static/scripts/panels/Templates.js
@@ -2,6 +2,7 @@
 
 import {DropDownMenu} from "../DropDown.js";
 import {Panel} from "./Panel.js";
+import {Router} from "../Router.js";
 import {Utils} from "../Utils.js";
 
 export class TemplatesPanel extends Panel {
@@ -38,7 +39,7 @@ export class TemplatesPanel extends Panel {
     let templates = pWheelConfigValuesData.return[0].data.return.saltgui_templates;
     if (templates) {
       Utils.setStorageItem("session", "templates", JSON.stringify(templates));
-      this.router.updateMainMenu();
+      Router.updateMainMenu();
     } else {
       templates = {};
     }


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
I would like to allow some people in our team to access SaltGUI to run salt commands on the minions they are allowed to control, and it would be great to be able to hide the tabs they won't use.

**Describe the solution you'd like**
The best solution would be to have a way to configure which pages a user is allowed to see (maybe through extra configuration in the salt-master config like this is currently done for the templates feature), then based on this user config, SaltGUI could hide the pages that the user is not allowed to see.
