### PR TITLE
add support for additional salt.auth types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ yarn.lock
 package-lock.json
 saltgui/static/minions.txt
 saltgui/static/mkMinions.sh
+saltgui/static/salt-auth.txt

--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ SaltGUI supports the following authentication methods supported by salt:
 - mysql
 - yubico
 
+Since pam by itself is already very powerfull, that one is mentionned as standard.
+By default, it provides access to the Linux password file,
+When other authentication methods need to be used their names can be added to file `saltgui/static/salt-auth.txt`.
+There is one name per line in that file. Choose the authentication methods that are activated
+in the salt-master configuration wisely, as the integrity of the salt-master and all salt-minions depends on it.
+
 See the [EAUTH documentation](https://docs.saltstack.com/en/latest/topics/eauth/index.html) and the [Salt auth source code](https://github.com/saltstack/salt/tree/master/salt/auth) for more information.
 
 ## Command Box

--- a/saltgui/static/scripts/Api.js
+++ b/saltgui/static/scripts/Api.js
@@ -68,6 +68,10 @@ export class API {
     return this.apiRequest("GET", "/static/minions.txt");
   }
 
+  getStaticSaltAuthTxt () {
+    return this.apiRequest("GET", "/static/salt-auth.txt");
+  }
+
   getLocalBeaconsList (pMinionId) {
     const params = {
       "client": "local",

--- a/saltgui/static/scripts/panels/Login.js
+++ b/saltgui/static/scripts/panels/Login.js
@@ -37,58 +37,9 @@ export class LoginPanel extends Panel {
 
     // see https://docs.saltstack.com/en/latest/ref/auth/all/index.html
     const select = document.createElement("select");
-
-    const option1 = document.createElement("option");
-    option1.id = "eauth-default";
-    option1.value = "default";
-    option1.innerText = "Type";
-    select.append(option1);
-
-    const option2 = document.createElement("optgroup");
-    option2.label = "standard";
-    select.append(option2);
-
-    const option2a = document.createElement("option");
-    option2a.value = "pam";
-    option2a.innerText = "pam";
-    option2.append(option2a);
-
-    // move items to this optgroup only when at least
-    // one user reports a succesful use
-    // see https://github.com/saltstack/salt/tree/master/salt/auth
-    // for information and configuration
-    const option3 = document.createElement("optgroup");
-    option3.label = "other";
-    select.append(option3);
-
-    const option3a = document.createElement("option");
-    option3a.value = "file";
-    option3a.innerText = "file";
-    option3.append(option3a);
-
-    const option3b = document.createElement("option");
-    option3b.value = "ldap";
-    option3b.innerText = "ldap";
-    option3.append(option3b);
-
-    const option3c = document.createElement("option");
-    option3c.value = "mysql";
-    option3c.innerText = "mysql";
-    option3.append(option3c);
-
-    const option3d = document.createElement("option");
-    option3d.value = "yubico";
-    option3d.innerText = "yubico";
-    option3.append(option3d);
-
-    // auto and sharedsecret already tested but not suitable for general use
-    // other values are: django, keystone, pki, rest
-    // these can be added after testing to optgroup 'other'
-    // add untested values to (new) optgroup 'experimental' on explicit user request
-    // and only while the code is on a branch
-
     form.append(select);
     this.eauthField = select;
+    this._updateEauthField();
 
     const submit = document.createElement("input");
     submit.id = "login-button";
@@ -117,6 +68,57 @@ export class LoginPanel extends Panel {
     this._registerEventListeners(form);
   }
 
+  _addEauthSection (sectionName, optionValues) {
+    if (optionValues.length === 0) {
+      // no optionValues --> no section
+      return;
+    }
+
+    const optgroup = document.createElement("optgroup");
+    optgroup.label = sectionName;
+    this.eauthField.append(optgroup);
+
+    for (const optionValue of optionValues) {
+      const option = document.createElement("option");
+      option.value = optionValue;
+      option.innerText = optionValue;
+      optgroup.append(option);
+    }
+  }
+
+  _updateEauthField () {
+    // start fresh
+    this.eauthField.innerHTML = "";
+
+    const option1 = document.createElement("option");
+    option1.id = "eauth-default";
+    option1.value = "default";
+    option1.innerText = "Type";
+    this.eauthField.append(option1);
+
+    this._addEauthSection("standard", ["pam"]);
+
+    // move items to this optgroup only when at least
+    // one user reports a succesful use
+    // see https://github.com/saltstack/salt/tree/master/salt/auth
+    // for information and configuration
+    this._addEauthSection("other", ["file", "ldap", "mysql", "yubico"]);
+
+    // auto and sharedsecret already tested but not suitable for general use
+    // other values are: django, keystone, pki, rest
+    // these can be added after testing to optgroup 'other'
+    // add untested values to (new) optgroup 'experimental' on explicit user request
+    // and only while the code is on a branch
+
+    // allow user to add any value they want
+    const saltAuthText = Utils.getStorageItem("local", "salt-auth-txt", "[]");
+    const saltAuth = JSON.parse(saltAuthText);
+    this._addEauthSection("salt-auth.txt", saltAuth);
+
+    this.eauthField.value = Utils.getStorageItem("local", "eauth", "pam");
+
+  }
+
   _registerEventListeners (pLoginForm) {
     pLoginForm.addEventListener("submit", (ev) => {
       this._onLogin(ev);
@@ -134,8 +136,40 @@ export class LoginPanel extends Panel {
     this.noticeWrapperDiv.appendChild(noticeDiv);
   }
 
+  _loadSaltAuthTxt () {
+    const staticSaltAuthTxtPromise = this.api.getStaticSaltAuthTxt();
+
+    staticSaltAuthTxtPromise.then((pStaticSaltAuthTxt) => {
+      if (pStaticSaltAuthTxt) {
+        const lines = pStaticSaltAuthTxt.
+          trim().
+          split(/\r?\n/).
+          filter((item) => !item.startsWith("#"));
+        const saltAauth = [];
+        for (const line of lines) {
+          const fields = line.split(/[ \t]+/);
+          if (fields.length === 1) {
+            saltAauth.push(fields[0]);
+          } else {
+            console.warn("lines in 'salt-auth.txt' must have 1 word, not " + fields.length + " like in: " + line);
+          }
+        }
+        Utils.setStorageItem("local", "salt-auth-txt", JSON.stringify(saltAauth));
+        this._updateEauthField();
+      } else {
+        Utils.setStorageItem("local", "salt-auth-txt", "[]");
+        this._updateEauthField();
+      }
+      return true;
+    }, () => {
+      Utils.setStorageItem("local", "salt-auth-txt", "[]");
+      this._updateEauthField();
+      return false;
+    });
+  }
+
   onShow () {
-    this.eauthField.value = Utils.getStorageItem("local", "eauth", "pam");
+    this._loadSaltAuthTxt();
 
     const reason = decodeURIComponent(Utils.getQueryParam("reason"));
     switch (reason) {

--- a/saltgui/static/scripts/panels/Login.js
+++ b/saltgui/static/scripts/panels/Login.js
@@ -145,16 +145,16 @@ export class LoginPanel extends Panel {
           trim().
           split(/\r?\n/).
           filter((item) => !item.startsWith("#"));
-        const saltAauth = [];
+        const saltAuth = [];
         for (const line of lines) {
           const fields = line.split(/[ \t]+/);
           if (fields.length === 1) {
-            saltAauth.push(fields[0]);
+            saltAuth.push(fields[0]);
           } else {
             console.warn("lines in 'salt-auth.txt' must have 1 word, not " + fields.length + " like in: " + line);
           }
         }
-        Utils.setStorageItem("local", "salt-auth-txt", JSON.stringify(saltAauth));
+        Utils.setStorageItem("local", "salt-auth-txt", JSON.stringify(saltAuth));
         this._updateEauthField();
       } else {
         Utils.setStorageItem("local", "salt-auth-txt", "[]");


### PR DESCRIPTION
In #367, @hoaivan requests the addition of auth method `sharedsecred`.
However, that is not a safe mechanism unless additional measures are taken to prevent leaking these credentials.
Therefore `sharedsecret` will not be added as a standard option in the login screen.

But here is an alternative...
A file `salt-auth.txt` can be placed on the server, which contains all of the additional auth methods that should be shown.
So additional options will only be visible when they are added to that file.
And also, any other auth mechanism can be made selectable.

Note that an auth method does not work unless it is also configured in the `master` file.

This PR replaces the original PR #367.