### PR TITLE
Allow template definitions to be read from a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ saltgui/static/mkMinions.sh
 saltgui/static/salt-auth.txt*
 saltgui/static/salt-motd.txt*
 saltgui/static/salt-motd.html*
+saltgui/static/salt-templates.txt*
 *.swp

--- a/README.md
+++ b/README.md
@@ -139,6 +139,24 @@ saltgui_templates:
         command: test.version
 ```
 
+Alternatively, a separate file can be used.
+The filename must be `saltgui/static/salt-templates.json`.
+e.g.:
+```
+{
+    "template3": {
+        "description": "Third template"
+        "target": "*"
+        "command": "test.fib num=10"
+    },
+    "template4": {
+        "description": "Fourth template"
+        "targettype": "glob"
+        "target": "dev*
+        "command": "test.version"
+    }
+}
+```
 
 ## Jobs
 SaltGUI shows a maximum of 7 jobs in on the right-hand-side of the screen.

--- a/saltgui/static/salt-templates.json
+++ b/saltgui/static/salt-templates.json
@@ -1,0 +1,17 @@
+{
+"template4": {
+  "description": "Third template",
+  "target": "#*",
+  "command": "test.fib num=10"
+  },
+"template3": {
+  "description": "Fourth template",
+  "target": "xev*",
+  "command": "test.version"
+  },
+"template5": {
+  "description": "Fifth template",
+  "target": "xev*",
+  "command": "test.version"
+  }
+}

--- a/saltgui/static/salt-templates.json
+++ b/saltgui/static/salt-templates.json
@@ -1,4 +1,9 @@
 {
+"template2": {
+  "description": "2nd template",
+  "target": "#*",
+  "command": "test.fib num=10"
+  },
 "template4": {
   "description": "Third template",
   "target": "#*",

--- a/saltgui/static/scripts/Api.js
+++ b/saltgui/static/scripts/Api.js
@@ -80,6 +80,10 @@ export class API {
     return this.apiRequest("GET", "/static/salt-motd.html");
   }
 
+  getStaticTemplatesJson () {
+    return this.apiRequest("GET", "/static/salt-templates.json");
+  }
+
   getLocalBeaconsList (pMinionId) {
     const params = {
       "client": "local",

--- a/saltgui/static/scripts/CommandBox.js
+++ b/saltgui/static/scripts/CommandBox.js
@@ -42,7 +42,12 @@ export class CommandBox {
       return;
     }
     const menu = new DropDownMenu(titleElement);
-    const templatesText = Utils.getStorageItem("session", "templates", "{}");
+    CommandBox._populateTemplateMenu2(menu, "templates_master");
+    CommandBox._populateTemplateMenu2(menu, "templates_json");
+  }
+
+  static _populateTemplateMenu2 (pMenu, pTemplateType) {
+    const templatesText = Utils.getStorageItem("session", pTemplateType, "{}");
     const templates = JSON.parse(templatesText);
     const keys = Object.keys(templates).sort();
     for (const key of keys) {
@@ -51,7 +56,7 @@ export class CommandBox {
       if (!description) {
         description = "(" + key + ")";
       }
-      menu.addMenuItem(
+      pMenu.addMenuItem(
         description,
         () => {
           CommandBox._applyTemplate(template);

--- a/saltgui/static/scripts/pages/Templates.js
+++ b/saltgui/static/scripts/pages/Templates.js
@@ -22,7 +22,8 @@ export class TemplatesPage extends Page {
 
   static isVisible () {
     // show template menu item if templates defined
-    const templatesText = Utils.getStorageItem("session", "templates", "");
-    return templatesText;
+    const templatesMasterText = Utils.getStorageItem("session", "templates_master", "");
+    const templatesJsonText = Utils.getStorageItem("session", "templates_json", "");
+    return templatesMasterText || templatesJsonText;
   }
 }

--- a/saltgui/static/scripts/panels/Login.js
+++ b/saltgui/static/scripts/panels/Login.js
@@ -284,17 +284,29 @@ export class LoginPanel extends Panel {
   _onLoginSuccess () {
     this._showNoticeText("#4CAF50", "Please wait...", "notice_please_wait");
 
+    // these values were only used before login
     Utils.setStorageItem("local", "salt-motd-txt", "");
     Utils.setStorageItem("local", "salt-motd-html", "");
 
     // We need these functions to populate the dropdown boxes
     const wheelConfigValuesPromise = this.api.getWheelConfigValues();
-
-    // We need these functions to populate the dropdown boxes
     wheelConfigValuesPromise.then((pWheelConfigValuesData) => {
       LoginPanel._handleLoginWheelConfigValues(pWheelConfigValuesData);
       return true;
     }, () => false);
+
+    const staticTemplatesJsonPromise = this.api.getStaticTemplatesJson();
+    staticTemplatesJsonPromise.then((pStaticTemplatesJson) => {
+      if (pStaticTemplatesJson) {
+        Utils.setStorageItem("session", "templates_json", JSON.stringify(pStaticTemplatesJson));
+      } else {
+        Utils.setStorageItem("session", "templates_json", "{}");
+      }
+      return true;
+    }, () => {
+      Utils.setStorageItem("session", "templates_json", "{}");
+      return false;
+    });
 
     // allow the success message to be seen
     window.setTimeout(() => {
@@ -311,7 +323,7 @@ export class LoginPanel extends Panel {
     // store for later use
 
     const templates = wheelConfigValuesData.saltgui_templates;
-    Utils.setStorageItem("session", "templates", JSON.stringify(templates));
+    Utils.setStorageItem("session", "templates_master", JSON.stringify(templates));
 
     const reactors = wheelConfigValuesData.reactor;
     Utils.setStorageItem("session", "reactors", JSON.stringify(reactors));

--- a/saltgui/static/scripts/panels/Options.js
+++ b/saltgui/static/scripts/panels/Options.js
@@ -41,7 +41,8 @@ export class OptionsPanel extends Panel {
         "state-output-pct", null, "false",
         [["output-pct", "true", "false"]]
       ],
-      ["templates", null, "(none)"],
+      ["templates-master", null, "(none)"],
+      ["templates-json", null, "(none)"],
       ["public-pillars", "saltgui", "(none)"],
       ["preview-grains", "saltgui", "(none)"],
       ["hide-jobs", "saltgui", "(none)"],

--- a/saltgui/static/scripts/panels/Templates.js
+++ b/saltgui/static/scripts/panels/Templates.js
@@ -12,7 +12,7 @@ export class TemplatesPanel extends Panel {
 
     this.addTitle("Templates");
     this.addSearchButton();
-    this.addTable(["Name", "Description", "Target", "Command", "-menu-"]);
+    this.addTable(["Name", "Location", "Description", "Target", "Command", "-menu-"]);
     this.setTableSortable("Name", "asc");
     this.setTableClickable();
     this.addMsg();
@@ -36,28 +36,36 @@ export class TemplatesPanel extends Panel {
     }
 
     // should we update it or just use from cache (see commandbox) ?
-    let templates = pWheelConfigValuesData.return[0].data.return.saltgui_templates;
-    if (templates) {
-      Utils.setStorageItem("session", "templates", JSON.stringify(templates));
+    let masterTemplates = pWheelConfigValuesData.return[0].data.return.saltgui_templates;
+    if (masterTemplates) {
+      Utils.setStorageItem("session", "templates", JSON.stringify(masterTemplates));
       Router.updateMainMenu();
     } else {
-      templates = {};
-    }
-    const keys = Object.keys(templates).sort();
-    for (const key of keys) {
-      const template = templates[key];
-      this._addTemplate(key, template);
+      masterTemplates = {};
     }
 
-    const txt = Utils.txtZeroOneMany(keys.length,
+    const masterKeys = Object.keys(masterTemplates).sort();
+    for (const key of masterKeys) {
+      const template = masterTemplates[key];
+      this._addTemplate("master", key, template);
+    }
+
+    const totalKeys = masterKeys.length;
+    let txt = Utils.txtZeroOneMany(totalKeys,
       "No templates", "{0} template", "{0} templates");
+    if (masterKeys.length > 0 && masterKeys.length !== totalKeys) {
+      txt += Utils.txtZeroOneMany(masterKeys.length,
+        "", ", {0} master template", ", {0} master templates");
+    }
     this.setMsg(txt);
   }
 
-  _addTemplate (pTemplateName, template) {
+  _addTemplate (pLocation, pTemplateName, template) {
     const tr = document.createElement("tr");
 
     tr.appendChild(Utils.createTd("name", pTemplateName));
+
+    tr.appendChild(Utils.createTd("location", pLocation));
 
     // calculate description
     const description = template["description"];

--- a/saltgui/static/scripts/panels/Templates.js
+++ b/saltgui/static/scripts/panels/Templates.js
@@ -38,7 +38,7 @@ export class TemplatesPanel extends Panel {
     // should we update it or just use from cache (see commandbox) ?
     let masterTemplates = pWheelConfigValuesData.return[0].data.return.saltgui_templates;
     if (masterTemplates) {
-      Utils.setStorageItem("session", "templates", JSON.stringify(masterTemplates));
+      Utils.setStorageItem("session", "templates_master", JSON.stringify(masterTemplates));
       Router.updateMainMenu();
     } else {
       masterTemplates = {};
@@ -48,6 +48,14 @@ export class TemplatesPanel extends Panel {
     for (const key of masterKeys) {
       const template = masterTemplates[key];
       this._addTemplate("master", key, template);
+    }
+
+    const saltTemplatesJsonTxt = Utils.getStorageItem("session", "templates_json", {});
+    const saltTemplatesJson = JSON.parse(saltTemplatesJsonTxt);
+    const saltTemplatesKeys = Object.keys(saltTemplatesJson).sort();
+    for (const key of saltTemplatesKeys) {
+      const template = saltTemplatesJson[key];
+      this._addTemplate("salt-templates.json", key, template);
     }
 
     const totalKeys = masterKeys.length;


### PR DESCRIPTION
Currently, templates can be defined in the `master` file.
But that has a disadvantage in 2 cases:
* changing a profile needs a salt-master and/or salt-api restart
* salt-api may be configured to run on a different host; in that case having setting in the master file should be avoided; this is because the purpose of separating salt-master and salt-api to to get a higher availability of the salt-master. making changes often and requiring a restart is opposite of that.

Add a function to read templates from a separate file `saltgui/static/salt-templates.json`.