### PR TITLE
should always use full_return

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -110,6 +110,10 @@ minions, or with `*` when all minions are connected, or with an expression when 
 
 Commands can be run normally, in which case the command runs to completion and shows the results. Alternatively, it can be started asynchronously, in which case only a bit of progress information is shown. When variable `state_events` is set to `true`, then the progress is shown per state when applicable. Batch commands are not supported at this time.
 
+When executing commands, the setting for api-flag `full_return` is taken from option `saltgui_full_return` in salt master configuration file `/etc/salt/master`.
+When set to `true`, this will result in some more information available in the execution result, e.g. the job-id.
+This flag may (or may not) be applied to the internal commands that SaltGUI uses to show information.
+
 
 ## Output
 SaltGUI shows the data that is returned by the Salt API.

--- a/saltgui/static/scripts/CommandBox.js
+++ b/saltgui/static/scripts/CommandBox.js
@@ -552,10 +552,13 @@ export class CommandBox {
       }
     }
 
+    const fullReturn = Utils.getStorageItemBoolean("session", "full_return");
+
     let params = {};
     if (functionToRun.startsWith("runners.")) {
       params = argsObject;
       params.client = "runner";
+      params["full_return"] = fullReturn;
       // use only the part after "runners." (8 chars)
       params.fun = functionToRun.substring(8);
       if (argsArray.length > 0) {
@@ -578,6 +581,7 @@ export class CommandBox {
       params.client = "local";
       params.fun = functionToRun;
       params.tgt = pTarget;
+      params["full_return"] = fullReturn;
       if (pTargetType) {
         params["tgt_type"] = pTargetType;
       }

--- a/saltgui/static/scripts/panels/Login.js
+++ b/saltgui/static/scripts/panels/Login.js
@@ -411,6 +411,9 @@ export class LoginPanel extends Panel {
     const customHelp = wheelConfigValuesData.saltgui_custom_command_help;
     Utils.setStorageItem("session", "custom_command_help", customHelp);
 
+    const fullReturn = wheelConfigValuesData.saltgui_full_return;
+    Utils.setStorageItem("session", "full_return", fullReturn);
+
     Router.updateMainMenu();
   }
 

--- a/saltgui/static/scripts/panels/Options.js
+++ b/saltgui/static/scripts/panels/Options.js
@@ -54,6 +54,10 @@ export class OptionsPanel extends Panel {
         "datetime-representation", "saltgui", "utc",
         [["representation", "utc", "local", "utc-localtime:utc+localtime", "local-utctime:local+utctime"]]
       ],
+      [
+        "full-return", "saltgui", "false",
+        [["full-return", "true", "false"]]
+      ],
 
       /* note that this is not in the alphabetic order */
       ["show-jobs", "saltgui", "(all)"],
@@ -161,6 +165,10 @@ export class OptionsPanel extends Panel {
           } else if (pName === "tooltip-mode") {
             radio.addEventListener("change", () => {
               this._newToolTipMode();
+            });
+          } else if (pName === "full-return") {
+            radio.addEventListener("change", () => {
+              this._newFullReturn();
             });
           }
 
@@ -480,5 +488,16 @@ export class OptionsPanel extends Panel {
     const toolTipModeTd = this.div.querySelector("#option-tooltip-mode-value");
     toolTipModeTd.innerText = value;
     Utils.setStorageItem("session", "tooltip_mode", value);
+  }
+
+  _newFullReturn () {
+    let value = "";
+    /* eslint-disable curly */
+    if (this._isSelected("full-return", "full-return", "false")) value = "false";
+    if (this._isSelected("full-return", "full-return", "true")) value = "true";
+    /* eslint-enable curly */
+    const fullReturnTd = this.div.querySelector("#option-full-return-value");
+    fullReturnTd.innerText = value;
+    Utils.setStorageItem("session", "full_return", value);
   }
 }


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Some commands return only very simple information, like true/false. This is indistinguishable from the return of `false` on a timeout.

**Describe the solution you'd like**
The API should use `full_return` as much as possible. The response from that clearly indicates success/failure as well as a separate result.

Update: while the data is better separated from the meta-data, it does not indicate success/failure. instead, it provided a result-code separate from the results. but the indication for success/failure is still missing.

Update: this is only relevant for free-format commands, not for the internal commands. When internal commands fail we don't show much extra information anyway.

Update: this must be arranged as a setting `saltgui_use_full_return: True` (default: `False`) as this is a breaking change. not only will the gui show different output, also the job history as maintained by the SaltStack system will change a little bit. And that may be an unpleasant surprise for some.