### PR TITLE
removed minions still show up in issues tab (recreated)

### DIFF
--- a/saltgui/static/scripts/issues/State.js
+++ b/saltgui/static/scripts/issues/State.js
@@ -2,6 +2,7 @@
 
 import {Issues} from "./Issues.js";
 import {JobsPanel} from "../panels/Jobs.js";
+import {Utils} from "../Utils.js";
 
 const MAX_HIGHSTATE_JOBS = 10;
 
@@ -11,24 +12,39 @@ export class StateIssues extends Issues {
 
     const msg = super.onGetIssues(pPanel, "STATE");
 
+    const wheelKeyListAllPromise = this.api.getWheelKeyListAll();
+
     const runnerJobsListJobsPromise = this.api.getRunnerJobsListJobs(["state.apply", "state.highstate", "state.sls_id"]);
 
-    runnerJobsListJobsPromise.then((pRunnerJobsListJobsData) => {
-      Issues.removeCategory(pPanel, "state");
-      this._handleLowstateRunnerJobsListJobs(pPanel, pRunnerJobsListJobsData, msg);
+    wheelKeyListAllPromise.then((pWheelKeyListAllData) => {
+      runnerJobsListJobsPromise.then((pRunnerJobsListJobsData) => {
+        Issues.removeCategory(pPanel, "state");
+        this._handleLowstateRunnerJobsListJobs(pPanel, pRunnerJobsListJobsData, pWheelKeyListAllData, msg);
+        return true;
+      }, (pRunnerJobsListJobsMsg) => {
+        Issues.removeCategory(pPanel, "state");
+        const tr = Issues.addIssue(pPanel, "state", "retrieving");
+        Issues.addIssueMsg(tr, "Could not retrieve list of jobs");
+        Issues.addIssueErr(tr, pRunnerJobsListJobsMsg);
+        Issues.readyCategory(pPanel, msg);
+        return false;
+      });
       return true;
-    }, (pRunnerJobsListJobsMsg) => {
+    }, (pWheelKeyListAllMsg) => {
+      Utils.ignorePromise(runnerJobsListJobsPromise);
       Issues.removeCategory(pPanel, "state");
       const tr = Issues.addIssue(pPanel, "state", "retrieving");
-      Issues.addIssueMsg(tr, "Could not retrieve list of jobs");
-      Issues.addIssueErr(tr, pRunnerJobsListJobsMsg);
+      Issues.addIssueMsg(tr, "Could not retrieve list of keys");
+      Issues.addIssueErr(tr, pWheelKeyListAllMsg);
       Issues.readyCategory(pPanel, msg);
       return false;
     });
   }
 
-  _handleLowstateRunnerJobsListJobs (pPanel, pData, pMsg) {
+  _handleLowstateRunnerJobsListJobs (pPanel, pData, pKeys, pMsg) {
     // due to filter, all jobs are state.apply jobs
+
+    pKeys = pKeys.return[0].data.return.minions;
 
     let jobs = JobsPanel._jobsToArray(pData.return[0]);
     JobsPanel._sortJobs(jobs);
@@ -41,10 +57,10 @@ export class StateIssues extends Issues {
     // this is good only while "State" is the only issue-provider
     pPanel.setPlayPauseButton(jobs.length === 0 ? "none" : "play");
 
-    this._updateNextJob(pPanel, pMsg);
+    this._updateNextJob(pPanel, pMsg, pKeys);
   }
 
-  _updateNextJob (pPanel, pMsg) {
+  _updateNextJob (pPanel, pMsg, pKeys) {
     if (!this.jobs) {
       return;
     }
@@ -58,7 +74,7 @@ export class StateIssues extends Issues {
 
     if (pPanel.playOrPause !== "play") {
       window.setTimeout(() => {
-        this._updateNextJob(pPanel, pMsg);
+        this._updateNextJob(pPanel, pMsg, pKeys);
       }, 1000);
       return;
     }
@@ -68,9 +84,9 @@ export class StateIssues extends Issues {
     const runnerJobsListJobPromise = this.api.getRunnerJobsListJob(job.id);
 
     runnerJobsListJobPromise.then((pRunnerJobsListJobData) => {
-      StateIssues._handleJobRunnerJobsListJob(pPanel, pRunnerJobsListJobData);
+      StateIssues._handleJobRunnerJobsListJob(pPanel, pRunnerJobsListJobData, pKeys);
       window.setTimeout(() => {
-        this._updateNextJob(pPanel, pMsg);
+        this._updateNextJob(pPanel, pMsg, pKeys);
       }, 100);
       return true;
     }, (pRunnerJobsListJobsMsg) => {
@@ -81,10 +97,16 @@ export class StateIssues extends Issues {
     });
   }
 
-  static _handleJobRunnerJobsListJob (pPanel, pJobData) {
+  static _handleJobRunnerJobsListJob (pPanel, pJobData, pKeys) {
     const jobData = pJobData.return[0];
 
     for (const minionId in jobData.Result) {
+
+      if (pKeys.indexOf(minionId) < 0) {
+        // this is no longer a valid minion
+        continue;
+      }
+
       const minionData = jobData.Result[minionId];
       if (minionData.out !== "highstate") {
         // never mind


### PR DESCRIPTION
**Describe the bug**
Removed minions are still in the issues panel

**To Reproduce**
1. add a minion.
2. accept its key
3. run highstate. Make it fail. (other failed state may work as well. haven't tested that)
4. remove minion
5. open issues tab. Minion still mentioned there as failed.

**Expected behavior**
The minion is gone. I expect it to be gone everywhere :)

**Additional context**
If it's just a matter of time before it's erased then there's not really an issue so just close it then.

This issue was re-created from #439, which was accidentally connected to the wrong git branch...