### PR TITLE
improve table building

### DIFF
--- a/saltgui/static/scripts/CommandBox.js
+++ b/saltgui/static/scripts/CommandBox.js
@@ -440,19 +440,19 @@ export class CommandBox {
     }
     const nodeGroups = Utils.getStorageItemObject("session", "nodegroups");
 
-    const optionConnected = document.createElement("option");
+    const optionConnected = Utils.createElem("option");
     optionConnected.value = "##connected";
     targetList.appendChild(optionConnected);
 
     for (const nodeGroup of Object.keys(nodeGroups).sort()) {
-      const option = document.createElement("option");
+      const option = Utils.createElem("option");
       option.value = "#" + nodeGroup;
       targetList.appendChild(option);
     }
 
     const minions = Utils.getStorageItemList("session", "minions");
     for (const minionId of [...minions].sort()) {
-      const option = document.createElement("option");
+      const option = Utils.createElem("option");
       option.value = minionId;
       targetList.appendChild(option);
     }
@@ -622,15 +622,15 @@ export class CommandBox {
     const id = "run-" + Utils.getIdFromMinionId(eventMinionId);
     let div = document.getElementById(id);
     if (div === null) {
-      div = document.createElement("div");
+      div = Utils.createDiv();
       div.id = "run-" + Utils.getIdFromMinionId(eventMinionId);
       div.style.marginTop = 0;
 
-      const minionSpan1 = document.createElement("span");
+      const minionSpan1 = Utils.createSpan();
       minionSpan1.innerText = eventMinionId;
       div.appendChild(minionSpan1);
 
-      const minionSpan2 = document.createElement("span");
+      const minionSpan2 = Utils.createSpan();
       minionSpan2.innerText = ": " + Character.HOURGLASS_WITH_FLOWING_SAND + " ";
       div.appendChild(minionSpan2);
 
@@ -677,7 +677,7 @@ export class CommandBox {
 
     // make sure there is a black circle for the current event
     while (div.children.length <= eventSeqNr + 2) {
-      const newSpan = document.createElement("span");
+      const newSpan = Utils.createSpan();
       newSpan.innerText = Character.BLACK_CIRCLE;
       div.appendChild(newSpan);
     }
@@ -710,28 +710,28 @@ export class CommandBox {
     minionsList.remove();
 
     // leave some space
-    const spacerDiv = document.createElement("div");
+    const spacerDiv = Utils.createDiv();
     output.appendChild(spacerDiv);
 
     // add new minions list to track progress of this state command
     for (const minionId of CommandBox.minionIds) {
-      const minionDiv = document.createElement("div");
+      const minionDiv = Utils.createDiv();
       minionDiv.id = "run-" + Utils.getIdFromMinionId(minionId);
       minionDiv.style.marginTop = 0;
       minionDiv.classList.add("task-summary");
 
-      const minionSpan1 = document.createElement("span");
+      const minionSpan1 = Utils.createSpan();
       minionSpan1.innerText = minionId;
       minionDiv.appendChild(minionSpan1);
 
-      const minionSpan2 = document.createElement("span");
+      const minionSpan2 = Utils.createSpan();
       minionSpan2.innerText = ": " + Character.HOURGLASS_WITH_FLOWING_SAND + " ";
       minionDiv.appendChild(minionSpan2);
 
       output.appendChild(minionDiv);
     }
 
-    const warnSpan = document.createElement("span");
+    const warnSpan = Utils.createSpan();
     warnSpan.innerText = "\nnote that unresponsive minions will not time out in this overview";
     output.appendChild(warnSpan);
   }

--- a/saltgui/static/scripts/CommandBox.js
+++ b/saltgui/static/scripts/CommandBox.js
@@ -626,12 +626,10 @@ export class CommandBox {
       div.id = "run-" + Utils.getIdFromMinionId(eventMinionId);
       div.style.marginTop = 0;
 
-      const minionSpan1 = Utils.createSpan();
-      minionSpan1.innerText = eventMinionId;
+      const minionSpan1 = Utils.createSpan("", eventMinionId);
       div.appendChild(minionSpan1);
 
-      const minionSpan2 = Utils.createSpan();
-      minionSpan2.innerText = ": " + Character.HOURGLASS_WITH_FLOWING_SAND + " ";
+      const minionSpan2 = Utils.createSpan("", ": " + Character.HOURGLASS_WITH_FLOWING_SAND + " ");
       div.appendChild(minionSpan2);
 
       const output = document.querySelector(".run-command pre");
@@ -642,8 +640,7 @@ export class CommandBox {
     const minionClass = Output.getMinionLabelClass(isSuccess, pData);
 
     const span1 = div.children[0];
-    span1.classList.add("minion-id");
-    span1.classList.add(minionClass);
+    span1.classList.add("minion-id", minionClass);
 
     const span2 = div.children[1];
     span2.innerText = div.children.length > 2 ? ": " : "";
@@ -677,8 +674,7 @@ export class CommandBox {
 
     // make sure there is a black circle for the current event
     while (div.children.length <= eventSeqNr + 2) {
-      const newSpan = Utils.createSpan();
-      newSpan.innerText = Character.BLACK_CIRCLE;
+      const newSpan = Utils.createSpan("", Character.BLACK_CIRCLE);
       div.appendChild(newSpan);
     }
 
@@ -701,8 +697,7 @@ export class CommandBox {
       // not an asynchronous job
       return;
     }
-    labelSpan.classList.remove("minion-id");
-    labelSpan.classList.remove("host-success");
+    labelSpan.classList.remove("minion-id", "host-success");
 
     // remove the initial minions list
     const minionsId = Utils.getIdFromMinionId("minions");
@@ -715,24 +710,22 @@ export class CommandBox {
 
     // add new minions list to track progress of this state command
     for (const minionId of CommandBox.minionIds) {
-      const minionDiv = Utils.createDiv();
+      const minionDiv = Utils.createDiv("task-summary");
       minionDiv.id = "run-" + Utils.getIdFromMinionId(minionId);
       minionDiv.style.marginTop = 0;
-      minionDiv.classList.add("task-summary");
 
-      const minionSpan1 = Utils.createSpan();
-      minionSpan1.innerText = minionId;
+      const minionSpan1 = Utils.createSpan("", minionId);
       minionDiv.appendChild(minionSpan1);
 
-      const minionSpan2 = Utils.createSpan();
-      minionSpan2.innerText = ": " + Character.HOURGLASS_WITH_FLOWING_SAND + " ";
+      const minionSpan2 = Utils.createSpan("", ": " + Character.HOURGLASS_WITH_FLOWING_SAND + " ");
       minionDiv.appendChild(minionSpan2);
 
       output.appendChild(minionDiv);
     }
 
-    const warnSpan = Utils.createSpan();
-    warnSpan.innerText = "\nnote that unresponsive minions will not time out in this overview";
+    const warnSpan = Utils.createSpan(
+      "",
+      "\nnote that unresponsive minions will not time out in this overview");
     output.appendChild(warnSpan);
   }
 }

--- a/saltgui/static/scripts/DropDown.js
+++ b/saltgui/static/scripts/DropDown.js
@@ -1,3 +1,5 @@
+/* global */
+
 import {Character} from "./Character.js";
 import {Utils} from "./Utils.js";
 
@@ -31,8 +33,7 @@ export class DropDownMenu {
       pParentElement = td;
     }
 
-    this.menuDropdown = Utils.createDiv("run-command-button");
-    this.menuDropdown.classList.add("no-search");
+    this.menuDropdown = Utils.createDiv(["run-command-button", "no-search"]);
 
     if (pParentElement.id === "cmd-box") {
       this.menuButton = Utils.createDiv("", Character.OPEN_BOOK);
@@ -46,12 +47,10 @@ export class DropDownMenu {
       // assume it will be a command menu
       this.menuButton = Utils.createDiv("", Character.CH_HAMBURGER);
     }
-    this.menuButton.classList.add("small-button");
+    this.menuButton.classList.add("small-button", "small-button-for-hover", "menu-dropdown");
     if (pIsSmall) {
       this.menuButton.classList.add("small-small-button");
     }
-    this.menuButton.classList.add("small-button-for-hover");
-    this.menuButton.classList.add("menu-dropdown");
     this.menuButton.addEventListener("click", (pClickEvent) => {
       // better support for touch screens where user touch
       // the menu button instead of hovering over it

--- a/saltgui/static/scripts/Utils.js
+++ b/saltgui/static/scripts/Utils.js
@@ -156,10 +156,9 @@ export class Utils {
     }
 
     if (pToolTipText) {
-      const toolTipSpan = Utils.createSpan("", pToolTipText);
-      toolTipSpan.classList.add("no-search");
-      toolTipSpan.classList.add("tooltip-text");
-      toolTipSpan.classList.add("tooltip-text-" + pStyle);
+      const toolTipSpan = Utils.createSpan(
+        ["no-search", "tooltip-text", "tooltip-text-" + pStyle],
+        pToolTipText);
       pToolTipHost.classList.add("tooltip");
 
       // ...then add the new tooltip
@@ -237,10 +236,9 @@ export class Utils {
 
     const searchOptionsMenu = new DropDownMenu(menuAndFieldDiv, true);
 
-    const input = Utils.createElem("input");
+    const input = Utils.createElem("input", "filter-text");
     input.type = "text";
     input.spellcheck = false;
-    input.classList.add("filter-text");
     input.placeholder = Character.LEFT_POINTING_MAGNIFYING_GLASS;
     if (pFieldList) {
       input.setAttribute("list", pFieldList);
@@ -505,8 +503,11 @@ export class Utils {
   }
 
   static createJobStatusSpan (pJobId, pInitialDisplay) {
-    const span = Utils.createSpan("", "", "status" + pJobId);
-    span.innerText = Character.CLOCKWISE_OPEN_CIRCLE_ARROW + Character.NO_BREAK_SPACE;
+    const span = Utils.createSpan(
+      "",
+      Character.CLOCKWISE_OPEN_CIRCLE_ARROW + Character.NO_BREAK_SPACE,
+      "status" + pJobId);
+
     if (!pInitialDisplay) {
       span.style.display = "none";
     }

--- a/saltgui/static/scripts/Utils.js
+++ b/saltgui/static/scripts/Utils.js
@@ -237,7 +237,7 @@ export class Utils {
 
     const searchOptionsMenu = new DropDownMenu(menuAndFieldDiv, true);
 
-    const input = document.createElement("input");
+    const input = Utils.createElem("input");
     input.type = "text";
     input.spellcheck = false;
     input.classList.add("filter-text");
@@ -514,46 +514,45 @@ export class Utils {
     return span;
   }
 
-  static createTd (pClassName, pInnerText, pId) {
-    const td = document.createElement("td");
+  static createElem (pTag, pClassName, pInnerText, pId) {
+    const elem = document.createElement(pTag);
     if (pId) {
-      td.id = pId;
+      elem.id = pId;
     }
     if (pClassName) {
-      td.className = pClassName;
+      if (Array.isArray(pClassName)) {
+        elem.classList.add(...pClassName);
+      } else {
+        elem.className = pClassName;
+      }
     }
     if (pInnerText) {
-      td.innerText = pInnerText;
+      elem.innerText = pInnerText;
     }
-    return td;
+    return elem;
+  }
+
+  // helper function when createElem is used more than
+  // 10 times for a specific pTag
+
+  static createBr (pClassName, pInnerText, pId) {
+    return Utils.createElem("br", pClassName, pInnerText, pId);
   }
 
   static createDiv (pClassName, pInnerText, pId) {
-    const div = document.createElement("div");
-    if (pId) {
-      div.id = pId;
-    }
-    if (pClassName) {
-      div.className = pClassName;
-    }
-    if (pInnerText) {
-      div.innerText = pInnerText;
-    }
-    return div;
+    return Utils.createElem("div", pClassName, pInnerText, pId);
   }
 
   static createSpan (pClassName, pInnerText, pId) {
-    const span = document.createElement("span");
-    if (pId) {
-      span.id = pId;
-    }
-    if (pClassName) {
-      span.className = pClassName;
-    }
-    if (pInnerText) {
-      span.innerText = pInnerText;
-    }
-    return span;
+    return Utils.createElem("span", pClassName, pInnerText, pId);
+  }
+
+  static createTd (pClassName, pInnerText, pId) {
+    return Utils.createElem("td", pClassName, pInnerText, pId);
+  }
+
+  static createTr (pClassName, pInnerText, pId) {
+    return Utils.createElem("tr", pClassName, pInnerText, pId);
   }
 
   static ignorePromise (pPromise) {

--- a/saltgui/static/scripts/issues/Issues.js
+++ b/saltgui/static/scripts/issues/Issues.js
@@ -53,8 +53,7 @@ export class Issues {
     theTr.menu = menu;
 
     const descTd = Utils.createTd();
-    const descSpan = Utils.createSpan();
-    descSpan.classList.add("desc");
+    const descSpan = Utils.createSpan("desc");
     descTd.appendChild(descSpan);
     theTr.appendChild(descTd);
 
@@ -115,9 +114,7 @@ export class Issues {
   onGetIssues (pPanel, pTitle) {
     this.api = pPanel.api;
 
-    const msg = Utils.createDiv();
-    msg.classList.add("msg");
-    msg.innerText = "(loading info for " + pTitle + ")";
+    const msg = Utils.createDiv("msg", "(loading info for " + pTitle + ")");
     pPanel.msg2.appendChild(msg);
 
     return msg;

--- a/saltgui/static/scripts/issues/Issues.js
+++ b/saltgui/static/scripts/issues/Issues.js
@@ -47,13 +47,13 @@ export class Issues {
     // remove a previous incarnation of the same issue
     Issues.removeIssue(pPanel, pCatName, pIssueName);
 
-    const theTr = document.createElement("tr");
+    const theTr = Utils.createTr();
 
     const menu = new DropDownMenu(theTr, true);
     theTr.menu = menu;
 
-    const descTd = document.createElement("td");
-    const descSpan = document.createElement("span");
+    const descTd = Utils.createTd();
+    const descSpan = Utils.createSpan();
     descSpan.classList.add("desc");
     descTd.appendChild(descSpan);
     theTr.appendChild(descTd);
@@ -115,7 +115,7 @@ export class Issues {
   onGetIssues (pPanel, pTitle) {
     this.api = pPanel.api;
 
-    const msg = document.createElement("div");
+    const msg = Utils.createDiv();
     msg.classList.add("msg");
     msg.innerText = "(loading info for " + pTitle + ")";
     pPanel.msg2.appendChild(msg);

--- a/saltgui/static/scripts/output/Output.js
+++ b/saltgui/static/scripts/output/Output.js
@@ -79,7 +79,7 @@ export class Output {
     // replace all returned JIDs to links
     // typically found in the output of an async job
     if (pMinionResponse.match(ParseCommandLine.getPatJid())) {
-      const link = document.createElement("a");
+      const link = Utils.createElem("a");
       link.href = "?id=" + encodeURIComponent(pMinionResponse) + "#job";
       link.innerText = pMinionResponse;
       return link;
@@ -498,13 +498,13 @@ export class Output {
   }
 
   static _addDownload (pParentDiv, pJobId, pObject, pFormatFunction, pTypeLabel, pContentType, pFilenameExtension) {
-    const downloadA = document.createElement("a");
+    const downloadA = Utils.createElem("a");
     downloadA.innerText = pTypeLabel;
     downloadA.style = "float:right; margin-left:10px";
     downloadA.addEventListener("click", (pClickEvent) => {
       // based on one of the answers in:
       // https://stackoverflow.com/questions/4184944/javascript-download-data-to-file-from-content-within-the-page
-      const dummyA = document.createElement("a");
+      const dummyA = Utils.createElem("a");
       const blob = new Blob([pFormatFunction(pObject)], {"type": pContentType});
       /* eslint-disable compat/compat */
       /* URL is not supported in op_mini all, IE 11  compat/compat */
@@ -870,7 +870,7 @@ export class Output {
       div.append(minionRow);
 
       if (minionMultiLine) {
-        div.appendChild(document.createElement("br"));
+        div.appendChild(Utils.createBr());
       }
 
       // move back to the top of the host, that makes

--- a/saltgui/static/scripts/output/Output.js
+++ b/saltgui/static/scripts/output/Output.js
@@ -81,7 +81,6 @@ export class Output {
     if (pMinionResponse.match(ParseCommandLine.getPatJid())) {
       const link = Utils.createElem("a");
       link.href = "?id=" + encodeURIComponent(pMinionResponse) + "#job";
-      link.innerText = pMinionResponse;
       return link;
     }
 
@@ -115,9 +114,7 @@ export class Output {
   static _getNormalOutput (pMinionResponse) {
     const content = Output.formatObject(pMinionResponse);
     const isMultiLineString = Utils.isMultiLineString(content);
-    const element = isMultiLineString ? Utils.createDiv() : Utils.createSpan();
-    element.innerText = content;
-    return element;
+    return Utils.createElem(isMultiLineString ? "div" : "span", "", content);
   }
 
 
@@ -353,16 +350,12 @@ export class Output {
       txt += "\nhidden";
     }
 
-    while (pSpan.classList.length > 0) {
-      pSpan.classList.remove(pSpan.classList.item(0));
-    }
-
     if (pTask.result === null) {
-      pSpan.classList.add("task-skipped");
+      pSpan.className = "task-skipped";
     } else if (pTask.result) {
-      pSpan.classList.add("task-success");
+      pSpan.className = "task-success";
     } else {
-      pSpan.classList.add("task-failure");
+      pSpan.className = "task-failure";
     }
     if (nrChanges) {
       pSpan.classList.add("task-changes");
@@ -892,8 +885,9 @@ export class Output {
         });
       }
 
-      minionOutput.classList.add("minion-output");
-      minionOutput.classList.add(minionMultiLine ? "minion-output-multiple" : "minion-output-single");
+      minionOutput.classList.add(
+        "minion-output",
+        minionMultiLine ? "minion-output-multiple" : "minion-output-single");
       // hide the per-minion details when we have so many minions
       if (triangle && triangle.innerText === Character.WHITE_RIGHT_POINTING_TRIANGLE) {
         minionOutput.style.display = "none";

--- a/saltgui/static/scripts/output/OutputHighstateTaskSaltGui.js
+++ b/saltgui/static/scripts/output/OutputHighstateTaskSaltGui.js
@@ -12,7 +12,7 @@ export class OutputHighstateTaskSaltGui {
     }
 
     if (typeof pTask.changes !== "object" || Array.isArray(pTask.changes)) {
-      pTaskDiv.append(document.createElement("br"));
+      pTaskDiv.append(Utils.createBr());
       pTaskDiv.append(document.createTextNode(pIndent + JSON.stringify(pTask.changes)));
       return;
     }
@@ -27,12 +27,12 @@ export class OutputHighstateTaskSaltGui {
       }
 
       if (typeof change === "string" && Utils.isMultiLineString(change)) {
-        pTaskDiv.append(document.createElement("br"));
+        pTaskDiv.append(Utils.createBr());
         // show multi-line text as a separate block
         pTaskDiv.append(document.createTextNode(pIndent + key + ":"));
         const lines = change.trim().split("\n");
         for (const line of lines) {
-          pTaskDiv.append(document.createElement("br"));
+          pTaskDiv.append(Utils.createBr());
           pTaskDiv.append(document.createTextNode("      " + line));
         }
         continue;
@@ -41,7 +41,7 @@ export class OutputHighstateTaskSaltGui {
       if (Array.isArray(change)) {
         for (const idx in change) {
           const task = change[idx];
-          pTaskDiv.append(document.createElement("br"));
+          pTaskDiv.append(Utils.createBr());
           pTaskDiv.append(document.createTextNode(
             pIndent + key + "[" + idx + "]: " + JSON.stringify(task)));
         }
@@ -50,7 +50,7 @@ export class OutputHighstateTaskSaltGui {
 
       if (change === null || typeof change !== "object") {
         // show all other non-objects in a simple way
-        pTaskDiv.append(document.createElement("br"));
+        pTaskDiv.append(Utils.createBr());
         pTaskDiv.append(document.createTextNode(
           pIndent + key + ": " +
           JSON.stringify(change)));
@@ -59,7 +59,7 @@ export class OutputHighstateTaskSaltGui {
 
       // treat old->new first
       if (change["old"] !== undefined && change["new"] !== undefined) {
-        pTaskDiv.append(document.createElement("br"));
+        pTaskDiv.append(Utils.createBr());
         // place changes on one line
         // don't use arrows here, these are higher than a regular
         // text-line and disturb the text-flow
@@ -80,7 +80,7 @@ export class OutputHighstateTaskSaltGui {
           continue;
         }
 
-        pTaskDiv.append(document.createElement("br"));
+        pTaskDiv.append(Utils.createBr());
         pTaskDiv.append(document.createTextNode(
           pIndent + key + ": " + taskkey + ": " +
           JSON.stringify(change[taskkey])));
@@ -118,12 +118,12 @@ export class OutputHighstateTaskSaltGui {
 
     const indent = "    ";
 
-    taskDiv.append(document.createElement("br"));
+    taskDiv.append(Utils.createBr());
     taskDiv.append(document.createTextNode(
       indent + "Function is " + pFunctionName));
 
     if (pTask.comment) {
-      taskDiv.append(document.createElement("br"));
+      taskDiv.append(Utils.createBr());
       let txt = pTask.comment;
       // trim extra whitespace
       txt = txt.replace(/[ \r\n]+$/g, "");
@@ -135,7 +135,7 @@ export class OutputHighstateTaskSaltGui {
     OutputHighstateTaskSaltGui._addChangesInfo(taskDiv, pTask, indent);
 
     if (pTask["start_time"] !== undefined) {
-      taskDiv.append(document.createElement("br"));
+      taskDiv.append(Utils.createBr());
       const startTime = Output.dateTimeStr("1999, Sep 9 " + pTask.start_time, null, null, true);
       taskDiv.append(document.createTextNode(indent + "Started at " + startTime));
     }
@@ -146,7 +146,7 @@ export class OutputHighstateTaskSaltGui {
         // anything below 10ms is not worth reporting
         // report only the "slow" jobs
         // it still counts for the grand total thought
-        taskDiv.append(document.createElement("br"));
+        taskDiv.append(Utils.createBr());
         taskDiv.append(document.createTextNode(
           indent + "Duration " + Output.getDuration(milliSeconds)));
       }
@@ -175,7 +175,7 @@ export class OutputHighstateTaskSaltGui {
       if (key === "skip_watch") continue; // related to onlyif
       if (key === "start_time") continue; // handled
       /* eslint-enable line-comment-position,no-inline-comments,curly */
-      taskDiv.append(document.createElement("br"));
+      taskDiv.append(Utils.createBr());
       taskDiv.append(document.createTextNode(
         indent + key + " = " + JSON.stringify(item)));
     }

--- a/saltgui/static/scripts/output/OutputHighstateTaskTerse.js
+++ b/saltgui/static/scripts/output/OutputHighstateTaskTerse.js
@@ -25,8 +25,6 @@ export class OutputHighstateTaskTerse {
       txt += " - Duration: " + Output.getDuration(pTask.duration);
     }
 
-    const span = Utils.createSpan();
-    span.innerText = txt;
-    return span;
+    return Utils.createSpan("", txt);
   }
 }

--- a/saltgui/static/scripts/panels/BeaconsMinion.js
+++ b/saltgui/static/scripts/panels/BeaconsMinion.js
@@ -137,7 +137,7 @@ export class BeaconsMinionPanel extends Panel {
 
     const keys = Object.keys(beacons.beacons).sort();
     for (const beaconName of keys) {
-      const tr = document.createElement("tr");
+      const tr = Utils.createTr();
       tr.id = "beacon-" + beaconName;
 
       const nameTd = Utils.createTd("beacon-name", beaconName);

--- a/saltgui/static/scripts/panels/BeaconsMinion.js
+++ b/saltgui/static/scripts/panels/BeaconsMinion.js
@@ -137,8 +137,7 @@ export class BeaconsMinionPanel extends Panel {
 
     const keys = Object.keys(beacons.beacons).sort();
     for (const beaconName of keys) {
-      const tr = Utils.createTr();
-      tr.id = "beacon-" + beaconName;
+      const tr = Utils.createTr("", "", "beacon-" + beaconName);
 
       const nameTd = Utils.createTd("beacon-name", beaconName);
       tr.appendChild(nameTd);
@@ -175,14 +174,12 @@ export class BeaconsMinionPanel extends Panel {
       tr.appendChild(beaconConfigTd);
 
       const beaconTimestampTd = Utils.createTd();
-      const beaconTimestampSpan = Utils.createSpan("beacon-timestamp", initialTimestamp);
-      beaconTimestampSpan.classList.add("beacon-waiting");
+      const beaconTimestampSpan = Utils.createSpan(["beacon-timestamp", "beacon-waiting"], initialTimestamp);
       beaconTimestampTd.appendChild(beaconTimestampSpan);
       tr.appendChild(beaconTimestampTd);
       tr.beaconTimestampSpan = beaconTimestampSpan;
 
-      const beaconValueTd = Utils.createTd("beacon-value", initialValue);
-      beaconValueTd.classList.add("beacon-waiting");
+      const beaconValueTd = Utils.createTd(["beacon-value", "beacon-waiting"], initialValue);
       tr.appendChild(beaconValueTd);
       tr.beaconValueTd = beaconValueTd;
 

--- a/saltgui/static/scripts/panels/Events.js
+++ b/saltgui/static/scripts/panels/Events.js
@@ -72,11 +72,10 @@ export class EventsPanel extends Panel {
     tr.append(tagTd);
 
     // add data value
-    const dataTd = Utils.createTd("event-data");
     const pDataObj = {};
     Object.assign(pDataObj, pData);
     delete pDataObj._stamp;
-    dataTd.innerText = Output.formatObject(pDataObj);
+    const dataTd = Utils.createTd("event-data", Output.formatObject(pDataObj));
     tr.append(dataTd);
 
     tbody.prepend(tr);

--- a/saltgui/static/scripts/panels/Events.js
+++ b/saltgui/static/scripts/panels/Events.js
@@ -54,7 +54,7 @@ export class EventsPanel extends Panel {
     }
 
     const tbody = this.table.tBodies[0];
-    const tr = document.createElement("tr");
+    const tr = Utils.createTr();
 
     // add timestamp value
     const stampTd = Utils.createTd();

--- a/saltgui/static/scripts/panels/Grains.js
+++ b/saltgui/static/scripts/panels/Grains.js
@@ -27,8 +27,7 @@ export class GrainsPanel extends Panel {
     // the div is not added to the DOM yet
     const tr = this.div.querySelector("#grains-table-thead-tr");
     for (const previewGrain of this.previewGrains) {
-      const th = document.createElement("th");
-      th.innerText = previewGrain;
+      const th = document.createElement("th", "", previewGrain);
       tr.appendChild(th);
     }
 

--- a/saltgui/static/scripts/panels/GrainsMinion.js
+++ b/saltgui/static/scripts/panels/GrainsMinion.js
@@ -60,7 +60,7 @@ export class GrainsMinionPanel extends Panel {
 
     const grainNames = Object.keys(grains).sort();
     for (const grainName of grainNames) {
-      const grainTr = document.createElement("tr");
+      const grainTr = Utils.createTr();
 
       const grainNameTd = Utils.createTd("grain-name", grainName);
       grainTr.appendChild(grainNameTd);

--- a/saltgui/static/scripts/panels/HighState.js
+++ b/saltgui/static/scripts/panels/HighState.js
@@ -136,7 +136,7 @@ export class HighStatePanel extends Panel {
       this._addMenuItemStateApply(menu, minionId);
       this._addMenuItemStateApplyTest(menu, minionId);
 
-      minionTr.appendChild(Utils.createTd("", ""));
+      minionTr.appendChild(Utils.createTd());
 
       minionTr.addEventListener("click", (pClickEvent) => {
         const functionField = minionTr.querySelector(".function");
@@ -337,8 +337,7 @@ export class HighStatePanel extends Panel {
 
       minionTr.appendChild(Utils.createTd("minion-id", minionId));
 
-      const minionTd = Utils.createTd("status", "accepted");
-      minionTd.classList.add("accepted");
+      const minionTd = Utils.createTd(["status", "accepted"], "accepted");
       minionTr.appendChild(minionTd);
 
       const jobIdTd = Utils.createTd();
@@ -382,7 +381,7 @@ export class HighStatePanel extends Panel {
       this._addJobsMenuItemShowDetails(menu, jobData, minionId);
 
       const minionResult = jobData.Result[minionId];
-      const tasksTd = Utils.createTd("tasks", "");
+      const tasksTd = Utils.createTd("tasks");
 
       if (typeof minionResult.return !== "object" || Array.isArray(minionResult.return)) {
         Utils.addErrorToTableCell(tasksTd, minionResult.return);

--- a/saltgui/static/scripts/panels/Issues.js
+++ b/saltgui/static/scripts/panels/Issues.js
@@ -26,7 +26,7 @@ export class IssuesPanel extends Panel {
     this.addMsg();
 
     // keep the list of "loading..." messages
-    const msg2 = document.createElement("div");
+    const msg2 = Utils.createDiv();
     this.div.appendChild(msg2);
     this.msg2 = msg2;
 

--- a/saltgui/static/scripts/panels/Job.js
+++ b/saltgui/static/scripts/panels/Job.js
@@ -37,8 +37,8 @@ export class JobPanel extends Panel {
     this._addPanelMenuItemKillJob();
     this._addPanelMenuItemSignalJob();
 
-    const timeH2 = document.createElement("h2");
-    const timeSpan = document.createElement("span");
+    const timeH2 = Utils.createElem("h2");
+    const timeSpan = Utils.createSpan();
     timeSpan.classList.add("time");
     timeH2.appendChild(timeSpan);
     this.div.append(timeH2);
@@ -46,7 +46,7 @@ export class JobPanel extends Panel {
 
     this.addWarningField();
 
-    const output = document.createElement("pre");
+    const output = Utils.createElem("pre");
     output.id = "job-table";
     output.classList.add("output");
     this.output = output;

--- a/saltgui/static/scripts/panels/Job.js
+++ b/saltgui/static/scripts/panels/Job.js
@@ -38,17 +38,14 @@ export class JobPanel extends Panel {
     this._addPanelMenuItemSignalJob();
 
     const timeH2 = Utils.createElem("h2");
-    const timeSpan = Utils.createSpan();
-    timeSpan.classList.add("time");
+    const timeSpan = Utils.createSpan("time");
     timeH2.appendChild(timeSpan);
     this.div.append(timeH2);
     this.timeField = timeSpan;
 
     this.addWarningField();
 
-    const output = Utils.createElem("pre");
-    output.id = "job-table";
-    output.classList.add("output");
+    const output = Utils.createElem("pre", "output", "", "job-table");
     this.output = output;
 
     const searchBox = Utils.makeSearchBox(this.searchButton, this.output, "data-list-job");

--- a/saltgui/static/scripts/panels/JobsDetails.js
+++ b/saltgui/static/scripts/panels/JobsDetails.js
@@ -327,7 +327,7 @@ export class JobsDetailsPanel extends JobsPanel {
   }
 
   addJob (job) {
-    const tr = document.createElement("tr");
+    const tr = Utils.createTr();
     tr.id = Utils.getIdFromJobId(job.id);
     tr.dataset.jobid = job.id;
     tr.appendChild(Utils.createTd("", job.id));

--- a/saltgui/static/scripts/panels/JobsDetails.js
+++ b/saltgui/static/scripts/panels/JobsDetails.js
@@ -359,8 +359,7 @@ export class JobsDetailsPanel extends JobsPanel {
     this._addMenuItemJobsRerunJob(menu, job, argumentsText);
 
     const statusTd = Utils.createTd();
-    const statusSpan = Utils.createSpan("job-status", "loading...");
-    statusSpan.classList.add("no-job-status");
+    const statusSpan = Utils.createSpan(["job-status", "no-job-status"], "loading...");
     statusSpan.addEventListener("click", (pClickEvent) => {
       // show "loading..." only once, but we are updating the whole column
       statusSpan.classList.add("no-job-status");
@@ -375,8 +374,7 @@ export class JobsDetailsPanel extends JobsPanel {
 
     tr.dataset.detailsUnknown = "true";
     const detailsTd = Utils.createTd("details");
-    const detailsSpan = Utils.createSpan("details2", "(click)");
-    detailsSpan.classList.add("no-job-details");
+    const detailsSpan = Utils.createSpan(["details2", "no-job-details"], "(click)");
     detailsSpan.addEventListener("click", (pClickEvent) => {
       detailsSpan.classList.add("no-job-details");
       detailsSpan.innerText = "loading...";

--- a/saltgui/static/scripts/panels/JobsSummary.js
+++ b/saltgui/static/scripts/panels/JobsSummary.js
@@ -32,7 +32,7 @@ export class JobsSummaryPanel extends JobsPanel {
   /* eslint-enable class-methods-use-this */
 
   addJob (job) {
-    const tr = document.createElement("tr");
+    const tr = Utils.createTr();
     tr.id = Utils.getIdFromJobId(job.id);
 
     const td = Utils.createTd();

--- a/saltgui/static/scripts/panels/JobsSummary.js
+++ b/saltgui/static/scripts/panels/JobsSummary.js
@@ -50,8 +50,7 @@ export class JobsSummaryPanel extends JobsPanel {
     const functionDiv = Utils.createDiv("function", functionText);
     td.appendChild(functionDiv);
 
-    const statusSpan = Utils.createSpan("job-status", "loading...");
-    statusSpan.classList.add("no-job-status");
+    const statusSpan = Utils.createSpan(["job-status", "no-job-status"], "loading...");
     // effectively also the whole column, but it does not look like a column on screen
     statusSpan.addEventListener("click", (pClickEvent) => {
       // show "loading..." only once, but we are updating the whole column

--- a/saltgui/static/scripts/panels/Keys.js
+++ b/saltgui/static/scripts/panels/Keys.js
@@ -273,9 +273,8 @@ export class KeysPanel extends Panel {
     minionIdTd.appendChild(minionIdSpan);
     minionTr.appendChild(minionIdTd);
 
-    const accepted = Utils.createTd("status", "accepted");
+    const accepted = Utils.createTd(["status", "accepted"], "accepted");
     accepted.setAttribute("sorttable_customkey", 2);
-    accepted.classList.add("accepted");
     minionTr.appendChild(accepted);
 
     KeysPanel._flagMinion(pMinionId, accepted, minionTr, pMinionsDict);
@@ -296,9 +295,8 @@ export class KeysPanel extends Panel {
     minionIdTd.appendChild(minionIdSpan);
     minionTr.appendChild(minionIdTd);
 
-    const rejected = Utils.createTd("status", "rejected");
+    const rejected = Utils.createTd(["status", "rejected"], "rejected");
     rejected.setAttribute("sorttable_customkey", 4);
-    rejected.classList.add("rejected");
     minionTr.appendChild(rejected);
 
     KeysPanel._flagMinion(pMinionId, rejected, minionTr, pMinionsDict);
@@ -322,9 +320,8 @@ export class KeysPanel extends Panel {
     minionIdTd.appendChild(minionIdSpan);
     minionTr.appendChild(minionIdTd);
 
-    const denied = Utils.createTd("status", "denied");
+    const denied = Utils.createTd(["status", "denied"], "denied");
     denied.setAttribute("sorttable_customkey", 3);
-    denied.classList.add("denied");
     minionTr.appendChild(denied);
 
     KeysPanel._flagMinion(pMinionId, denied, minionTr, pMinionsDict);
@@ -348,11 +345,10 @@ export class KeysPanel extends Panel {
     minionIdTd.appendChild(minionIdSpan);
     minionTr.appendChild(minionIdTd);
 
-    const pre = Utils.createTd("status", "unaccepted");
+    const pre = Utils.createTd(["status", "unaccepted"], "unaccepted");
     // unaccepted comes first because user action is needed
     // all others have the same order as in 'salt-key'
     pre.setAttribute("sorttable_customkey", 1);
-    pre.classList.add("unaccepted");
     minionTr.appendChild(pre);
 
     KeysPanel._flagMinion(pMinionId, pre, minionTr, pMinionsDict);
@@ -382,9 +378,8 @@ export class KeysPanel extends Panel {
     minionIdTd.appendChild(minionIdSpan);
     minionTr.appendChild(minionIdTd);
 
-    const missing = Utils.createTd("status", "missing");
+    const missing = Utils.createTd(["status", "missing"], "missing");
     missing.setAttribute("sorttable_customkey", 5);
-    missing.classList.add("missing");
     minionTr.appendChild(missing);
 
     KeysPanel._flagMinion(pMinionId, missing, minionTr, pMinionsDict);

--- a/saltgui/static/scripts/panels/Login.js
+++ b/saltgui/static/scripts/panels/Login.js
@@ -56,11 +56,10 @@ export class LoginPanel extends Panel {
     form.append(submit);
     this.loginButton = submit;
 
-    const aa = Utils.createElem("a");
+    const aa = Utils.createElem("a", "attribution");
     aa.href = "https://github.com/erwindon/SaltGUI";
     aa.target = "_blank";
     aa.rel = "noopener";
-    aa.classList.add("attribution");
 
     const img = Utils.createElem("img");
     img.src = "static/images/github.png";
@@ -87,9 +86,8 @@ export class LoginPanel extends Panel {
     this.eauthField.append(optgroup);
 
     for (const optionValue of optionValues) {
-      const option = Utils.createElem("option");
+      const option = Utils.createElem("option", "", optionValue);
       option.value = optionValue;
-      option.innerText = optionValue;
       optgroup.append(option);
     }
   }
@@ -98,10 +96,8 @@ export class LoginPanel extends Panel {
     // start fresh
     this.eauthField.innerHTML = "";
 
-    const option1 = Utils.createElem("option");
-    option1.id = "eauth-default";
+    const option1 = Utils.createElem("option", "", "Type", "eauth-default");
     option1.value = "default";
-    option1.innerText = "Type";
     this.eauthField.append(option1);
 
     this._addEauthSection("standard", ["pam"]);
@@ -143,8 +139,7 @@ export class LoginPanel extends Panel {
 
   _showNoticeText (pBackgroundColour, pText, pInfoClass) {
     // create a new child every time to restart the animation
-    const noticeDiv = Utils.createDiv("", pText, "notice");
-    noticeDiv.classList.add(pInfoClass);
+    const noticeDiv = Utils.createDiv(pInfoClass, pText, "notice");
     noticeDiv.style.backgroundColor = pBackgroundColour;
     while (this.noticeWrapperDiv.hasChildNodes()) {
       this.noticeWrapperDiv.removeChild(this.noticeWrapperDiv.firstChild);

--- a/saltgui/static/scripts/panels/Login.js
+++ b/saltgui/static/scripts/panels/Login.js
@@ -13,7 +13,7 @@ export class LoginPanel extends Panel {
 
     // The FORM is important, so that the ENTER key
     // in any field is redirected to the submit button
-    const form = document.createElement("form");
+    const form = Utils.createElem("form");
     this.div.append(form);
 
     const motdTxt = Utils.createDiv("motd");
@@ -28,7 +28,7 @@ export class LoginPanel extends Panel {
     form.append(noticeWrapper);
     this.noticeWrapperDiv = noticeWrapper;
 
-    const username = document.createElement("input");
+    const username = Utils.createElem("input");
     username.type = "text";
     username.id = "username";
     username.placeholder = "Username";
@@ -36,7 +36,7 @@ export class LoginPanel extends Panel {
     form.append(username);
     this.usernameField = username;
 
-    const password = document.createElement("input");
+    const password = Utils.createElem("input");
     password.type = "password";
     password.id = "password";
     password.placeholder = "Password";
@@ -44,25 +44,25 @@ export class LoginPanel extends Panel {
     this.passwordField = password;
 
     // see https://docs.saltstack.com/en/latest/ref/auth/all/index.html
-    const select = document.createElement("select");
+    const select = Utils.createElem("select");
     form.append(select);
     this.eauthField = select;
     this._updateEauthField();
 
-    const submit = document.createElement("input");
+    const submit = Utils.createElem("input");
     submit.id = "login-button";
     submit.type = "submit";
     submit.value = "Login";
     form.append(submit);
     this.loginButton = submit;
 
-    const aa = document.createElement("a");
+    const aa = Utils.createElem("a");
     aa.href = "https://github.com/erwindon/SaltGUI";
     aa.target = "_blank";
     aa.rel = "noopener";
     aa.classList.add("attribution");
 
-    const img = document.createElement("img");
+    const img = Utils.createElem("img");
     img.src = "static/images/github.png";
     aa.append(img);
 
@@ -82,12 +82,12 @@ export class LoginPanel extends Panel {
       return;
     }
 
-    const optgroup = document.createElement("optgroup");
+    const optgroup = Utils.createElem("optgroup");
     optgroup.label = sectionName;
     this.eauthField.append(optgroup);
 
     for (const optionValue of optionValues) {
-      const option = document.createElement("option");
+      const option = Utils.createElem("option");
       option.value = optionValue;
       option.innerText = optionValue;
       optgroup.append(option);
@@ -98,7 +98,7 @@ export class LoginPanel extends Panel {
     // start fresh
     this.eauthField.innerHTML = "";
 
-    const option1 = document.createElement("option");
+    const option1 = Utils.createElem("option");
     option1.id = "eauth-default";
     option1.value = "default";
     option1.innerText = "Type";

--- a/saltgui/static/scripts/panels/Options.js
+++ b/saltgui/static/scripts/panels/Options.js
@@ -83,7 +83,7 @@ export class OptionsPanel extends Panel {
   }
 
   _addOptionRow (pName, pCategory, pDefaultValue, pValues = null) {
-    const tr = document.createElement("tr");
+    const tr = Utils.createTr();
     tr.id = "option-" + pName;
     tr.dataset.defaultValue = pDefaultValue;
 
@@ -99,16 +99,16 @@ export class OptionsPanel extends Panel {
       const span = Utils.createSpan("", "", "option-" + pName + "-value");
       tdValue.appendChild(span);
 
-      const br1 = document.createElement("br");
+      const br1 = Utils.createBr();
       tdValue.appendChild(br1);
 
-      const br2 = document.createElement("br");
+      const br2 = Utils.createBr();
       tdValue.appendChild(br2);
 
       let addSep = false;
       for (const row of pValues) {
         if (addSep) {
-          const br3 = document.createElement("br");
+          const br3 = Utils.createBr();
           tdValue.appendChild(br3);
         }
         addSep = true;
@@ -121,7 +121,7 @@ export class OptionsPanel extends Panel {
             itemLabel = row[i].substring(colonPos + 1);
           }
 
-          const radio = document.createElement("input");
+          const radio = Utils.createElem("input");
           radio.id = "option-" + pName + "-value-" + row[0] + "-" + itemValue;
           radio.type = "radio";
           radio.name = "option-" + pName + "-value-" + row[0];
@@ -157,7 +157,7 @@ export class OptionsPanel extends Panel {
           }
           tdValue.appendChild(radio);
 
-          const label = document.createElement("label");
+          const label = Utils.createElem("label");
           label.htmlFor = radio.id;
           label.innerText = itemLabel;
           label.style.whiteSpace = "nowrap";

--- a/saltgui/static/scripts/panels/Options.js
+++ b/saltgui/static/scripts/panels/Options.js
@@ -157,9 +157,8 @@ export class OptionsPanel extends Panel {
           }
           tdValue.appendChild(radio);
 
-          const label = Utils.createElem("label");
+          const label = Utils.createElem("label", "", itemLabel);
           label.htmlFor = radio.id;
-          label.innerText = itemLabel;
           label.style.whiteSpace = "nowrap";
           tdValue.appendChild(label);
         }

--- a/saltgui/static/scripts/panels/Panel.js
+++ b/saltgui/static/scripts/panels/Panel.js
@@ -42,7 +42,7 @@ export class Panel {
   }
 
   addTitle (pTitle) {
-    const h1 = document.createElement("h1");
+    const h1 = Utils.createElem("h1");
     h1.id = this.key + "-title";
     h1.innerText = pTitle;
     this.div.appendChild(h1);
@@ -55,7 +55,7 @@ export class Panel {
   }
 
   addPanelMenu () {
-    const span = document.createElement("span");
+    const span = Utils.createSpan();
     span.id = this.key + "-menu";
     const menu = new DropDownMenu(span);
     menu.menuButton.classList.add("small-button-left");
@@ -73,7 +73,7 @@ export class Panel {
   }
 
   addSearchButton () {
-    const span = document.createElement("span");
+    const span = Utils.createSpan();
     span.id = this.key + "-search-button";
     span.classList.add("small-button");
     span.classList.add("small-button-left");
@@ -85,7 +85,7 @@ export class Panel {
   }
 
   addPlayPauseButton () {
-    const playButton = document.createElement("span");
+    const playButton = Utils.createSpan();
     playButton.innerText = Character.CH_PLAY;
     playButton.classList.add("small-button");
     playButton.classList.add("small-button-left");
@@ -94,7 +94,7 @@ export class Panel {
     this.div.appendChild(playButton);
     this.playButton = playButton;
 
-    const pauseButton = document.createElement("span");
+    const pauseButton = Utils.createSpan();
     pauseButton.innerText = Character.CH_PAUSE;
     pauseButton.classList.add("small-button");
     pauseButton.classList.add("small-button-left");
@@ -134,7 +134,7 @@ export class Panel {
   }
 
   addHelpButton (pHelpTextArr, pUrl) {
-    const span = document.createElement(pUrl ? "a" : "span");
+    const span = Utils.createElem(pUrl ? "a" : "span");
     span.id = this.key + "-help-button";
     span.classList.add("small-button");
     span.classList.add("small-button-right");
@@ -152,7 +152,7 @@ export class Panel {
   }
 
   addCloseButton () {
-    const span = document.createElement("span");
+    const span = Utils.createSpan();
     span.id = this.key + "-close-button";
     span.classList.add("small-button");
     span.classList.add("small-button-right");
@@ -195,7 +195,7 @@ export class Panel {
   }
 
   addTable (pColumnNames, pFieldList = null) {
-    const table = document.createElement("table");
+    const table = Utils.createElem("table");
     table.id = this.key + "-table";
     table.classList.add(this.key);
 
@@ -210,7 +210,7 @@ export class Panel {
 
     if (anyHiddenColumns) {
       for (const colName of pColumnNames) {
-        const col = document.createElement("col");
+        const col = Utils.createElem("col");
         if (colName.startsWith("@")) {
           col.style.visibility = "collapse";
         }
@@ -219,13 +219,13 @@ export class Panel {
     }
 
     if (pColumnNames) {
-      const thead = document.createElement("thead");
+      const thead = Utils.createElem("thead");
       thead.id = this.key + "-table-thead";
-      const tr = document.createElement("tr");
+      const tr = Utils.createTr();
       tr.id = this.key + "-table-thead-tr";
 
       for (const columnName of pColumnNames) {
-        const th = document.createElement("th");
+        const th = Utils.createElem("th");
         let cn = columnName;
         if (cn && cn.startsWith("@")) {
           cn = cn.substring(1);
@@ -239,7 +239,7 @@ export class Panel {
       table.appendChild(thead);
     }
 
-    const tbody = document.createElement("tbody");
+    const tbody = Utils.createElem("tbody");
     // not needed yet
     // tbody.id = this.key + "-table-tbody";
     table.appendChild(tbody);
@@ -299,7 +299,7 @@ export class Panel {
   }
 
   addConsole () {
-    const console = document.createElement("div");
+    const console = Utils.createDiv();
     console.id = this.key + "-output";
     console.classList.add("output");
     this.div.appendChild(console);
@@ -307,7 +307,7 @@ export class Panel {
   }
 
   addMsg () {
-    const msgDiv = document.createElement("div");
+    const msgDiv = Utils.createDiv();
     msgDiv.id = this.key + "-msg";
     msgDiv.classList.add("msg");
     this.div.appendChild(msgDiv);
@@ -402,7 +402,7 @@ export class Panel {
     td.colSpan = 99;
     Utils.addErrorToTableCell(td, pData, "bottom-left");
 
-    const tr = document.createElement("tr");
+    const tr = Utils.createTr();
     tr.id = "error-row";
     tr.appendChild(td);
 
@@ -432,7 +432,7 @@ export class Panel {
       return;
     }
 
-    minionTr = document.createElement("tr");
+    minionTr = Utils.createTr();
     minionTr.id = Utils.getIdFromMinionId(pMinionId);
     minionTr.dataset.minionId = pMinionId;
 
@@ -459,7 +459,7 @@ export class Panel {
     if (minionTr === null) {
       // minion not found on screen...
       // construct a basic element that can be updated
-      minionTr = document.createElement("tr");
+      minionTr = Utils.createTr();
       minionTr.id = id;
       this.table.querySelector("tbody").appendChild(minionTr);
     }

--- a/saltgui/static/scripts/panels/Panel.js
+++ b/saltgui/static/scripts/panels/Panel.js
@@ -42,9 +42,7 @@ export class Panel {
   }
 
   addTitle (pTitle) {
-    const h1 = Utils.createElem("h1");
-    h1.id = this.key + "-title";
-    h1.innerText = pTitle;
+    const h1 = Utils.createElem("h1", "", pTitle, this.key + "-title");
     this.div.appendChild(h1);
     this.title = h1;
     this.originalTitle = pTitle;
@@ -73,32 +71,25 @@ export class Panel {
   }
 
   addSearchButton () {
-    const span = Utils.createSpan();
-    span.id = this.key + "-search-button";
-    span.classList.add("small-button");
-    span.classList.add("small-button-left");
-    span.classList.add("small-button-for-click");
-    span.classList.add("search-button");
-    span.innerText = Character.LEFT_POINTING_MAGNIFYING_GLASS;
+    const span = Utils.createSpan(
+      ["search-button", "small-button", "small-button-left", "small-button-for-click"],
+      Character.LEFT_POINTING_MAGNIFYING_GLASS,
+      this.key + "-search-button");
     this.div.appendChild(span);
     this.searchButton = span;
   }
 
   addPlayPauseButton () {
-    const playButton = Utils.createSpan();
-    playButton.innerText = Character.CH_PLAY;
-    playButton.classList.add("small-button");
-    playButton.classList.add("small-button-left");
-    playButton.classList.add("small-button-for-click");
+    const playButton = Utils.createSpan(
+      ["small-button", "small-button-left", "small-button-for-click"],
+      Character.CH_PLAY);
     playButton.style.cursor = "pointer";
     this.div.appendChild(playButton);
     this.playButton = playButton;
 
-    const pauseButton = Utils.createSpan();
-    pauseButton.innerText = Character.CH_PAUSE;
-    pauseButton.classList.add("small-button");
-    pauseButton.classList.add("small-button-left");
-    pauseButton.classList.add("small-button-for-click");
+    const pauseButton = Utils.createSpan(
+      ["small-button", "small-button-left", "small-button-for-click"],
+      Character.CH_PAUSE);
     pauseButton.style.display = "none";
     pauseButton.style.cursor = "pointer";
     this.div.appendChild(pauseButton);
@@ -134,12 +125,11 @@ export class Panel {
   }
 
   addHelpButton (pHelpTextArr, pUrl) {
-    const span = Utils.createElem(pUrl ? "a" : "span");
-    span.id = this.key + "-help-button";
-    span.classList.add("small-button");
-    span.classList.add("small-button-right");
-    span.classList.add("small-button-for-hover");
-    span.innerText = Character.BLACK_QUESTION_MARK_ORNAMENT;
+    const span = Utils.createElem(
+      pUrl ? "a" : "span",
+      ["small-button", "small-button-right", "small-button-for-hover"],
+      Character.BLACK_QUESTION_MARK_ORNAMENT,
+      this.key + "-help-button");
     span.style.cursor = "help";
     this.div.appendChild(span);
 
@@ -152,12 +142,10 @@ export class Panel {
   }
 
   addCloseButton () {
-    const span = Utils.createSpan();
-    span.id = this.key + "-close-button";
-    span.classList.add("small-button");
-    span.classList.add("small-button-right");
-    span.classList.add("small-button-for-click");
-    span.innerText = Character.HEAVY_MULTIPLICATION_X;
+    const span = Utils.createSpan(
+      ["small-button", "small-button-right", "small-button-for-click"],
+      Character.HEAVY_MULTIPLICATION_X,
+      this.key + "-close-button");
     this.div.appendChild(span);
 
     span.addEventListener("click", (pClickEvent) => {
@@ -195,9 +183,7 @@ export class Panel {
   }
 
   addTable (pColumnNames, pFieldList = null) {
-    const table = Utils.createElem("table");
-    table.id = this.key + "-table";
-    table.classList.add(this.key);
+    const table = Utils.createElem("table", this.key, "", this.key + "-table");
 
     let anyHiddenColumns = false;
     if (pColumnNames) {
@@ -299,17 +285,13 @@ export class Panel {
   }
 
   addConsole () {
-    const console = Utils.createDiv();
-    console.id = this.key + "-output";
-    console.classList.add("output");
+    const console = Utils.createDiv("output", "", this.key + "-output");
     this.div.appendChild(console);
     this.console = console;
   }
 
   addMsg () {
-    const msgDiv = Utils.createDiv();
-    msgDiv.id = this.key + "-msg";
-    msgDiv.classList.add("msg");
+    const msgDiv = Utils.createDiv("msg", "", this.key + "-msg");
     this.div.appendChild(msgDiv);
     this.msgDiv = msgDiv;
     this.setMsg("(loading)");
@@ -438,8 +420,7 @@ export class Panel {
 
     minionTr.appendChild(Utils.createTd("minion-id", pMinionId));
 
-    const minionTd = Utils.createTd("status", "accepted");
-    minionTd.classList.add("accepted");
+    const minionTd = Utils.createTd(["status", "accepted"], "accepted");
     minionTr.appendChild(minionTd);
 
     minionTr.appendChild(Utils.createTd("os", "loading..."));
@@ -636,7 +617,6 @@ export class Panel {
         }
         addressTd.setAttribute("sorttable_customkey", sorttableCustomkey);
       }
-      addressTd.classList.add("address");
       addressTd.setAttribute("tabindex", -1);
       addressSpan.addEventListener("click", (pClickEvent) => {
         Panel._copyAddress(addressSpan, pClickEvent.ctrlKey || pClickEvent.altKey);
@@ -648,8 +628,7 @@ export class Panel {
       Panel._restoreClickToCopy(addressSpan);
       minionTr.appendChild(addressTd);
     } else {
-      const accepted = Utils.createTd("status", "accepted");
-      accepted.classList.add("accepted");
+      const accepted = Utils.createTd(["status", "accepted"], "accepted");
       minionTr.appendChild(accepted);
     }
 

--- a/saltgui/static/scripts/panels/PillarsMinion.js
+++ b/saltgui/static/scripts/panels/PillarsMinion.js
@@ -75,7 +75,7 @@ export class PillarsMinionPanel extends Panel {
 
     const keys = Object.keys(pillars).sort();
     for (const pillarName of keys) {
-      const pillar = document.createElement("tr");
+      const pillar = Utils.createTr();
 
       const nameTd = Utils.createTd("pillar-name", pillarName);
       pillar.appendChild(nameTd);

--- a/saltgui/static/scripts/panels/Reactors.js
+++ b/saltgui/static/scripts/panels/Reactors.js
@@ -54,7 +54,7 @@ export class ReactorsPanel extends Panel {
   }
 
   _addReactor (pEvent, pReactor) {
-    const tr = document.createElement("tr");
+    const tr = Utils.createTr();
     tr.appendChild(Utils.createTd("", pEvent));
     tr.appendChild(Utils.createTd("", Output.formatObject(pReactor)));
 

--- a/saltgui/static/scripts/panels/Schedules.js
+++ b/saltgui/static/scripts/panels/Schedules.js
@@ -122,8 +122,7 @@ export class SchedulesPanel extends Panel {
 
     minionTr.appendChild(Utils.createTd("minion-id", pMinionId));
 
-    const statusDiv = Utils.createTd("status", "accepted");
-    statusDiv.classList.add("accepted");
+    const statusDiv = Utils.createTd(["status", "accepted"], "accepted");
     minionTr.appendChild(statusDiv);
 
     let cnt;

--- a/saltgui/static/scripts/panels/SchedulesMinion.js
+++ b/saltgui/static/scripts/panels/SchedulesMinion.js
@@ -90,7 +90,7 @@ export class SchedulesMinionPanel extends Panel {
         delete schedule.maxrunning;
       }
 
-      const tr = document.createElement("tr");
+      const tr = Utils.createTr();
 
       const nameTd = Utils.createTd("schedule-name", scheduleName);
       tr.appendChild(nameTd);

--- a/saltgui/static/scripts/panels/Stats.js
+++ b/saltgui/static/scripts/panels/Stats.js
@@ -3,6 +3,7 @@
 import {Character} from "../Character.js";
 import {Output} from "../output/Output.js";
 import {Panel} from "./Panel.js";
+import {Utils} from "../Utils.js";
 
 export class StatsPanel extends Panel {
 
@@ -23,9 +24,9 @@ export class StatsPanel extends Panel {
     if (this.table.tBodies[0].children.length === 0) {
       // cannot do this in the constructor
       // since the framework removes all rows
-      const tr = document.createElement("tr");
+      const tr = Utils.createTr();
       this.table.tBodies[0].appendChild(tr);
-      const td = document.createElement("td");
+      const td = Utils.createTd();
       tr.appendChild(td);
       this.statsTd = td;
     }

--- a/saltgui/static/scripts/panels/Templates.js
+++ b/saltgui/static/scripts/panels/Templates.js
@@ -121,7 +121,7 @@ export class TemplatesPanel extends Panel {
         continue;
       }
       // e.g. <option value="denied">
-      const option = document.createElement("option");
+      const option = Utils.createElem("option");
       option.value = category;
       lov.appendChild(option);
     }
@@ -130,7 +130,7 @@ export class TemplatesPanel extends Panel {
   }
 
   _addTemplate (pTemplateName, template) {
-    const tr = document.createElement("tr");
+    const tr = Utils.createTr();
 
     tr.appendChild(Utils.createTd("name", pTemplateName));
 


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
In a lot of places in SaltGUI, the construction of table fields is a bit primitive.
This can be improved.

**Describe the solution you'd like**
Initially, table fields should be created as TDs.
When a tooltip is added, it should be automatically upgraded to TD+SPAN. Any content must be moved to the SPAN. Any class-information must be moved to the SPAN. Any (relevant?) style-information must be moved to the SPAN.