### PR TITLE
use salt-api to determine connected minions

### DIFF
--- a/saltgui/static/scripts/Api.js
+++ b/saltgui/static/scripts/Api.js
@@ -216,6 +216,14 @@ export class API {
     return this.apiRequest("POST", "/", params);
   }
 
+  getWheelMinionsConnected () {
+    const params = {
+      "client": "wheel",
+      "fun": "minions.connected"
+    };
+    return this.apiRequest("POST", "/", params);
+  }
+
   getStats () {
     const params = {
     };

--- a/saltgui/static/scripts/CommandBox.js
+++ b/saltgui/static/scripts/CommandBox.js
@@ -442,6 +442,7 @@ export class CommandBox {
       params.client = "local";
       params.fun = functionToRun;
       params.tgt = pTarget;
+      params["full_return"] = true;
       if (pTargetType) {
         params["tgt_type"] = pTargetType;
       }
@@ -579,6 +580,7 @@ export class CommandBox {
       const minionDiv = document.createElement("div");
       minionDiv.id = "run-" + Utils.getIdFromMinionId(minionId);
       minionDiv.style.marginTop = 0;
+      minionDiv.classList.add("task-summary");
 
       const minionSpan1 = document.createElement("span");
       minionSpan1.innerText = minionId;

--- a/saltgui/static/scripts/output/Output.js
+++ b/saltgui/static/scripts/output/Output.js
@@ -303,6 +303,7 @@ export class Output {
   static _addHighStateSummary (pMinionRow, pMinionDiv, pMinionId, pTasks) {
 
     let nr = 0;
+    const summarySpan = Utils.createSpan("task-summary", "");
 
     for (const task of pTasks) {
 
@@ -343,13 +344,21 @@ export class Output {
         taskDiv.scrollIntoView({"behavior": "smooth", "block": "nearest"});
       });
 
-      pMinionRow.append(span);
+      summarySpan.append(span);
     }
+
+    pMinionRow.append(summarySpan);
   }
 
   static _getIsSuccess (pMinionResponse) {
+    if (!pMinionResponse) {
+      return false;
+    }
     if (Output._hasProperties(pMinionResponse, ["retcode", "return", "success"])) {
       return pMinionResponse.success;
+    }
+    if (Output._hasProperties(pMinionResponse, ["retcode", "ret", "jid"])) {
+      return pMinionResponse.retcode === 0;
     }
     return true;
   }
@@ -358,12 +367,18 @@ export class Output {
     if (Output._hasProperties(pMinionResponse, ["retcode", "return", "success"])) {
       return pMinionResponse.retcode;
     }
+    if (Output._hasProperties(pMinionResponse, ["retcode", "ret", "jid"])) {
+      return pMinionResponse.retcode;
+    }
     return 0;
   }
 
   static _getMinionResponse (pCommand, pMinionResponse) {
     if (Output._hasProperties(pMinionResponse, ["retcode", "return", "success"])) {
       return pMinionResponse.return;
+    }
+    if (Output._hasProperties(pMinionResponse, ["retcode", "ret", "jid"])) {
+      return pMinionResponse.ret;
     }
     if (pCommand.startsWith("runner.") && pMinionResponse && pMinionResponse["return"] !== undefined) {
       return pMinionResponse.return.return;
@@ -443,11 +458,9 @@ export class Output {
         if (typeof result !== "object") {
           continue;
         }
-        if (!("success" in result)) {
-          continue;
-        }
         // use keys that can conveniently be sorted
-        const key = (result.success ? "0-" : "1-") + result.retcode;
+        const isSuccess = Output._getIsSuccess(result);
+        const key = (isSuccess ? "0-" : "1-") + result.retcode;
         if (summary[key] === undefined) {
           summary[key] = 0;
         }
@@ -540,7 +553,7 @@ export class Output {
       let minionResponse = pResponse[minionId];
 
       const isSuccess = Output._getIsSuccess(minionResponse);
-      // const retCode = Output._getRetCode(minionResponse);
+      const retCode = Output._getRetCode(minionResponse);
       minionResponse = Output._getMinionResponse(pCommand, minionResponse);
 
       const minionClass = Output.getMinionLabelClass(isSuccess, minionResponse);
@@ -550,7 +563,7 @@ export class Output {
       let fndRepresentation = false;
 
       // implicit !fndRepresentation&&
-      if (pResponse[minionId] === undefined) {
+      if (pResponse[minionId] === undefined || pResponse[minionId] === false) {
         minionOutput = Output._getTextOutput("(no response)");
         minionOutput.classList.add("noresponse");
         fndRepresentation = true;

--- a/saltgui/static/scripts/output/OutputHighstate.js
+++ b/saltgui/static/scripts/output/OutputHighstate.js
@@ -74,7 +74,8 @@ export class OutputHighstate {
     let failed = 0;
     let skipped = 0;
     let totalMilliSeconds = 0;
-    let changes = 0;
+    let changesSummary = 0;
+    let changesDetail = 0;
     let hidden = 0;
     let nr = 0;
     for (const task of pTasks) {
@@ -114,7 +115,7 @@ export class OutputHighstate {
         if (str !== "{}") {
           hasChanges = true;
         }
-        changes += Object.keys(chgs).length;
+        changesDetail += Object.keys(chgs).length;
       }
 
       const taskId = components[1];
@@ -137,11 +138,12 @@ export class OutputHighstate {
       }
 
       if (!task.result) {
-        taskSpan.style.color = "red";
+        taskSpan.classList.add("task-failure");
       } else if (hasChanges) {
-        taskSpan.style.color = "aqua";
+        taskSpan.classList.add("task-changes");
+        changesSummary += 1;
       } else {
-        taskSpan.style.color = "lime";
+        taskSpan.classList.add("task-success");
       }
       const taskDiv = Utils.createDiv("", "", Utils.getIdFromMinionId(pMinionId + "." + nr));
       taskDiv.append(taskSpan);
@@ -150,9 +152,9 @@ export class OutputHighstate {
     }
 
     if (Output.isOutputFormatAllowed("saltguihighstate")) {
-      OutputHighstateSummarySaltGui.addSummarySpan(div, succeeded, failed, skipped, totalMilliSeconds, changes, hidden);
+      OutputHighstateSummarySaltGui.addSummarySpan(div, succeeded, failed, skipped, totalMilliSeconds, changesDetail, hidden);
     } else {
-      OutputHighstateSummaryOriginal.addSummarySpan(div, pMinionId, succeeded, failed, skipped, totalMilliSeconds, changes);
+      OutputHighstateSummaryOriginal.addSummarySpan(div, pMinionId, succeeded, failed, skipped, totalMilliSeconds, changesSummary);
     }
 
     return div;

--- a/saltgui/static/scripts/output/OutputHighstateSummaryOriginal.js
+++ b/saltgui/static/scripts/output/OutputHighstateSummaryOriginal.js
@@ -3,7 +3,7 @@ import {Utils} from "../Utils.js";
 
 export class OutputHighstateSummaryOriginal {
 
-  static addSummarySpan (pDiv, pMinionId, pSucceeded, pFailed, pSkipped, pTotalMilliSeconds, pChanges) {
+  static addSummarySpan (pDiv, pMinionId, pSucceeded, pFailed, pSkipped, pTotalMilliSeconds, pChangesSummary) {
 
     let txt = "\nSummary for " + pMinionId;
     txt += "\n------------";
@@ -12,19 +12,17 @@ export class OutputHighstateSummaryOriginal {
     pDiv.append(summarySpan);
 
     txt = "\nSucceeded: " + pSucceeded;
-    const succeededSpan = Utils.createSpan("", txt);
-    succeededSpan.style.color = "lime";
+    const succeededSpan = Utils.createSpan("task-success", txt);
     pDiv.append(succeededSpan);
 
-    if (pChanges > 0) {
+    if (pChangesSummary > 0) {
       txt = " (";
       const oSpan = Utils.createSpan("", txt);
       oSpan.style.color = "white";
       pDiv.append(oSpan);
 
-      txt = "changed=" + pChanges;
-      const changedSpan = Utils.createSpan("", txt);
-      changedSpan.style.color = "lime";
+      txt = "changed=" + pChangesSummary;
+      const changedSpan = Utils.createSpan("task-changes", txt);
       pDiv.append(changedSpan);
 
       txt = ")";
@@ -36,7 +34,7 @@ export class OutputHighstateSummaryOriginal {
     txt = "\nFailed:    " + pFailed;
     const failedSpan = Utils.createSpan("", txt);
     if (pFailed > 0) {
-      failedSpan.style.color = "red";
+      failedSpan.classList.add("task-failure");
     } else {
       failedSpan.style.color = "aqua";
     }

--- a/saltgui/static/scripts/output/OutputHighstateSummarySaltGui.js
+++ b/saltgui/static/scripts/output/OutputHighstateSummarySaltGui.js
@@ -3,7 +3,7 @@ import {Utils} from "../Utils.js";
 
 export class OutputHighstateSummarySaltGui {
 
-  static addSummarySpan (pDiv, pSucceeded, pFailed, pSkipped, pTotalMilliSeconds, pChanges, pHidden) {
+  static addSummarySpan (pDiv, pSucceeded, pFailed, pSkipped, pTotalMilliSeconds, pChangesDetail, pHidden) {
 
     // add a summary line
     let line = "";
@@ -29,7 +29,7 @@ export class OutputHighstateSummarySaltGui {
     // note that the number of changes may be higher or lower
     // than the number of tasks. tasks may contribute multiple
     // changes, or tasks may have no changes.
-    line += Utils.txtZeroOneMany(pChanges, "", ", {0} change", ", {0} changes");
+    line += Utils.txtZeroOneMany(pChangesDetail, "", ", {0} change", ", {0} changes");
 
     // multiple durations and significant?
     if (total > 1 && pTotalMilliSeconds >= 10) {

--- a/saltgui/static/scripts/output/OutputHighstateTaskSaltGui.js
+++ b/saltgui/static/scripts/output/OutputHighstateTaskSaltGui.js
@@ -94,14 +94,15 @@ export class OutputHighstateTaskSaltGui {
     const span = Utils.createSpan("task-icon");
     if (pTask.result === null) {
       span.innerText = Character.HEAVY_CHECK_MARK;
-      span.style.color = "yellow";
+      span.classList.add("task-skipped");
     } else if (pTask.result) {
       span.innerText = Character.HEAVY_CHECK_MARK;
-      span.style.color = "lime";
+      span.classList.add("task-success");
     } else {
       span.innerText = Character.HEAVY_BALLOT_X;
-      span.style.color = "red";
+      span.classList.add("task-failure");
     }
+    // don't use task-changes here
     taskDiv.append(span);
 
     taskDiv.append(document.createTextNode(pTaskName));

--- a/saltgui/static/scripts/panels/Job.js
+++ b/saltgui/static/scripts/panels/Job.js
@@ -513,11 +513,11 @@ export class JobPanel extends Panel {
       if (newLevel > oldLevel) {
         span.dataset.level = newLevel;
         if (newLevel === 1) {
-          span.style.color = "lime";
+          span.classList.add("host-success");
         } else if (newLevel === 2) {
-          span.style.color = "yellow";
+          span.classList.add("host-skips");
         } else if (newLevel === 3) {
-          span.style.color = "red";
+          span.classList.add("host-failed");
         }
       }
       span.style.removeProperty("display");

--- a/saltgui/static/scripts/panels/Minions.js
+++ b/saltgui/static/scripts/panels/Minions.js
@@ -110,15 +110,16 @@ export class MinionsPanel extends Panel {
 
     for (const tr of this.table.tBodies[0].childNodes) {
       if (minionIds.indexOf(tr.dataset.minionId) >= 0) {
+        // skip the connected minions
         continue;
       }
       const statusTd = tr.querySelector("td.status");
       if(!statusTd) continue;
       // this is the initial warning only
-      // it will be replaced by a less aggressive warning
+      // it will potentially be replaced by a less aggressive warning
       // when the grains information is returned
       statusTd.innerText = "offline";
-      statusTd.style.color = "red";
+      statusTd.classList.add("offline");
     }
   }
 

--- a/saltgui/static/scripts/panels/Minions.js
+++ b/saltgui/static/scripts/panels/Minions.js
@@ -29,6 +29,7 @@ export class MinionsPanel extends Panel {
 
   onShow () {
     const wheelKeyListAllPromise = this.api.getWheelKeyListAll();
+    const wheelMinionsConnectedPromise = this.api.getWheelMinionsConnected();
     const localGrainsItemsPromise = this.api.getLocalGrainsItems(null);
     const runnerManageVersionsPromise = this.api.getRunnerManageVersions();
 
@@ -36,6 +37,14 @@ export class MinionsPanel extends Panel {
 
     wheelKeyListAllPromise.then((pWheelKeyListAllData) => {
       this._handleMinionsWheelKeyListAll(pWheelKeyListAllData);
+
+      wheelMinionsConnectedPromise.then((pWheelMinionsConnectedData) => {
+        this._handlewheelMinionsConnected(pWheelMinionsConnectedData);
+        return true;
+      }, (getWheelMinionsConnectedMsg) => {
+        console.log("pWheelMinionsConnectedMsg", pWheelMinionsConnectedMsg);
+        return false;
+      });
 
       localGrainsItemsPromise.then((pLocalGrainsItemsData) => {
         this.updateMinions(pLocalGrainsItemsData);
@@ -90,6 +99,27 @@ export class MinionsPanel extends Panel {
     const txt = Utils.txtZeroOneMany(minionIds.length,
       "No minions", "{0} minion", "{0} minions");
     this.setMsg(txt);
+  }
+
+  _handlewheelMinionsConnected(pWheelMinionsConnectedData) {
+    if (this.showErrorRowInstead(pWheelMinionsConnectedData)) {
+      return;
+    }
+
+    const minionIds = pWheelMinionsConnectedData.return[0].data.return;
+
+    for (const tr of this.table.tBodies[0].childNodes) {
+      if (minionIds.indexOf(tr.dataset.minionId) >= 0) {
+        continue;
+      }
+      const statusTd = tr.querySelector("td.status");
+      if(!statusTd) continue;
+      // this is the initial warning only
+      // it will be replaced by a less aggressive warning
+      // when the grains information is returned
+      statusTd.innerText = "offline";
+      statusTd.style.color = "red";
+    }
   }
 
   updateOfflineMinion (pMinionId, pMinionsDict) {

--- a/saltgui/static/scripts/panels/Panel.js
+++ b/saltgui/static/scripts/panels/Panel.js
@@ -301,6 +301,7 @@ export class Panel {
 
     minionTr = document.createElement("tr");
     minionTr.id = Utils.getIdFromMinionId(pMinionId);
+    minionTr.dataset.minionId = pMinionId;
 
     minionTr.appendChild(Utils.createTd("minion-id", pMinionId));
 

--- a/saltgui/static/scripts/panels/Panel.js
+++ b/saltgui/static/scripts/panels/Panel.js
@@ -238,8 +238,10 @@ export class Panel {
           const fields = line.split(/[ \t]+/);
           if (fields.length === 1) {
             minions[fields[0]] = "true";
-          } else {
+          } else if (fields.length === 2) {
             minions[fields[0]] = fields[1];
+          } else {
+            console.warn("lines in 'minions.txt' must have 1 or 2 words, not " + fields.length + " like in: " + line);
           }
         }
         Utils.setStorageItem("session", "minions-txt", JSON.stringify(minions));
@@ -576,12 +578,14 @@ export class Panel {
     if (pMinionId in pMinionsDict) {
       if (pMinionsDict[pMinionId] === "true") {
         Utils.addToolTip(offlineSpan, "Minion is offline\nIs the host running and is the salt-minion installed and started?\nUpdate file 'minions.txt' when needed", "bottom-left");
-        offlineSpan.style.color = "red";
+        offlineSpan.classList.add("offline");
       } else {
         Utils.addToolTip(offlineSpan, "Minion is offline\nSince it is reported as inactive in file 'minions.txt', that should be OK", "bottom-left");
+        offlineSpan.classList.remove("offline");
       }
+    } else {
+      offlineSpan.classList.add("offline");
     }
-    offlineSpan.classList.add("offline");
     const offlineTd = Utils.createTd();
     offlineTd.appendChild(offlineSpan);
     minionTr.appendChild(offlineTd);

--- a/saltgui/static/stylesheets/page.css
+++ b/saltgui/static/stylesheets/page.css
@@ -75,6 +75,10 @@ pre .task-success {
 }
 
 pre .task-changes {
+  color: aqua;
+}
+
+pre .task-summary .task-changes {
   text-decoration-line: overline underline;
   text-decoration-style: double;
 }

--- a/saltgui/static/stylesheets/page.css
+++ b/saltgui/static/stylesheets/page.css
@@ -193,6 +193,10 @@ table tr td:last-of-type {
   color: #00f;
 }
 
+.offline {
+  color: red;
+}
+
 .osimage {
   max-width: 18px;
   max-height: 18px;


### PR DESCRIPTION
use the `wheel.minions.connected` function to quickly determine the on-line minions. The other minions as reported by `wheel.key.list_all` are thus offline. This helps on the main screen because otherwise the off-line status is only known once `grains.items` returns. And with offline minions present, that may take several seconds.