### PR TITLE
(sub)folders for job templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,27 @@ saltgui_templates:
         command: test.version
 ```
 
+When there are a lot of templates, they can be organized into categories.
+e.g.:
+```
+saltgui_templates:
+    template1:
+        description: First template
+        target: "*"
+        command: test.fib num=10
+        category: cat1
+    template2:
+        description: Second template
+        targettype: glob
+        target: dev*
+        command: test.version
+        categories:
+          - cat1
+          - cat2
+```
+When at least one template is assigned to a category, then you can select a template category before
+selecting the actual category. Otherwise that choice remains hidden. Templates can be in multiple categories
+when a list of categories is assigned.
 
 ## Jobs
 SaltGUI shows a maximum of 7 jobs in on the right-hand-side of the screen.

--- a/saltgui/static/scripts/panels/Panel.js
+++ b/saltgui/static/scripts/panels/Panel.js
@@ -154,14 +154,36 @@ export class Panel {
     table.id = this.key + "-table";
     table.classList.add(this.key);
 
+    let anyHiddenColumns = false;
+    if (pColumnNames) {
+      for (const colName of pColumnNames) {
+        if (colName.startsWith("@")) {
+          anyHiddenColumns = true;
+        }
+      }
+    }
+
+    if (anyHiddenColumns) {
+      for (const colName of pColumnNames) {
+        const col = document.createElement("col");
+        if (colName.startsWith("@")) {
+          col.style.visibility = "collapse";
+        }
+        table.append(col);
+      }
+    }
+
     if (pColumnNames) {
       const thead = document.createElement("thead");
       thead.id = this.key + "-table-thead";
       const tr = document.createElement("tr");
       tr.id = this.key + "-table-thead-tr";
 
-      for (const columnName of pColumnNames) {
+      for (let columnName of pColumnNames) {
         const th = document.createElement("th");
+        if (columnName && columnName.startsWith("@")) {
+          columnName = columnName.substr(1);
+        }
         if (columnName && !columnName.startsWith("-")) {
           th.innerText = columnName;
         }

--- a/saltgui/static/scripts/panels/Templates.js
+++ b/saltgui/static/scripts/panels/Templates.js
@@ -12,7 +12,7 @@ export class TemplatesPanel extends Panel {
 
     this.addTitle("Templates");
     this.addSearchButton();
-    this.addTable(["Name", "Description", "Target", "Command", "-menu-"]);
+    this.addTable(["Name", "@Category", "Description", "Target", "Command", "-menu-"]);
     this.setTableSortable("Name", "asc");
     this.setTableClickable();
     this.addMsg();
@@ -58,6 +58,27 @@ export class TemplatesPanel extends Panel {
     const tr = document.createElement("tr");
 
     tr.appendChild(Utils.createTd("name", pTemplateName));
+
+    let categories = [];
+    const categoryColumn = this.table.querySelectorAll("col")[1];
+    if (template.category && typeof template.category === "string") {
+      categories = [template.category];
+    } else if (typeof template.categories === "object" && Array.isArray(template.categories)) {
+      for (const category of template.categories) {
+        if (typeof category === "string") {
+          categories.push(category);
+        }
+      }
+    }
+    if (categories.length) {
+      // show the categories column only when a category was filled in somewhere
+      categoryColumn.removeAttribute("style");
+    }
+    const categoryTh = this.table.querySelectorAll("th")[1];
+    if (categories.length > 1) {
+      categoryTh.innerText = "Categories";
+    }
+    tr.appendChild(Utils.createTd("category", categories.join("\n")));
 
     // calculate description
     const description = template["description"];


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
My templates list is getting a bit long

**Describe the solution you'd like**
I'd love to be able to sort the job templates a bit better instead of just one big list. One way would be in collapsible folders in the same way as you can open and close the job results per minion.

**Describe alternatives you've considered**
I don't really know of another way. If you can think of another way to order or categorize them better, also great..