### PR TITLE
use salt-api to determine connected minions

### DIFF
--- a/saltgui/static/scripts/Api.js
+++ b/saltgui/static/scripts/Api.js
@@ -216,6 +216,14 @@ export class API {
     return this.apiRequest("POST", "/", params);
   }
 
+  getWheelMinionsConnected () {
+    const params = {
+      "client": "wheel",
+      "fun": "minions.connected"
+    };
+    return this.apiRequest("POST", "/", params);
+  }
+
   getStats () {
     const params = {
     };

--- a/saltgui/static/scripts/panels/Minions.js
+++ b/saltgui/static/scripts/panels/Minions.js
@@ -42,7 +42,7 @@ export class MinionsPanel extends Panel {
         this._handlewheelMinionsConnected(pWheelMinionsConnectedData);
         return true;
       }, (getWheelMinionsConnectedMsg) => {
-        console.log("pWheelMinionsConnectedMsg", pWheelMinionsConnectedMsg);
+        console.log("getWheelMinionsConnectedMsg", getWheelMinionsConnectedMsg);
         return false;
       });
 
@@ -101,7 +101,7 @@ export class MinionsPanel extends Panel {
     this.setMsg(txt);
   }
 
-  _handlewheelMinionsConnected(pWheelMinionsConnectedData) {
+  _handlewheelMinionsConnected (pWheelMinionsConnectedData) {
     if (this.showErrorRowInstead(pWheelMinionsConnectedData)) {
       return;
     }
@@ -114,7 +114,9 @@ export class MinionsPanel extends Panel {
         continue;
       }
       const statusTd = tr.querySelector("td.status");
-      if(!statusTd) continue;
+      if (!statusTd) {
+        continue;
+      }
       // this is the initial warning only
       // it will potentially be replaced by a less aggressive warning
       // when the grains information is returned

--- a/saltgui/static/scripts/panels/Minions.js
+++ b/saltgui/static/scripts/panels/Minions.js
@@ -29,6 +29,7 @@ export class MinionsPanel extends Panel {
 
   onShow () {
     const wheelKeyListAllPromise = this.api.getWheelKeyListAll();
+    const wheelMinionsConnectedPromise = this.api.getWheelMinionsConnected();
     const localGrainsItemsPromise = this.api.getLocalGrainsItems(null);
     const runnerManageVersionsPromise = this.api.getRunnerManageVersions();
 
@@ -36,6 +37,14 @@ export class MinionsPanel extends Panel {
 
     wheelKeyListAllPromise.then((pWheelKeyListAllData) => {
       this._handleMinionsWheelKeyListAll(pWheelKeyListAllData);
+
+      wheelMinionsConnectedPromise.then((pWheelMinionsConnectedData) => {
+        this._handlewheelMinionsConnected(pWheelMinionsConnectedData);
+        return true;
+      }, (getWheelMinionsConnectedMsg) => {
+        console.log("pWheelMinionsConnectedMsg", pWheelMinionsConnectedMsg);
+        return false;
+      });
 
       localGrainsItemsPromise.then((pLocalGrainsItemsData) => {
         this.updateMinions(pLocalGrainsItemsData);
@@ -90,6 +99,28 @@ export class MinionsPanel extends Panel {
     const txt = Utils.txtZeroOneMany(minionIds.length,
       "No minions", "{0} minion", "{0} minions");
     this.setMsg(txt);
+  }
+
+  _handlewheelMinionsConnected(pWheelMinionsConnectedData) {
+    if (this.showErrorRowInstead(pWheelMinionsConnectedData)) {
+      return;
+    }
+
+    const minionIds = pWheelMinionsConnectedData.return[0].data.return;
+
+    for (const tr of this.table.tBodies[0].childNodes) {
+      if (minionIds.indexOf(tr.dataset.minionId) >= 0) {
+        // skip the connected minions
+        continue;
+      }
+      const statusTd = tr.querySelector("td.status");
+      if(!statusTd) continue;
+      // this is the initial warning only
+      // it will potentially be replaced by a less aggressive warning
+      // when the grains information is returned
+      statusTd.innerText = "offline";
+      statusTd.classList.add("offline");
+    }
   }
 
   updateOfflineMinion (pMinionId, pMinionsDict) {

--- a/saltgui/static/scripts/panels/Panel.js
+++ b/saltgui/static/scripts/panels/Panel.js
@@ -303,6 +303,7 @@ export class Panel {
 
     minionTr = document.createElement("tr");
     minionTr.id = Utils.getIdFromMinionId(pMinionId);
+    minionTr.dataset.minionId = pMinionId;
 
     minionTr.appendChild(Utils.createTd("minion-id", pMinionId));
 
@@ -577,12 +578,14 @@ export class Panel {
     if (pMinionId in pMinionsDict) {
       if (pMinionsDict[pMinionId] === "true") {
         Utils.addToolTip(offlineSpan, "Minion is offline\nIs the host running and is the salt-minion installed and started?\nUpdate file 'minions.txt' when needed", "bottom-left");
-        offlineSpan.style.color = "red";
+        offlineSpan.classList.add("offline");
       } else {
         Utils.addToolTip(offlineSpan, "Minion is offline\nSince it is reported as inactive in file 'minions.txt', that should be OK", "bottom-left");
+        offlineSpan.classList.remove("offline");
       }
+    } else {
+      offlineSpan.classList.add("offline");
     }
-    offlineSpan.classList.add("offline");
     const offlineTd = Utils.createTd();
     offlineTd.appendChild(offlineSpan);
     minionTr.appendChild(offlineTd);

--- a/saltgui/static/stylesheets/page.css
+++ b/saltgui/static/stylesheets/page.css
@@ -189,6 +189,10 @@ table tr td:last-of-type {
   color: #00f;
 }
 
+.offline {
+  color: red;
+}
+
 .osimage {
   max-width: 18px;
   max-height: 18px;


### PR DESCRIPTION
use the `wheel.minions.connected` function to quickly determine the on-line minions. The other minions as reported by `wheel.key.list_all` are thus offline. This helps on the main screen because otherwise the off-line status is only known once `grains.items` returns. And with offline minions present, that may take several seconds.