### PR TITLE
prevent each page from having its own "JobsPanel"

### DIFF
--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -40,9 +40,6 @@
       <div id="warning" style="display: none"></div>
     </header>
 
-    <div id='route-container'>
-    </div>
-
     <div class='popup' id='popup-run-command'>
       <div class='run-command'>
         <!-- 2716 = HEAVY MULTIPLICATION X -->
@@ -56,6 +53,9 @@
         <div id="run-block"><input id="run-command" type='submit' value="Run command"/></div>
         <pre id="popup-output" class='output'>Waiting for command...</pre>
       </div>
+    </div>
+
+    <div id='route-container' class="dashboard">
     </div>
 
     <datalist id="data-list-target">

--- a/saltgui/static/scripts/Api.js
+++ b/saltgui/static/scripts/Api.js
@@ -1,6 +1,7 @@
 /* global config EventSource window */
 
 import {CommandBox} from "./CommandBox.js";
+import {Page} from "./pages/Page.js";
 import {Utils} from "./Utils.js";
 
 export class HTTPError extends Error {
@@ -396,18 +397,8 @@ export class API {
         // return value
         CommandBox.handleSaltJobRetEvent(tag, data);
         pRouter.jobPage.handleSaltJobRetEvent(data);
-        pRouter.minionsPage.handleSaltJobRetEvent(data);
-        pRouter.grainsPage.handleSaltJobRetEvent(data);
-        pRouter.grainsMinionPage.handleSaltJobRetEvent(data);
-        pRouter.schedulesPage.handleSaltJobRetEvent(data);
-        pRouter.schedulesMinionPage.handleSaltJobRetEvent(data);
-        pRouter.pillarsPage.handleSaltJobRetEvent(data);
-        pRouter.pillarsMinionPage.handleSaltJobRetEvent(data);
-        pRouter.beaconsPage.handleSaltJobRetEvent(data);
-        pRouter.beaconsMinionPage.handleSaltJobRetEvent(data);
+        Page.handleSaltJobRetEvent(data);
         pRouter.jobsPage.handleSaltJobRetEvent(data);
-        pRouter.templatesPage.handleSaltJobRetEvent(data);
-        pRouter.reactorsPage.handleSaltJobRetEvent(data);
       } else if (tag.startsWith("salt/job/") && tag.includes("/prog/")) {
         // progress value (exists only for states)
         CommandBox.handleSaltJobProgEvent(tag, data);

--- a/saltgui/static/scripts/Router.js
+++ b/saltgui/static/scripts/Router.js
@@ -15,6 +15,7 @@ import {LoginPage} from "./pages/Login.js";
 import {LogoutPage} from "./pages/Logout.js";
 import {MinionsPage} from "./pages/Minions.js";
 import {OptionsPage} from "./pages/Options.js";
+import {Page} from "./pages/Page.js";
 import {PillarsMinionPage} from "./pages/PillarsMinion.js";
 import {PillarsPage} from "./pages/Pillars.js";
 import {ReactorsPage} from "./pages/Reactors.js";
@@ -346,6 +347,10 @@ export class Router {
       elem2.classList.add("menu-item-active");
     }
 
+    pPage.clearPage();
+
+    Router._hideShowPanels(pPage);
+
     pPage.onShow();
 
     // start the event-pipe (again)
@@ -360,16 +365,24 @@ export class Router {
     Router.currentPage.pageElement.classList.add("current");
   }
 
-  static _hidePage (pPage) {
-    const page = pPage.pageElement;
-    page.classList.remove("current");
+  static _hideShowPanels (pCurrentPage) {
     // 500ms matches the timeout in main.css (.route)
     window.setTimeout(() => {
-      // Hide element after fade, so it does not expand the body
-      page.style.display = "none";
+      let firstSeen = false;
+      for (const panel of Page.panels) {
+        if (pCurrentPage.panels.includes(panel)) {
+          panel.div.style.display = "";
+          panel.div.classList.add("current");
+          if (!firstSeen) {
+            panel.div.style.marginLeft = "0";
+            firstSeen = true;
+          }
+          continue;
+        }
+        // Hide element after fade, so it does not expand the body
+        panel.div.style.display = "none";
+        panel.div.classList.remove("current");
+      }
     }, 500);
-    if (pPage.onHide) {
-      pPage.onHide();
-    }
   }
 }

--- a/saltgui/static/scripts/pages/Beacons.js
+++ b/saltgui/static/scripts/pages/Beacons.js
@@ -1,21 +1,15 @@
 /* global */
 
 import {BeaconsPanel} from "../panels/Beacons.js";
-import {JobsSummaryPanel} from "../panels/JobsSummary.js";
 import {Page} from "./Page.js";
 
 export class BeaconsPage extends Page {
 
   constructor (pRouter) {
-    super("beacons", "Beacons", "page-beacons", "button-beacons", pRouter);
+    super("beacons", "Beacons", "button-beacons", pRouter);
 
     this.beacons = new BeaconsPanel();
     super.addPanel(this.beacons);
-    this.jobs = new JobsSummaryPanel();
-    super.addPanel(this.jobs);
-  }
-
-  handleSaltJobRetEvent (pData) {
-    this.jobs.handleSaltJobRetEvent(pData);
+    this.addJobsSummaryPanel();
   }
 }

--- a/saltgui/static/scripts/pages/BeaconsMinion.js
+++ b/saltgui/static/scripts/pages/BeaconsMinion.js
@@ -1,25 +1,19 @@
 /* global */
 
 import {BeaconsMinionPanel} from "../panels/BeaconsMinion.js";
-import {JobsSummaryPanel} from "../panels/JobsSummary.js";
 import {Page} from "./Page.js";
 
 export class BeaconsMinionPage extends Page {
 
   constructor (pRouter) {
-    super("beacons-minion", "Beacons", "page-beacons-minion", "button-beacons", pRouter);
+    super("beacons-minion", "Beacons", "button-beacons", pRouter);
 
     this.beaconsminion = new BeaconsMinionPanel();
     super.addPanel(this.beaconsminion);
-    this.jobs = new JobsSummaryPanel();
-    super.addPanel(this.jobs);
+    this.addJobsSummaryPanel();
   }
 
   handleSaltBeaconEvent (pTag, pData) {
     this.beaconsminion.handleSaltBeaconEvent(pTag, pData);
-  }
-
-  handleSaltJobRetEvent (pData) {
-    this.jobs.handleSaltJobRetEvent(pData);
   }
 }

--- a/saltgui/static/scripts/pages/Events.js
+++ b/saltgui/static/scripts/pages/Events.js
@@ -7,7 +7,7 @@ export class EventsPage extends Page {
 
   constructor (pRouter) {
     // don't use /events for the page, that url is reserved
-    super("eventsview", "Events", "page-events", "button-events", pRouter);
+    super("eventsview", "Events", "button-events", pRouter);
 
     this.events = new EventsPanel();
     super.addPanel(this.events);

--- a/saltgui/static/scripts/pages/Grains.js
+++ b/saltgui/static/scripts/pages/Grains.js
@@ -1,21 +1,15 @@
 /* global */
 
 import {GrainsPanel} from "../panels/Grains.js";
-import {JobsSummaryPanel} from "../panels/JobsSummary.js";
 import {Page} from "./Page.js";
 
 export class GrainsPage extends Page {
 
   constructor (pRouter) {
-    super("grains", "Grains", "page-grains", "button-grains", pRouter);
+    super("grains", "Grains", "button-grains", pRouter);
 
     this.grains = new GrainsPanel();
     super.addPanel(this.grains);
-    this.jobs = new JobsSummaryPanel();
-    super.addPanel(this.jobs);
-  }
-
-  handleSaltJobRetEvent (pData) {
-    this.jobs.handleSaltJobRetEvent(pData);
+    this.addJobsSummaryPanel();
   }
 }

--- a/saltgui/static/scripts/pages/GrainsMinion.js
+++ b/saltgui/static/scripts/pages/GrainsMinion.js
@@ -1,21 +1,15 @@
 /* global */
 
 import {GrainsMinionPanel} from "../panels/GrainsMinion.js";
-import {JobsSummaryPanel} from "../panels/JobsSummary.js";
 import {Page} from "./Page.js";
 
 export class GrainsMinionPage extends Page {
 
   constructor (pRouter) {
-    super("grains-minion", "Grains", "page-grains-minion", "button-grains", pRouter);
+    super("grains-minion", "Grains", "button-grains", pRouter);
 
     this.grainsminion = new GrainsMinionPanel();
     super.addPanel(this.grainsminion);
-    this.jobs = new JobsSummaryPanel();
-    super.addPanel(this.jobs);
-  }
-
-  handleSaltJobRetEvent (pData) {
-    this.jobs.handleSaltJobRetEvent(pData);
+    this.addJobsSummaryPanel();
   }
 }

--- a/saltgui/static/scripts/pages/Job.js
+++ b/saltgui/static/scripts/pages/Job.js
@@ -6,7 +6,7 @@ import {Page} from "./Page.js";
 export class JobPage extends Page {
 
   constructor (pRouter) {
-    super("job", "Job", "page-job", "button-jobs", pRouter);
+    super("job", "Job", "button-jobs", pRouter);
 
     this.job = new JobPanel();
     super.addPanel(this.job);

--- a/saltgui/static/scripts/pages/Jobs.js
+++ b/saltgui/static/scripts/pages/Jobs.js
@@ -6,7 +6,7 @@ import {Page} from "./Page.js";
 export class JobsPage extends Page {
 
   constructor (pRouter) {
-    super("jobs", "Jobs", "page-jobs", "button-jobs", pRouter);
+    super("jobs", "Jobs", "button-jobs", pRouter);
 
     this.jobs = new JobsDetailsPanel();
     super.addPanel(this.jobs);

--- a/saltgui/static/scripts/pages/Keys.js
+++ b/saltgui/static/scripts/pages/Keys.js
@@ -1,18 +1,16 @@
 /* global */
 
-import {JobsSummaryPanel} from "../panels/JobsSummary.js";
 import {KeysPanel} from "../panels/Keys.js";
 import {Page} from "./Page.js";
 
 export class KeysPage extends Page {
 
   constructor (pRouter) {
-    super("keys", "Keys", "page-keys", "button-keys", pRouter);
+    super("keys", "Keys", "button-keys", pRouter);
 
     this.keys = new KeysPanel();
     super.addPanel(this.keys);
-    this.jobs = new JobsSummaryPanel();
-    super.addPanel(this.jobs);
+    this.addJobsSummaryPanel();
   }
 
   handleSaltAuthEvent (pData) {
@@ -21,9 +19,5 @@ export class KeysPage extends Page {
 
   handleSaltKeyEvent (pData) {
     this.keys.handleSaltKeyEvent(pData);
-  }
-
-  handleSaltJobRetEvent (pData) {
-    this.jobs.handleSaltJobRetEvent(pData);
   }
 }

--- a/saltgui/static/scripts/pages/Login.js
+++ b/saltgui/static/scripts/pages/Login.js
@@ -6,7 +6,7 @@ import {Page} from "./Page.js";
 export class LoginPage extends Page {
 
   constructor (pRouter) {
-    super("login", "Login", "page-login", "", pRouter);
+    super("login", "Login", "", pRouter);
 
     this.login = new LoginPanel();
     this.login.router = pRouter;

--- a/saltgui/static/scripts/pages/Logout.js
+++ b/saltgui/static/scripts/pages/Logout.js
@@ -6,7 +6,7 @@ import {Utils} from "../Utils.js";
 export class LogoutPage extends Page {
 
   constructor (pRouter) {
-    super("logout", "Logout", "page-logout", "", pRouter);
+    super("logout", "Logout", "", pRouter);
   }
 
   onRegister () {

--- a/saltgui/static/scripts/pages/Minions.js
+++ b/saltgui/static/scripts/pages/Minions.js
@@ -1,6 +1,5 @@
 /* global */
 
-import {JobsSummaryPanel} from "../panels/JobsSummary.js";
 import {MinionsPanel} from "../panels/Minions.js";
 import {Page} from "./Page.js";
 
@@ -11,11 +10,6 @@ export class MinionsPage extends Page {
 
     this.minions = new MinionsPanel();
     super.addPanel(this.minions);
-    this.jobs = new JobsSummaryPanel();
-    super.addPanel(this.jobs);
-  }
-
-  handleSaltJobRetEvent (pData) {
-    this.jobs.handleSaltJobRetEvent(pData);
+    this.addJobsSummaryPanel();
   }
 }

--- a/saltgui/static/scripts/pages/Options.js
+++ b/saltgui/static/scripts/pages/Options.js
@@ -7,7 +7,7 @@ import {StatsPanel} from "../panels/Stats.js";
 export class OptionsPage extends Page {
 
   constructor (pRouter) {
-    super("options", "Options", "page-options", "", pRouter);
+    super("options", "Options", "", pRouter);
 
     this.options = new OptionsPanel();
     super.addPanel(this.options);

--- a/saltgui/static/scripts/pages/Pillars.js
+++ b/saltgui/static/scripts/pages/Pillars.js
@@ -1,21 +1,15 @@
 /* global */
 
-import {JobsSummaryPanel} from "../panels/JobsSummary.js";
 import {Page} from "./Page.js";
 import {PillarsPanel} from "../panels/Pillars.js";
 
 export class PillarsPage extends Page {
 
   constructor (pRouter) {
-    super("pillars", "Pillars", "page-pillars", "button-pillars", pRouter);
+    super("pillars", "Pillars", "button-pillars", pRouter);
 
     this.pillars = new PillarsPanel();
     super.addPanel(this.pillars);
-    this.jobs = new JobsSummaryPanel();
-    super.addPanel(this.jobs);
-  }
-
-  handleSaltJobRetEvent (pData) {
-    this.jobs.handleSaltJobRetEvent(pData);
+    this.addJobsSummaryPanel();
   }
 }

--- a/saltgui/static/scripts/pages/PillarsMinion.js
+++ b/saltgui/static/scripts/pages/PillarsMinion.js
@@ -1,21 +1,15 @@
 /* global */
 
-import {JobsSummaryPanel} from "../panels/JobsSummary.js";
 import {Page} from "./Page.js";
 import {PillarsMinionPanel} from "../panels/PillarsMinion.js";
 
 export class PillarsMinionPage extends Page {
 
   constructor (pRouter) {
-    super("pillars-minion", "Pillars", "page-pillars-minion", "button-pillars", pRouter);
+    super("pillars-minion", "Pillars", "button-pillars", pRouter);
 
     this.pillarsminion = new PillarsMinionPanel();
     super.addPanel(this.pillarsminion);
-    this.jobs = new JobsSummaryPanel();
-    super.addPanel(this.jobs);
-  }
-
-  handleSaltJobRetEvent (pData) {
-    this.jobs.handleSaltJobRetEvent(pData);
+    this.addJobsSummaryPanel();
   }
 }

--- a/saltgui/static/scripts/pages/Reactors.js
+++ b/saltgui/static/scripts/pages/Reactors.js
@@ -1,6 +1,5 @@
 /* global */
 
-import {JobsSummaryPanel} from "../panels/JobsSummary.js";
 import {Page} from "./Page.js";
 import {ReactorsPanel} from "../panels/Reactors.js";
 import {Utils} from "../Utils.js";
@@ -8,16 +7,11 @@ import {Utils} from "../Utils.js";
 export class ReactorsPage extends Page {
 
   constructor (pRouter) {
-    super("reactors", "Reactors", "page-reactors", "button-reactors", pRouter);
+    super("reactors", "Reactors", "button-reactors", pRouter);
 
     this.reactors = new ReactorsPanel();
     super.addPanel(this.reactors);
-    this.jobs = new JobsSummaryPanel();
-    super.addPanel(this.jobs);
-  }
-
-  handleSaltJobRetEvent (pData) {
-    this.jobs.handleSaltJobRetEvent(pData);
+    this.addJobsSummaryPanel();
   }
 
   static isVisible () {

--- a/saltgui/static/scripts/pages/Schedules.js
+++ b/saltgui/static/scripts/pages/Schedules.js
@@ -1,21 +1,15 @@
 /* global */
 
-import {JobsSummaryPanel} from "../panels/JobsSummary.js";
 import {Page} from "./Page.js";
 import {SchedulesPanel} from "../panels/Schedules.js";
 
 export class SchedulesPage extends Page {
 
   constructor (pRouter) {
-    super("schedules", "Schedules", "page-schedules", "button-schedules", pRouter);
+    super("schedules", "Schedules", "button-schedules", pRouter);
 
     this.schedules = new SchedulesPanel();
     super.addPanel(this.schedules);
-    this.jobs = new JobsSummaryPanel();
-    super.addPanel(this.jobs);
-  }
-
-  handleSaltJobRetEvent (pData) {
-    this.jobs.handleSaltJobRetEvent(pData);
+    this.addJobsSummaryPanel();
   }
 }

--- a/saltgui/static/scripts/pages/SchedulesMinion.js
+++ b/saltgui/static/scripts/pages/SchedulesMinion.js
@@ -1,21 +1,15 @@
 /* global */
 
-import {JobsSummaryPanel} from "../panels/JobsSummary.js";
 import {Page} from "./Page.js";
 import {SchedulesMinionPanel} from "../panels/SchedulesMinion.js";
 
 export class SchedulesMinionPage extends Page {
 
   constructor (pRouter) {
-    super("schedules-minion", "Schedules", "page-schedules-minion", "button-schedules", pRouter);
+    super("schedules-minion", "Schedules", "button-schedules", pRouter);
 
     this.schedulesminion = new SchedulesMinionPanel();
     super.addPanel(this.schedulesminion);
-    this.jobs = new JobsSummaryPanel();
-    super.addPanel(this.jobs);
-  }
-
-  handleSaltJobRetEvent (pData) {
-    this.jobs.handleSaltJobRetEvent(pData);
+    this.addJobsSummaryPanel();
   }
 }

--- a/saltgui/static/scripts/pages/Templates.js
+++ b/saltgui/static/scripts/pages/Templates.js
@@ -1,6 +1,5 @@
 /* global */
 
-import {JobsSummaryPanel} from "../panels/JobsSummary.js";
 import {Page} from "./Page.js";
 import {TemplatesPanel} from "../panels/Templates.js";
 import {Utils} from "../Utils.js";
@@ -8,16 +7,11 @@ import {Utils} from "../Utils.js";
 export class TemplatesPage extends Page {
 
   constructor (pRouter) {
-    super("templates", "Templates", "page-templates", "button-templates", pRouter);
+    super("templates", "Templates", "button-templates", pRouter);
 
     this.templates = new TemplatesPanel();
     super.addPanel(this.templates);
-    this.jobs = new JobsSummaryPanel();
-    super.addPanel(this.jobs);
-  }
-
-  handleSaltJobRetEvent (pData) {
-    this.jobs.handleSaltJobRetEvent(pData);
+    this.addJobsSummaryPanel();
   }
 
   static isVisible () {

--- a/saltgui/static/stylesheets/beacons.css
+++ b/saltgui/static/stylesheets/beacons.css
@@ -6,10 +6,6 @@ td.beacon-value {
   white-space: pre-wrap;
 }
 
-#page-beacons {
-  width: 100%;
-}
-
 .beacons {
   padding: 0;
 }

--- a/saltgui/static/stylesheets/events.css
+++ b/saltgui/static/stylesheets/events.css
@@ -6,7 +6,3 @@ td.event-data {
 #events-pause-button:hover {
   color: #4caf50;
 }
-
-#page-events {
-  width: 100%;
-}

--- a/saltgui/static/stylesheets/grains.css
+++ b/saltgui/static/stylesheets/grains.css
@@ -1,7 +1,3 @@
 td.grain-value {
   white-space: pre-wrap;
 }
-
-#page-grains {
-  width: 100%;
-}

--- a/saltgui/static/stylesheets/job.css
+++ b/saltgui/static/stylesheets/job.css
@@ -1,15 +1,11 @@
-#page-job .time {
+#job-panel .time {
   font-size: 15px;
   font-weight: normal;
   margin-top: 5px;
   margin-bottom: 5px;
 }
 
-#page-job .job-menu {
-  display: inline;
-}
-
-#page-job .highlight-task {
+#job-panel .highlight-task {
   background-color: gray;
 }
 

--- a/saltgui/static/stylesheets/keys.css
+++ b/saltgui/static/stylesheets/keys.css
@@ -1,7 +1,3 @@
-#page-keys {
-  width: 100%;
-}
-
 td.fingerprint {
   font-family: monospace;
   overflow: hidden;

--- a/saltgui/static/stylesheets/login.css
+++ b/saltgui/static/stylesheets/login.css
@@ -1,19 +1,7 @@
-#page-login {
-  display: flex;
-  justify-content: center;
-  width: 100%;
-  background-color: #263238;
-  position: absolute;
-  height: 100%;
-  top: 0;
-}
-
 #login-panel {
-  align-self: center;
-  background-color: white;
   padding: 0 50px;
-  box-shadow: 0 0 24px rgba(0, 0, 0, 0.7);
-  border-radius: 2px;
+  border-radius: 20px;
+  margin-top: 50px;
 }
 
 #login-panel h1 {

--- a/saltgui/static/stylesheets/main.css
+++ b/saltgui/static/stylesheets/main.css
@@ -26,7 +26,7 @@ header {
   font-weight: normal;
   display: block;
   float: left;
-  padding: 10px 20px 10px 20px;
+  padding: 10px 20px 6px 20px;
 
   /* prevent text selection */
   -webkit-user-select: none;
@@ -53,12 +53,17 @@ h1 {
   background-color: white;
   padding: 20px;
   border-radius: 1px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.5s; /* Can be used to add transitions between views */
 
   /* separate main-panel and jobs-panel */
   margin: 5px 0 0 5px;
 }
 
-.panel:first-of-type {
+.panel1 {
+  /* first-of-type cannot be used here
+     we need the first visible panel */
   margin-left: 0;
 }
 
@@ -162,18 +167,9 @@ h1 {
   padding: 5px 10px 5px 20px;
 }
 
-.route {
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.5s; /* Can be used to add transitions between views */
-  position: absolute;
-  width: 100%;
-}
-
-.route.current {
+.panel.current {
   opacity: 1;
   pointer-events: all;
-  z-index: 2;
 }
 
 .popup {

--- a/saltgui/static/stylesheets/page.css
+++ b/saltgui/static/stylesheets/page.css
@@ -1,14 +1,14 @@
-#page-minions {
-  width: 100%;
-}
-
 .dashboard {
+  width: 100%;
   display: flex;
-  align-items: flex-start;
 }
 
 .dashboard .panel {
   width: 100%;
+}
+
+.dashboard .panel#login-panel {
+  width: initial;
 }
 
 pre a.disabled {
@@ -226,18 +226,8 @@ table tr td:last-of-type {
   font-size: 12px;
 }
 
-#page-jobs .job-status {
+#jobs-panel .job-status {
   font-size: inherit;
-}
-
-#jobs-panel {
-  /* the left panel has the default 100%, therefore the ratio is 2/3 vs 1/3 */
-  flex-basis: 50%;
-}
-
-#page-jobs #jobs-panel {
-  /* no right panel here */
-  flex-basis: 100%;
 }
 
 .highlight-rows tbody tr:hover {

--- a/saltgui/static/stylesheets/pillars.css
+++ b/saltgui/static/stylesheets/pillars.css
@@ -1,7 +1,3 @@
-#page-pillars {
-  width: 100%;
-}
-
 .pillars {
   padding: 0;
 }

--- a/saltgui/static/stylesheets/schedules.css
+++ b/saltgui/static/stylesheets/schedules.css
@@ -1,7 +1,3 @@
-#page-schedules {
-  width: 100%;
-}
-
 td.schedule-value {
   white-space: pre-wrap;
 }


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Most pages consist of 2 panels, with the right-hand panel a (short) list of recent jobs.
However, it is is technically a different panel each time.

**Describe the solution you'd like**
There should only be one panel that is re-shown each time.

**Describe alternatives you've considered**
none

**Additional context**
This is only an issue since the migration to a Single Page Application (see #339).

Needs update of routing logic as this panel might appear on both the previous page and the next page.
The visibility of the panel is managed by `Router.js`.