### PR TITLE
show message-of-the-day during login and after login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,6 @@ package-lock.json
 saltgui/static/minions.txt
 saltgui/static/mkMinions.sh
 saltgui/static/salt-auth.txt
+saltgui/static/salt-motd.txt
+saltgui/static/salt-motd.html
 *.swp

--- a/README.md
+++ b/README.md
@@ -187,7 +187,9 @@ It can be used for any information, e.g.:
 - informing users about system availability
 - etc.
 
-The text is stored in file `saltgui/static/salt-motd.txt` or `saltgui/static/salt-motd.html`. The first must be pre-formatted text only. The second one can contain full HTML text. Both are shown when they are present.
+The text is stored in file `saltgui/static/salt-motd.txt` or `saltgui/static/salt-motd.html`. The first must be pre-formatted text only. The second one can contain full HTML text. Both are shown when they are present. Note that the message should not contain sensitive data, as its content is shown before logging in.
+
+Alternatively, the text can be retrieved from the `master` file entries `saltgui_motd_txt` and `saltgui_motd_html`. These entries can contain sensitive information because its content can only be retrieved after login. But it is still recommended to not let the text contain any sensitive data.
 
 ## Reduced menus
 When api's are disabled using the native `external_auth` mechanism,

--- a/README.md
+++ b/README.md
@@ -178,6 +178,17 @@ saltgui_public_pillars:
     - pub_.*
 ```
 
+## Message-of-the-day
+A message-of-the-day (motd) can be added to the login screen.
+It can be used for any information, e.g.:
+- legal statement
+- system identification
+- useful links to other systems
+- informing users about system availability
+- etc.
+
+The text is stored in file `saltgui/static/salt-motd.txt` or `saltgui/static/salt-motd.html`. The first must be pre-formatted text only. The second one can contain full HTML text. Both are shown when they are present.
+
 ## Reduced menus
 When api's are disabled using the native `external_auth` mechanism,
 SaltGUI may show menu-items that have become unuseable.

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ It can be used for any information, e.g.:
 
 The text is stored in file `saltgui/static/salt-motd.txt` or `saltgui/static/salt-motd.html`. The first must be pre-formatted text only. The second one can contain full HTML text. Both are shown when they are present. Note that the message should not contain sensitive data, as its content is shown before logging in.
 
-Alternatively, the text can be retrieved from the `master` file entries `saltgui_motd_txt` and `saltgui_motd_html`. These entries can contain sensitive information because its content can only be retrieved after login. But it is still recommended to not let the text contain any sensitive data.
+Alternatively, or additionally, the text can be retrieved from the `master` file entries `saltgui_motd_txt` and `saltgui_motd_html`. These entries can contain sensitive information because its content can only be retrieved after login. But it is still recommended to not let the text contain any sensitive data.
 
 ## Reduced menus
 When api's are disabled using the native `external_auth` mechanism,

--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -38,13 +38,15 @@
         </div>
       </div>
 <!-- motd -->
-      <div id="motd" style="display: none; margin: 5px 0 0 20px; padding-bottom: 5px">
+      <div id="motd" style="display: none; margin: 5px 0 0 20px">
         <div style="display: inline-block; vertical-align: top">
           <div id="close-motd" class="small-button small-small-button small-button-left">&#x2716;</div>
         </div>
         <div style="display: inline-block">
-          <div id="motdtxt"></div>
-          <div id="motdhtml"></div>
+          <div id="motd1txt" style="padding-bottom: 5px"></div>
+          <div id="motd1html" style="padding-bottom: 5px"></div>
+          <div id="motd2txt" style="padding-bottom: 5px"></div>
+          <div id="motd2html" style="padding-bottom: 5px"></div>
         </div>
       </div>
 <!-- warning -->

--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -37,6 +37,17 @@
           <div class="dropdown-content"></div>
         </div>
       </div>
+<!-- motd -->
+      <div id="motd" style="display: none; margin: 5px 0 0 20px; padding-bottom: 5px">
+        <div style="display: inline-block; vertical-align: top">
+          <div id="close-motd" class="small-button small-small-button small-button-left">&#x2716;</div>
+        </div>
+        <div style="display: inline-block">
+          <div id="motdtxt"></div>
+          <div id="motdhtml"></div>
+        </div>
+      </div>
+<!-- warning -->
       <div id="warning" style="display: none"></div>
     </header>
 

--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -43,10 +43,8 @@
           <div id="close-motd" class="small-button small-small-button small-button-left">&#x2716;</div>
         </div>
         <div style="display: inline-block">
-          <div id="motd1txt" style="padding-bottom: 5px"></div>
-          <div id="motd1html" style="padding-bottom: 5px"></div>
-          <div id="motd2txt" style="padding-bottom: 5px"></div>
-          <div id="motd2html" style="padding-bottom: 5px"></div>
+          <div id="motdtxt" style="padding-bottom: 5px"></div>
+          <div id="motdhtml" style="padding-bottom: 5px"></div>
         </div>
       </div>
 <!-- warning -->

--- a/saltgui/static/scripts/Api.js
+++ b/saltgui/static/scripts/Api.js
@@ -72,6 +72,14 @@ export class API {
     return this.apiRequest("GET", "/static/salt-auth.txt");
   }
 
+  getStaticSaltMotdTxt () {
+    return this.apiRequest("GET", "/static/salt-motd.txt");
+  }
+
+  getStaticSaltMotdHtml () {
+    return this.apiRequest("GET", "/static/salt-motd.html");
+  }
+
   getLocalBeaconsList (pMinionId) {
     const params = {
       "client": "local",
@@ -260,6 +268,8 @@ export class API {
     };
     if (pPage.endsWith(".txt")) {
       headers["Accept"] = "text/plain";
+    } else if (pPage.endsWith(".html")) {
+      headers["Accept"] = "text/html";
     }
     const options = {
       "headers": headers,
@@ -277,6 +287,9 @@ export class API {
     /* eslint-enable compat/compat */
       then((pResponse) => {
         if (pResponse.ok && pPage.endsWith(".txt")) {
+          return pResponse.text();
+        }
+        if (pResponse.ok && pPage.endsWith(".html")) {
           return pResponse.text();
         }
         if (pResponse.ok) {

--- a/saltgui/static/scripts/pages/Page.js
+++ b/saltgui/static/scripts/pages/Page.js
@@ -125,10 +125,51 @@ export class Page {
     return true;
   }
 
+  _updateMotd() {
+
+    const motd = document.getElementById("motd");
+
+    const motdStatus = Utils.getStorageItem("session", "motd-status", "");
+    if (motdStatus === "hidden") {
+      motd.style.display = "none";
+      return;
+    }
+
+    const saltMotdTxt = Utils.getStorageItem("local", "salt-motd-txt", "");
+    const motdTxtDiv = document.getElementById("motdtxt");
+    motdTxtDiv.innerText = saltMotdTxt;
+    motdTxtDiv.style.display = saltMotdTxt ? "" : "none";
+
+    const saltMotdHtml = Utils.getStorageItem("local", "salt-motd-html", "");
+    const motdHtmlDiv = document.getElementById("motdhtml");
+    motdHtmlDiv.innerHTML = saltMotdHtml;
+    motdHtmlDiv.style.display = saltMotdHtml ? "" : "none";
+
+    if (!saltMotdTxt && !saltMotdHtml) {
+      motd.style.display = "none";
+      return;
+    }
+
+    motd.style.display = "";
+
+    const motdCLoseButton1  = document.getElementById("close-motd");
+    // remove all event-handlers (yes, this is otherwise a silly assignment)
+    motdCLoseButton1.outerHTML = motdCLoseButton1.outerHTML;
+    // that made it a different object
+    const motdCLoseButton2  = document.getElementById("close-motd");
+    // add the event-handler
+    motdCLoseButton2.addEventListener("click", () => {
+      Utils.setStorageItem("local", "salt-motd-txt", "");
+      Utils.setStorageItem("local", "salt-motd-html", "");
+      motd.style.display = "none";
+    });
+  }
+
   onShow () {
     for (const panel of this.panels) {
       panel.onShow();
     }
+    this._updateMotd();
   }
 
   clearPage () {

--- a/saltgui/static/scripts/pages/Page.js
+++ b/saltgui/static/scripts/pages/Page.js
@@ -125,7 +125,7 @@ export class Page {
     return true;
   }
 
-  _updateMotd() {
+  static _updateMotd () {
 
     const motd = document.getElementById("motd");
 
@@ -155,10 +155,12 @@ export class Page {
     motd2HtmlDiv.innerHTML = saltMotd2Html;
     motd2HtmlDiv.style.display = saltMotd2Html ? "" : "none";
 
-    const motdCLoseButton1  = document.getElementById("close-motd");
+    const motdCLoseButton1 = document.getElementById("close-motd");
     // remove all event-handlers (yes, this is otherwise a silly assignment)
     // that makes it a different object!
+    /* eslint-disable no-self-assign */
     motdCLoseButton1.outerHTML = motdCLoseButton1.outerHTML;
+    /* eslint-enable no-self-assign */
 
     if (!saltMotd1Txt && !saltMotd1Html && !saltMotd2Txt && !saltMotd2Html) {
       // nothing to see, don't bother
@@ -168,7 +170,7 @@ export class Page {
 
     motd.style.display = "";
 
-    const motdCLoseButton2  = document.getElementById("close-motd");
+    const motdCLoseButton2 = document.getElementById("close-motd");
     // add the event-handler
     motdCLoseButton2.addEventListener("click", () => {
       Utils.setStorageItem("local", "salt-motd-txt", "");
@@ -183,7 +185,7 @@ export class Page {
     for (const panel of this.panels) {
       panel.onShow();
     }
-    this._updateMotd();
+    Page._updateMotd();
   }
 
   clearPage () {

--- a/saltgui/static/scripts/pages/Page.js
+++ b/saltgui/static/scripts/pages/Page.js
@@ -135,32 +135,46 @@ export class Page {
       return;
     }
 
-    const saltMotdTxt = Utils.getStorageItem("local", "salt-motd-txt", "");
-    const motdTxtDiv = document.getElementById("motdtxt");
-    motdTxtDiv.innerText = saltMotdTxt;
-    motdTxtDiv.style.display = saltMotdTxt ? "" : "none";
+    const saltMotd1Txt = Utils.getStorageItem("local", "salt-motd-txt", "");
+    const motd1TxtDiv = document.getElementById("motd1txt");
+    motd1TxtDiv.innerText = saltMotd1Txt;
+    motd1TxtDiv.style.display = saltMotd1Txt ? "" : "none";
 
-    const saltMotdHtml = Utils.getStorageItem("local", "salt-motd-html", "");
-    const motdHtmlDiv = document.getElementById("motdhtml");
-    motdHtmlDiv.innerHTML = saltMotdHtml;
-    motdHtmlDiv.style.display = saltMotdHtml ? "" : "none";
+    const saltMotd1Html = Utils.getStorageItem("local", "salt-motd-html", "");
+    const motd1HtmlDiv = document.getElementById("motd1html");
+    motd1HtmlDiv.innerHTML = saltMotd1Html;
+    motd1HtmlDiv.style.display = saltMotd1Html ? "" : "none";
 
-    if (!saltMotdTxt && !saltMotdHtml) {
+    const saltMotd2Txt = Utils.getStorageItem("session", "motd_txt", "");
+    const motd2TxtDiv = document.getElementById("motd2txt");
+    motd2TxtDiv.innerText = saltMotd2Txt;
+    motd2TxtDiv.style.display = saltMotd2Txt ? "" : "none";
+
+    const saltMotd2Html = Utils.getStorageItem("session", "motd_html", "");
+    const motd2HtmlDiv = document.getElementById("motd2html");
+    motd2HtmlDiv.innerHTML = saltMotd2Html;
+    motd2HtmlDiv.style.display = saltMotd2Html ? "" : "none";
+
+    const motdCLoseButton1  = document.getElementById("close-motd");
+    // remove all event-handlers (yes, this is otherwise a silly assignment)
+    // that makes it a different object!
+    motdCLoseButton1.outerHTML = motdCLoseButton1.outerHTML;
+
+    if (!saltMotd1Txt && !saltMotd1Html && !saltMotd2Txt && !saltMotd2Html) {
+      // nothing to see, don't bother
       motd.style.display = "none";
       return;
     }
 
     motd.style.display = "";
 
-    const motdCLoseButton1  = document.getElementById("close-motd");
-    // remove all event-handlers (yes, this is otherwise a silly assignment)
-    motdCLoseButton1.outerHTML = motdCLoseButton1.outerHTML;
-    // that made it a different object
     const motdCLoseButton2  = document.getElementById("close-motd");
     // add the event-handler
     motdCLoseButton2.addEventListener("click", () => {
       Utils.setStorageItem("local", "salt-motd-txt", "");
       Utils.setStorageItem("local", "salt-motd-html", "");
+      Utils.setStorageItem("session", "motd_txt", "");
+      Utils.setStorageItem("session", "motd_html", "");
       motd.style.display = "none";
     });
   }

--- a/saltgui/static/scripts/pages/Page.js
+++ b/saltgui/static/scripts/pages/Page.js
@@ -135,25 +135,15 @@ export class Page {
       return;
     }
 
-    const saltMotd1Txt = Utils.getStorageItem("local", "salt-motd-txt", "");
-    const motd1TxtDiv = document.getElementById("motd1txt");
-    motd1TxtDiv.innerText = saltMotd1Txt;
-    motd1TxtDiv.style.display = saltMotd1Txt ? "" : "none";
+    const saltMotdTxt = Utils.getStorageItem("session", "motd_txt", "");
+    const motdTxtDiv = document.getElementById("motdtxt");
+    motdTxtDiv.innerText = saltMotdTxt;
+    motdTxtDiv.style.display = saltMotdTxt ? "" : "none";
 
-    const saltMotd1Html = Utils.getStorageItem("local", "salt-motd-html", "");
-    const motd1HtmlDiv = document.getElementById("motd1html");
-    motd1HtmlDiv.innerHTML = saltMotd1Html;
-    motd1HtmlDiv.style.display = saltMotd1Html ? "" : "none";
-
-    const saltMotd2Txt = Utils.getStorageItem("session", "motd_txt", "");
-    const motd2TxtDiv = document.getElementById("motd2txt");
-    motd2TxtDiv.innerText = saltMotd2Txt;
-    motd2TxtDiv.style.display = saltMotd2Txt ? "" : "none";
-
-    const saltMotd2Html = Utils.getStorageItem("session", "motd_html", "");
-    const motd2HtmlDiv = document.getElementById("motd2html");
-    motd2HtmlDiv.innerHTML = saltMotd2Html;
-    motd2HtmlDiv.style.display = saltMotd2Html ? "" : "none";
+    const saltMotdHtml = Utils.getStorageItem("session", "motd_html", "");
+    const motdHtmlDiv = document.getElementById("motdhtml");
+    motdHtmlDiv.innerHTML = saltMotdHtml;
+    motdHtmlDiv.style.display = saltMotdHtml ? "" : "none";
 
     const motdCLoseButton1 = document.getElementById("close-motd");
     // remove all event-handlers (yes, this is otherwise a silly assignment)
@@ -162,7 +152,7 @@ export class Page {
     motdCLoseButton1.outerHTML = motdCLoseButton1.outerHTML;
     /* eslint-enable no-self-assign */
 
-    if (!saltMotd1Txt && !saltMotd1Html && !saltMotd2Txt && !saltMotd2Html) {
+    if (!saltMotdTxt && !saltMotdHtml) {
       // nothing to see, don't bother
       motd.style.display = "none";
       return;
@@ -173,8 +163,6 @@ export class Page {
     const motdCLoseButton2 = document.getElementById("close-motd");
     // add the event-handler
     motdCLoseButton2.addEventListener("click", () => {
-      Utils.setStorageItem("local", "salt-motd-txt", "");
-      Utils.setStorageItem("local", "salt-motd-html", "");
       Utils.setStorageItem("session", "motd_txt", "");
       Utils.setStorageItem("session", "motd_html", "");
       motd.style.display = "none";

--- a/saltgui/static/scripts/panels/Login.js
+++ b/saltgui/static/scripts/panels/Login.js
@@ -284,6 +284,9 @@ export class LoginPanel extends Panel {
   _onLoginSuccess () {
     this._showNoticeText("#4CAF50", "Please wait...", "notice_please_wait");
 
+    Utils.setStorageItem("local", "salt-motd-txt", "");
+    Utils.setStorageItem("local", "salt-motd-html", "");
+
     // We need these functions to populate the dropdown boxes
     const wheelConfigValuesPromise = this.api.getWheelConfigValues();
 

--- a/saltgui/static/scripts/panels/Login.js
+++ b/saltgui/static/scripts/panels/Login.js
@@ -351,6 +351,12 @@ export class LoginPanel extends Panel {
     const toolTipMode = wheelConfigValuesData.saltgui_tooltip_mode;
     Utils.setStorageItem("session", "tooltip_mode", toolTipMode);
 
+    const motdTxt = wheelConfigValuesData.saltgui_motd_txt;
+    Utils.setStorageItem("session", "motd_txt", motdTxt);
+
+    const motdHtml = wheelConfigValuesData.saltgui_motd_html;
+    Utils.setStorageItem("session", "motd_html", motdHtml);
+
     Router.updateMainMenu();
   }
 

--- a/saltgui/static/scripts/panels/Login.js
+++ b/saltgui/static/scripts/panels/Login.js
@@ -16,6 +16,14 @@ export class LoginPanel extends Panel {
     const form = document.createElement("form");
     this.div.append(form);
 
+    const motdTxt = Utils.createDiv("motd");
+    form.append(motdTxt);
+    this.motdTxtDiv = motdTxt;
+
+    const motdHtml = Utils.createDiv("motd");
+    form.append(motdHtml);
+    this.motdHtmlDiv = motdHtml;
+
     const noticeWrapper = Utils.createDiv("notice-wrapper", "", "notice-wrapper");
     form.append(noticeWrapper);
     this.noticeWrapperDiv = noticeWrapper;
@@ -116,7 +124,16 @@ export class LoginPanel extends Panel {
     this._addEauthSection("salt-auth.txt", saltAuth);
 
     this.eauthField.value = Utils.getStorageItem("local", "eauth", "pam");
+  }
 
+  _updateMotdField () {
+    const saltMotdTxt = Utils.getStorageItem("local", "salt-motd-txt", "");
+    this.motdTxtDiv.innerText = saltMotdTxt;
+    this.motdTxtDiv.style.display = saltMotdTxt ? "" : "none";
+
+    const saltMotdHtml = Utils.getStorageItem("local", "salt-motd-html", "");
+    this.motdHtmlDiv.innerHTML = saltMotdHtml;
+    this.motdHtmlDiv.style.display = saltMotdHtml ? "" : "none";
   }
 
   _registerEventListeners (pLoginForm) {
@@ -168,8 +185,51 @@ export class LoginPanel extends Panel {
     });
   }
 
+  _loadSaltMotdTxt () {
+    const staticSaltMotdTxtPromise = this.api.getStaticSaltMotdTxt();
+
+    staticSaltMotdTxtPromise.then((pStaticSaltMotdTxt) => {
+      if (pStaticSaltMotdTxt) {
+        const lines = pStaticSaltMotdTxt.trim();
+        Utils.setStorageItem("local", "salt-motd-txt", lines);
+        this._updateMotdField();
+      } else {
+        Utils.setStorageItem("local", "salt-motd-txt", "");
+        this._updateMotdField();
+      }
+      return true;
+    }, () => {
+      Utils.setStorageItem("local", "salt-motd-txt", "");
+      this._updateMotdField();
+      return false;
+    });
+  }
+
+  _loadSaltMotdHtml () {
+    const staticSaltMotdHtmlPromise = this.api.getStaticSaltMotdHtml();
+
+    staticSaltMotdHtmlPromise.then((pStaticSaltMotdHtml) => {
+      if (pStaticSaltMotdHtml) {
+        const lines = pStaticSaltMotdHtml.trim();
+        Utils.setStorageItem("local", "salt-motd-html", lines);
+        this._updateMotdField();
+      } else {
+        Utils.setStorageItem("local", "salt-motd-html", "");
+        this._updateMotdField();
+      }
+      return true;
+    }, () => {
+      Utils.setStorageItem("local", "salt-motd-html", "");
+      this._updateMotdField();
+      return false;
+    });
+  }
+
   onShow () {
     this._loadSaltAuthTxt();
+
+    this._loadSaltMotdTxt();
+    this._loadSaltMotdHtml();
 
     const reason = decodeURIComponent(Utils.getQueryParam("reason"));
     switch (reason) {

--- a/saltgui/static/stylesheets/login.css
+++ b/saltgui/static/stylesheets/login.css
@@ -54,10 +54,6 @@
   width: 25px;
 }
 
-#notice-wrapper {
-  margin-bottom: 15px;
-}
-
 #notice {
   height: 0;
   overflow-y: hidden;
@@ -75,21 +71,25 @@
   0% {
     height: 0;
     padding: 0;
+    margin-bottom: 15px;
   }
 
   20% {
     height: 38px;
     padding: 9px 0;
+    margin-bottom: 15px;
   }
 
   80% {
     height: 38px;
     padding: 9px 0;
+    margin-bottom: 15px;
   }
 
   100% {
     height: 0;
     padding: 0;
+    margin-bottom: 0;
   }
 }
 
@@ -111,4 +111,8 @@
     height: 38px;
     padding: 9px 0;
   }
+}
+
+.motd {
+  margin-bottom: 15px;
 }


### PR DESCRIPTION
must support both TXT and HTML

content is different before and after login because after login, content may contain sensitive information (still not recommended though).

content before login is retrieved from a static file.
content after login is retrieved from the master file (which is unavailable before login)