### PR TITLE
ignore some jobs on highstate page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -237,6 +237,30 @@ saltgui_public_pillars:
     - pub_.*
 ```
 
+## Highstate
+The highstate page provides an overview of the minions and their latest state information.
+At most 10 highstate jobs (`state.apply` or `state.highstate`) are considered.
+
+Individual low-states can be re-tried by clicking on their state symbol.
+Note that since the output of the `state.sls_id` commands is not considered in this overview,
+the result of such action has no effect on this screen.
+Use `state.apply test=true` to update the information without making changes on the minions.
+
+For organisations where the 'saltenv' facility is used, it is possible to limit the jobs that are
+considered to include (or exclude) only specific saltenvs.
+e.g.:
+```
+saltgui_show_saltenvs:
+    - base
+```
+or
+```
+saltgui_hide_saltenvs:
+    - env2
+    - env3
+```
+Typically only one of these variables should be set.
+Jobs that were started without the `saltenv` parameter are always shown.
 
 ## Custom command documentation
 A custom HTML help text can be shown from the "Manual Run" overlay.

--- a/docs/README.md
+++ b/docs/README.md
@@ -260,7 +260,7 @@ saltgui_hide_saltenvs:
     - env3
 ```
 Typically only one of these variables should be set.
-Jobs that were started without the `saltenv` parameter are always shown.
+Jobs that were started without the `saltenv` parameter are, for this purpose only, assumed to use the value `default` for this parameter. This allows these jobs to be hidden/showed using the same mechanism. SaltGUI does not replicate the internal logic of the salt-master and/or the salt-minion to determine which saltenv would actually have been used for such jobs.
 
 ## Custom command documentation
 A custom HTML help text can be shown from the "Manual Run" overlay.

