### PR TITLE
custom command help

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The version tagged `release` is the latest released version. The version `master
 - View the live events on the salt-event bus
 - View internal documentation for any salt command
 - View external documentation for any salt command
+- Define your own custom documentation for commands
 - Match list of minions against reference list
 - Match status of minions against reference list
 
@@ -190,6 +191,21 @@ saltgui_public_pillars:
     - pub_.*
 ```
 
+## Custom command documentation
+A custom HTML help text can be shown from the "Manual Run" overlay.
+
+Therefor,
+- specify saltgui_custom_command_help in the salt master config. Example:
+```
+saltgui_custom_command_help: |
+  <h2>Job Commands</h2>
+    runners.jobs.active
+      => Show active jobs
+      
+    runners.jobs.list_job «JID»
+      => Show job with given job id (JID)
+```
+- Hover the documentation icon (`📖︎`) near the command input field and select `Show custom help`
 
 ## Message-of-the-day
 A message-of-the-day (motd) can be added to the login screen.

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ saltgui_public_pillars:
 A custom HTML help text can be shown from the "Manual Run" overlay.
 
 Therefor,
-- specify saltgui_custom_command_help in the salt master config. Example:
+- specify `saltgui_custom_command_help` in the salt master config. Example:
 ```
 saltgui_custom_command_help: |
   <h2>Job Commands</h2>

--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -62,8 +62,6 @@
         <!-- 2753 = BLACK QUESTION MARK ORNAMENT -->
         <!-- FE0E = VARIATION SELECTOR-15 (render as text) -->
         <span id="help" class="small-button small-button-right small-button-for-click" style="cursor: help">&#x2753;&#xFE0E;</span>
-        <!-- 03BB = GREEK SMALL LETTER LAMDA -->
-        <span id="custom-command-help" class="small-button small-button-right small-button-for-click" style="cursor: help">&#x03BB;</span>
         <div><h1>Manual Run</h1><p id="template-menu-here"></p></div>
         <div id="target-box"><input list="data-list-target" id='target' type='text' placeholder="Target" spellcheck="false" style="margin-right: 10px"/></div>
         <div id="cmd-box"><input id='command' type='text' placeholder="Command" spellcheck="false" style="margin-right: 10px"/></div>

--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -62,6 +62,8 @@
         <!-- 2753 = BLACK QUESTION MARK ORNAMENT -->
         <!-- FE0E = VARIATION SELECTOR-15 (render as text) -->
         <span id="help" class="small-button small-button-right small-button-for-click" style="cursor: help">&#x2753;&#xFE0E;</span>
+        <!-- 03BB = GREEK SMALL LETTER LAMDA -->
+        <span id="custom-command-help" class="small-button small-button-right small-button-for-click" style="cursor: help">&#x03BB;</span>
         <div><h1>Manual Run</h1><p id="template-menu-here"></p></div>
         <div id="target-box"><input list="data-list-target" id='target' type='text' placeholder="Target" spellcheck="false" style="margin-right: 10px"/></div>
         <div id="cmd-box"><input id='command' type='text' placeholder="Command" spellcheck="false" style="margin-right: 10px"/></div>

--- a/saltgui/static/scripts/CommandBox.js
+++ b/saltgui/static/scripts/CommandBox.js
@@ -27,9 +27,17 @@ export class CommandBox {
 
     const manualRun = document.getElementById("popup-run-command");
     Utils.addTableHelp(manualRun, "Click for help", "bottom-center");
+
     const helpButton = manualRun.querySelector("#help");
     helpButton.addEventListener("click", (pClickEvent) => {
       CommandBox._showHelp();
+      pClickEvent.stopPropagation();
+    });
+
+    const customCommandHelpButton = manualRun.querySelector("#custom-command-help");
+    Utils.addToolTip(customCommandHelpButton, "Click for custom command help", "bottom-center");
+    customCommandHelpButton.addEventListener("click", (pClickEvent) => {
+      this._showCustomCommandHelp();
       pClickEvent.stopPropagation();
     });
   }
@@ -128,6 +136,33 @@ export class CommandBox {
     txt += "</p>";
 
     output.innerHTML = txt;
+  }
+
+  _showCustomCommandHelp () {
+    const output = document.querySelector(".run-command pre");
+    output.innerHTML = "";
+
+    const _handleWheelConfigValuesResponseForCustomCommandHelp = (pWheelConfigValuesData, wasSuccessful) => {
+      if (!wasSuccessful) {
+        output.innerHTML = "Error fetching custom command help from config values. Are you logged in?";
+        return;
+      }
+
+      const wheelConfigValuesData = pWheelConfigValuesData.return[0].data.return;
+      const saltgui_custom_command_help = wheelConfigValuesData.saltgui_custom_command_help;
+
+      if (!saltgui_custom_command_help) {
+        output.innerHTML = "No custom command help found.<br/>"
+                           + "Please, set saltgui_custom_command_help in salt config.";
+        return;
+      }
+
+      output.innerHTML = saltgui_custom_command_help;
+    }
+
+    this.api.getWheelConfigValues()
+      .then(pWheelConfigValuesData => _handleWheelConfigValuesResponseForCustomCommandHelp(pWheelConfigValuesData, true),
+            () => _handleWheelConfigValuesResponseForCustomCommandHelp({}, false));
   }
 
   _registerCommandBoxEventListeners () {

--- a/saltgui/static/scripts/CommandBox.js
+++ b/saltgui/static/scripts/CommandBox.js
@@ -33,13 +33,6 @@ export class CommandBox {
       CommandBox._showHelp();
       pClickEvent.stopPropagation();
     });
-
-    const customCommandHelpButton = manualRun.querySelector("#custom-command-help");
-    Utils.addToolTip(customCommandHelpButton, "Click for custom command help", "bottom-center");
-    customCommandHelpButton.addEventListener("click", (pClickEvent) => {
-      this._showCustomCommandHelp();
-      pClickEvent.stopPropagation();
-    });
   }
 
   static _populateTemplateMenu () {
@@ -138,33 +131,6 @@ export class CommandBox {
     output.innerHTML = txt;
   }
 
-  _showCustomCommandHelp () {
-    const output = document.querySelector(".run-command pre");
-    output.innerHTML = "";
-
-    const _handleWheelConfigValuesResponseForCustomCommandHelp = (pWheelConfigValuesData, wasSuccessful) => {
-      if (!wasSuccessful) {
-        output.innerHTML = "Error fetching custom command help from config values. Are you logged in?";
-        return;
-      }
-
-      const wheelConfigValuesData = pWheelConfigValuesData.return[0].data.return;
-      const saltgui_custom_command_help = wheelConfigValuesData.saltgui_custom_command_help;
-
-      if (!saltgui_custom_command_help) {
-        output.innerHTML = "No custom command help found.<br/>"
-                           + "Please, set saltgui_custom_command_help in salt config.";
-        return;
-      }
-
-      output.innerHTML = saltgui_custom_command_help;
-    }
-
-    this.api.getWheelConfigValues()
-      .then(pWheelConfigValuesData => _handleWheelConfigValuesResponseForCustomCommandHelp(pWheelConfigValuesData, true),
-            () => _handleWheelConfigValuesResponseForCustomCommandHelp({}, false));
-  }
-
   _registerCommandBoxEventListeners () {
     document.getElementById("popup-run-command").addEventListener(
       "click", (pClickEvent) => {
@@ -177,7 +143,7 @@ export class CommandBox {
       });
     document.getElementById("button-manual-run").addEventListener(
       "click", (pClickEvent) => {
-        CommandBox.showManualRun(this.api);
+        this.showManualRun(this.api);
         pClickEvent.stopPropagation();
       });
     document.getElementById("cmd-close-button").addEventListener(
@@ -366,7 +332,7 @@ export class CommandBox {
     button.disabled = false;
   }
 
-  static showManualRun (pApi) {
+  showManualRun (pApi) {
     const manualRun = document.getElementById("popup-run-command");
     manualRun.style.display = "block";
 
@@ -430,6 +396,8 @@ export class CommandBox {
     }, () => {
       // VOID
     });
+
+    this.documentation.initCustomCommandHelpButton();
   }
 
   static hideManualRun () {

--- a/saltgui/static/scripts/Documentation.js
+++ b/saltgui/static/scripts/Documentation.js
@@ -16,6 +16,8 @@ export class Documentation {
   constructor (pRouter, pCommandBox) {
     this.router = pRouter;
     this.commandbox = pCommandBox;
+    this.api = pCommandBox.api;
+    this._isCustomCommandHelpButtonInitialized = false;
 
     pCommandBox.cmdmenu.addMenuItem(
       () => Documentation._manualRunMenuSysDocPrepare(),
@@ -31,6 +33,44 @@ export class Documentation {
     Documentation.EXTERNAL_LINK = Character.NO_BREAK_SPACE + Character.EXTERNAL_LINK_IMG;
 
     Documentation.PROVIDERS = { };
+  }
+
+  initCustomCommandHelpButton() {
+    // This method requires makes use of this.api, which requires a valid session.
+    // Thus, it cannot be used immediately in the constructor.
+
+    if (this._isCustomCommandHelpButtonInitialized) {
+      return;
+    }
+
+    this._getCustomCommandHelpPromise()
+    .then(customCommandHelp => {
+      if (!customCommandHelp) {
+        // Only show the button if the custom command help text has been defined.
+        return;
+      }
+
+      this.commandbox.cmdmenu.addMenuItem(
+        () => "Show custom help",
+        () => this._showCustomCommandHelp(customCommandHelp));
+      this._isCustomCommandHelpButtonInitialized = true;
+    })
+  }
+
+  _showCustomCommandHelp (customCommandHelp) {
+    const output = document.querySelector(".run-command pre");
+    output.innerHTML = customCommandHelp;
+  }
+
+  _getCustomCommandHelpPromise() {
+    return new Promise(onSuccess => {
+      this.api.getWheelConfigValues().
+        then(pWheelConfigValuesData => {
+          const wheelConfigValuesData = pWheelConfigValuesData.return[0].data.return;
+          const saltgui_custom_command_help = wheelConfigValuesData.saltgui_custom_command_help;
+          onSuccess(saltgui_custom_command_help);
+        })
+    });
   }
 
   // INTERNAL DOCUMENTATION


### PR DESCRIPTION
Button to show "custom command help", which is defined in salt master configuration

I very much like the command help from the '?' button.
Similarly, I want to be able to provide my own command help, with commands that we use frequently.
I know there are command templates. However, I wanted to provide a more general help.

- There is now a new button to show custom help text in the run-command-overlay
- Clicking the button fetches the salt config and creates the help text from config element `saltgui_custom_command_help`
    - Note that it is also possible to provide other help here, not necessarily related to commands.

For example, the following config:
```
saltgui_custom_command_help: |
  <h2>Job Commands</h2>
    runners.jobs.active
      => Show active jobs
      
    runners.jobs.list_job «JID»
      => Show job with given id
```

Results in the following help:
![2022-03-16 11_10_55-SaltGUI](https://user-images.githubusercontent.com/14967033/158567140-a36a71aa-0027-4bff-a15e-f6538b072e37.png)