--- a/saltgui/static/scripts/CommandBox.js
+++ b/saltgui/static/scripts/CommandBox.js
@@ -438,8 +438,7 @@ export class CommandBox {
     while (targetList.firstChild) {
       targetList.removeChild(targetList.firstChild);
     }
-    const nodeGroupsText = Utils.getStorageItem("session", "nodegroups", "[]");
-    const nodeGroups = JSON.parse(nodeGroupsText);
+    const nodeGroups = Utils.getStorageItemObject("session", "nodegroups");
 
     const optionConnected = document.createElement("option");
     optionConnected.value = "##connected";
@@ -451,7 +450,7 @@ export class CommandBox {
       targetList.appendChild(option);
     }
 
-    const minions = JSON.parse(Utils.getStorageItem("session", "minions", "[]"));
+    const minions = Utils.getStorageItemList("session", "minions");
     for (const minionId of minions.sort()) {
       const option = document.createElement("option");
       option.value = minionId;

--- a/saltgui/static/scripts/CommandBox.js
+++ b/saltgui/static/scripts/CommandBox.js
@@ -451,7 +451,7 @@ export class CommandBox {
     }
 
     const minions = Utils.getStorageItemList("session", "minions");
-    for (const minionId of minions.sort()) {
+    for (const minionId of [...minions].sort()) {
       const option = document.createElement("option");
       option.value = minionId;
       targetList.appendChild(option);

--- a/saltgui/static/scripts/Documentation.js
+++ b/saltgui/static/scripts/Documentation.js
@@ -803,8 +803,7 @@ export class Documentation {
                 }`
     };
 
-    const beaconsListAvailableStr = Utils.getStorageItem("session", "beacons_list_available", "[]");
-    const beaconsListAvailable = JSON.parse(beaconsListAvailableStr);
+    const beaconsListAvailable = Utils.getStorageItemObject("session", "beacons_list_available");
 
     // show the beacon names
     let html = "<p>Choose a template for 'beacons.add'</p>";

--- a/saltgui/static/scripts/Utils.js
+++ b/saltgui/static/scripts/Utils.js
@@ -600,4 +600,14 @@ export class Utils {
     console.error(...pStr);
     /* eslint-enable no-console */
   }
+
+  static isIncluded (pItem, pAllowList, pDenyList) {
+    if (pAllowList && pAllowList.length > 0) {
+      return pAllowList.includes(pItem);
+    }
+    if (pDenyList && pDenyList.length > 0) {
+      return !pDenyList.includes(pItem);
+    }
+    return true;
+  }
 }

--- a/saltgui/static/scripts/Utils.js
+++ b/saltgui/static/scripts/Utils.js
@@ -68,6 +68,27 @@ export class Utils {
     return null;
   }
 
+  static getStorageItemObject (pStorage, pKeyName, pDefaultValue = {}) {
+    const value = Utils.getStorageItem(pStorage, pKeyName, null);
+    const obj = JSON.parse(value);
+    if (obj !== null && typeof obj === "object" && !Array.isArray(obj)) {
+      return obj;
+    }
+    return pDefaultValue;
+  }
+
+  static getStorageItemList (pStorage, pKeyName, pDefaultValue = []) {
+    const value = Utils.getStorageItem(pStorage, pKeyName, null);
+    const obj = JSON.parse(value);
+    if (typeof obj !== "object") {
+      return [obj];
+    }
+    if (Array.isArray(obj)) {
+      return obj;
+    }
+    return pDefaultValue;
+  }
+
   static getStorageItem (pStorage, pKeyName, pDefaultValue = null) {
     const storage = Utils._getStorage(pStorage);
     if (!storage) {

--- a/saltgui/static/scripts/Utils.js
+++ b/saltgui/static/scripts/Utils.js
@@ -602,6 +602,9 @@ export class Utils {
   }
 
   static isIncluded (pItem, pAllowList, pDenyList) {
+    if (!pItem) {
+      return true;
+    }
     if (pAllowList && pAllowList.length > 0) {
       return pAllowList.includes(pItem);
     }

--- a/saltgui/static/scripts/output/Output.js
+++ b/saltgui/static/scripts/output/Output.js
@@ -723,7 +723,7 @@ export class Output {
 
     // for all other types we consider the output per minion
     // this is more generic and it simplifies the handlers
-    for (const minionId of pMinionData.sort()) {
+    for (const minionId of [...pMinionData].sort()) {
 
       let minionResponse = pResponse[minionId];
 

--- a/saltgui/static/scripts/panels/Grains.js
+++ b/saltgui/static/scripts/panels/Grains.js
@@ -21,11 +21,7 @@ export class GrainsPanel extends Panel {
     this.setTableClickable();
 
     // collect the list of displayed extra grains
-    const previewGrainsText = Utils.getStorageItem("session", "preview_grains", "[]");
-    this.previewGrains = JSON.parse(previewGrainsText);
-    if (!Array.isArray(this.previewGrains)) {
-      this.previewGrains = [];
-    }
+    this.previewGrains = Utils.getStorageItemList("session", "preview_grains");
 
     // add the preview columns (before we sort the table)
     // the div is not added to the DOM yet

--- a/saltgui/static/scripts/panels/HighState.js
+++ b/saltgui/static/scripts/panels/HighState.js
@@ -215,10 +215,10 @@ export class HighStatePanel extends Panel {
     }
   }
 
-  static _getJobNamedParam (pParamName, pJobData) {
+  static _getJobNamedParam (pParamName, pJobData, pDefaultValue) {
     const args = pJobData.Arguments;
     if (!args) {
-      return null;
+      return pDefaultValue;
     }
     for (const arg of args) {
       // for jobs that were started using 'salt-call'
@@ -236,7 +236,7 @@ export class HighStatePanel extends Panel {
         return arg[pParamName];
       }
     }
-    return null;
+    return pDefaultValue;
   }
 
   _handleJobsRunnerJobsListJob (pJobId, pJobData) {
@@ -260,7 +260,7 @@ export class HighStatePanel extends Panel {
 
     const jobData = pJobData.return[0];
 
-    const saltEnv = HighStatePanel._getJobNamedParam("saltenv", jobData);
+    const saltEnv = HighStatePanel._getJobNamedParam("saltenv", jobData, "default");
     if (!Utils.isIncluded(saltEnv, this._showSaltEnvs, this._hideSaltEnvs)) {
       this._afterJob();
       return;

--- a/saltgui/static/scripts/panels/Jobs.js
+++ b/saltgui/static/scripts/panels/Jobs.js
@@ -185,9 +185,7 @@ export class JobsPanel extends Panel {
     const numberOfJobsPresent = jobs.length;
     for (const job of jobs) {
 
-      // Arrays.includes() is only available from ES7/2016
-      if (this._hideJobs.indexOf(job.Function) < 0 ||
-         this._showJobs.indexOf(job.Function) >= 0) {
+      if (Utils.isIncluded(job.Function, this._showJobs, this._hideJobs)) {
         numberOfJobsEligible += 1;
       } else if (pMaxNumberOfJobs !== 99999) {
         continue;

--- a/saltgui/static/scripts/panels/Jobs.js
+++ b/saltgui/static/scripts/panels/Jobs.js
@@ -5,9 +5,13 @@ import {Utils} from "../Utils.js";
 
 export class JobsPanel extends Panel {
 
-  // constructor (pKey) {
-  //   super(pKey);
-  // }
+  constructor (pKey) {
+    super(pKey);
+
+    // collect the list of hidden/shown functions
+    this._showJobs = Utils.getStorageItemList("session", "show_jobs");
+    this._hideJobs = Utils.getStorageItemList("session", "hide_jobs");
+  }
 
   onShow (cnt) {
     const runnerJobsListJobsPromise = this.api.getRunnerJobsListJobs();
@@ -115,19 +119,6 @@ export class JobsPanel extends Panel {
 
     const jobs = JobsPanel._jobsToArray(pData.return[0]);
     JobsPanel._sortJobs(jobs);
-
-    // collect the list of hidden minions
-    const hideJobsText = Utils.getStorageItem("session", "hide_jobs", "[]");
-    this._hideJobs = JSON.parse(hideJobsText);
-    if (!Array.isArray(this._hideJobs)) {
-      this._hideJobs = [];
-    }
-    // collect the list of hidden minions
-    const showJobsText = Utils.getStorageItem("session", "show_jobs", "[]");
-    this._showJobs = JSON.parse(showJobsText);
-    if (!Array.isArray(this._showJobs)) {
-      this._showJobs = [];
-    }
 
     // These jobs are likely started by the SaltGUI
     // do not display them

--- a/saltgui/static/scripts/panels/Login.js
+++ b/saltgui/static/scripts/panels/Login.js
@@ -119,8 +119,7 @@ export class LoginPanel extends Panel {
     // and only while the code is on a branch
 
     // allow user to add any value they want
-    const saltAuthText = Utils.getStorageItem("local", "salt-auth-txt", "[]");
-    const saltAuth = JSON.parse(saltAuthText);
+    const saltAuth = Utils.getStorageItemList("local", "salt-auth-txt");
     this._addEauthSection("salt-auth.txt", saltAuth);
 
     this.eauthField.value = Utils.getStorageItem("local", "eauth", "pam");

--- a/saltgui/static/scripts/panels/Login.js
+++ b/saltgui/static/scripts/panels/Login.js
@@ -340,10 +340,15 @@ export class LoginPanel extends Panel {
     const previewGrains = wheelConfigValuesData.saltgui_preview_grains;
     Utils.setStorageItem("session", "preview_grains", JSON.stringify(previewGrains));
 
-    const hideJobs = wheelConfigValuesData.saltgui_hide_jobs;
-    Utils.setStorageItem("session", "hide_jobs", JSON.stringify(hideJobs));
+    const showSaltEnvs = wheelConfigValuesData.saltgui_show_saltenvs;
+    Utils.setStorageItem("session", "show_saltenvs", JSON.stringify(showSaltEnvs));
+    const hideSaltEnvs = wheelConfigValuesData.saltgui_hide_saltenvs;
+    Utils.setStorageItem("session", "hide_saltenvs", JSON.stringify(hideSaltEnvs));
+
     const showJobs = wheelConfigValuesData.saltgui_show_jobs;
     Utils.setStorageItem("session", "show_jobs", JSON.stringify(showJobs));
+    const hideJobs = wheelConfigValuesData.saltgui_hide_jobs;
+    Utils.setStorageItem("session", "hide_jobs", JSON.stringify(hideJobs));
 
     let nodeGroups = wheelConfigValuesData.nodegroups;
     // Even when not set, the api server gives this an actual value "{}" here.

--- a/saltgui/static/scripts/panels/Options.js
+++ b/saltgui/static/scripts/panels/Options.js
@@ -50,10 +50,15 @@ export class OptionsPanel extends Panel {
         "datetime-representation", "saltgui", "utc",
         [["representation", "utc", "local", "utc-localtime:utc+localtime", "local-utctime:local+utctime"]]
       ],
+
+      /* note that this is not in the alphabetic order */
+      ["show-jobs", "saltgui", "(all)"],
       ["hide-jobs", "saltgui", "(none)"],
 
-      /* show-jobs is not in the alphabetic order, but keep it close to hide-jobs */
-      ["show-jobs", "saltgui", "(all)"],
+      /* note that this is not in the alphabetic order */
+      ["show-saltenvs", "saltgui", "(all)"],
+      ["hide-saltenvs", "saltgui", "(none)"],
+
       ["motd-txt", "saltgui", "(none)"],
       ["motd-html", "saltgui", "(none)"],
       [

--- a/saltgui/static/scripts/panels/PillarsMinion.js
+++ b/saltgui/static/scripts/panels/PillarsMinion.js
@@ -62,11 +62,7 @@ export class PillarsMinionPanel extends Panel {
     }
 
     // collect the public pillars and compile their regexps
-    const publicPillarsText = Utils.getStorageItem("session", "public_pillars", "[]");
-    let publicPillars = JSON.parse(publicPillarsText);
-    if (!Array.isArray(publicPillars)) {
-      publicPillars = [];
-    }
+    const publicPillars = Utils.getStorageItemList("session", "public_pillars");
     for (let i = 0; i < publicPillars.length; i++) {
       try {
         publicPillars[i] = new RegExp(publicPillars[i]);


### PR DESCRIPTION
Hello,
it's not a bug, but questions or improvements.
I am using the separate SaltGUI (1.28.0) solution in a nginx container (nginx:1.21.6). 
Everything works fine but I have 2 problems with the hightstate page:

1) my saltstack master uses a Gitlab as a backend, so to deploy a specific branch with salt, I use this command on the host as an example: `salt-call state.apply saltenv=XXX pillarenv=XXX test=true`  (XXX = git branch)
The problem is that the result of the command will also be displayed on the saltgui hightstate page, but we should only see the results of the master branch and not the result of my XXX branch, because only the master branch is important to define if the server is in highstate or not.
Is it possible to hide these parasitic results in order to keep only the results of the master branch? or any other solution (like to show only the **state.highstate** and hide everything else) ?

2) I have a lot of minions and states, and in the highstate page,  the result of the highstate is far too long:
Is it possible to have only the final result ? and the detail if we click on the green/yellow/red circle ? or another proper solution.
I already tried this solution: https://github.com/erwindon/SaltGUI#performance,  but I didn't see any change, maybe because I use a separate SaltGUI.
**Screenshots**
<img width="938" alt="image" src="https://user-images.githubusercontent.com/102222224/173842557-1caf8b5c-e89b-48cf-b56a-78ddb3818233.png">

thanks a lot.

NOTE: nr. 2 is now in #459 
NOTE: question about salt-syndic (below) is now in #460 