### PR TITLE
Add the possibility to collapse the result of the states in the hightstate

### DIFF
--- a/saltgui/static/scripts/Character.js
+++ b/saltgui/static/scripts/Character.js
@@ -9,6 +9,7 @@ export class Character {
     // VS16 = request emoji representation
     Character._VARIATION_SELECTOR_16 = "\uFE0F";
 
+    Character.MULTIPLICATION_SIGN = "\u00D7";
     Character.NO_BREAK_SPACE = "\u00A0";
     Character.NON_BREAKING_HYPHEN = "\u2011";
     Character.HORIZONTAL_ELLIPSIS = "\u2026";

--- a/saltgui/static/scripts/panels/HighState.js
+++ b/saltgui/static/scripts/panels/HighState.js
@@ -10,6 +10,7 @@ import {TargetType} from "../TargetType.js";
 import {Utils} from "../Utils.js";
 
 const MAX_HIGHSTATE_JOBS = 10;
+const MAX_HIGHSTATE_STATES = 20;
 
 export class HighStatePanel extends Panel {
 
@@ -25,6 +26,7 @@ export class HighStatePanel extends Panel {
     this.addHelpButton([
       "This panel shows the latest state.highstate or state.apply job for each minion.",
       "Only the latest " + MAX_HIGHSTATE_JOBS + " jobs are verified.",
+      "With more than " + MAX_HIGHSTATE_STATES + " states, a summary is shown instead.",
       "Click on an individual state to re-apply only that state."
     ]);
     this.addTable(["Minion", "State", "Latest JID", "Target", "Function", "Start Time", "-menu-", "States"]);
@@ -321,16 +323,19 @@ export class HighStatePanel extends Panel {
         }
 
         // always create the span for the state
-        // we may use it for presentation (keys.length <= 20); or
-        // for information (keys.length > 20)
+        // we may use it for presentation (keys.length <= MAX_HIGHSTATE_STATES); or
+        // for information (keys.length > MAX_HIGHSTATE_STATES)
 
-        const span = Utils.createSpan("", Character.BLACK_CIRCLE);
+        const span = Utils.createSpan("task", Character.BLACK_CIRCLE);
         span.style.backgroundColor = "black";
 
         // this also sets the span's class(es)
         Output._setTaskToolTip(span, data);
 
-        if (keys.length > 20) {
+        // add class here, because it gets lost in _setTaskToolTip
+        span.classList.add("task");
+
+        if (keys.length > MAX_HIGHSTATE_STATES) {
           let statKey = "";
           let prio = 0;
 
@@ -389,6 +394,8 @@ export class HighStatePanel extends Panel {
 
           // remove the priority indicator from the key
           const itemSpan = Utils.createSpan(statKey.substring(2), Character.BLACK_CIRCLE);
+          itemSpan.classList.add("tasksummary");
+          itemSpan.style.backgroundColor = "black";
           summarySpan.append(itemSpan);
         }
 

--- a/saltgui/static/scripts/panels/HighState.js
+++ b/saltgui/static/scripts/panels/HighState.js
@@ -305,24 +305,100 @@ export class HighStatePanel extends Panel {
 
       if (typeof minionResult.return !== "object" || Array.isArray(minionResult.return)) {
         Utils.addErrorToTableCell(tasksTd, minionResult.return);
-      } else {
-        const keys = Object.keys(minionResult.return);
-        for (const key of keys) {
-          const span = Utils.createSpan("", Character.BLACK_CIRCLE);
-          span.style.backgroundColor = "black";
+        minionTr.appendChild(tasksTd);
+        this._afterJob();
+        return;
+      }
 
-          const data = minionResult.return[key];
-          if (typeof data !== "object") {
-            continue;
-          }
-          span.addEventListener("click", (pClickEvent) => {
-            const cmdArr = ["state.sls_id", data.__id__, "mods=", data.__sls__];
-            this.runCommand("", minionId, cmdArr);
-            pClickEvent.stopPropagation();
-          });
-          Output._setTaskToolTip(span, data);
-          tasksTd.append(span);
+      const keys = Object.keys(minionResult.return);
+
+      const stats = {};
+      for (const key of keys) {
+
+        const data = minionResult.return[key];
+        if (typeof data !== "object") {
+          continue;
         }
+
+        // always create the span for the state
+        // we may use it for presentation (keys.length <= 20); or
+        // for information (keys.length > 20)
+
+        const span = Utils.createSpan("", Character.BLACK_CIRCLE);
+        span.style.backgroundColor = "black";
+
+        // this also sets the span's class(es)
+        Output._setTaskToolTip(span, data);
+
+        if (keys.length > 20) {
+          let statKey = "";
+          let prio = 0;
+
+          // statkeys are sortable on their priority
+          if (span.classList.contains("task-skipped")) {
+            statKey = "task-skipped";
+            prio = 31;
+          } else if (span.classList.contains("task-success")) {
+            statKey = "task-success";
+            prio = 41;
+          } else if (span.classList.contains("task-failure")) {
+            statKey = "task-failure";
+            prio = 21;
+          } else {
+            statKey = "task-unknown";
+            prio = 11;
+          }
+
+          if (span.classList.contains("task-changes")) {
+            prio -= 1;
+            statKey += " task-changes";
+          }
+
+          // allow keys to be sortable
+          statKey = prio + statKey;
+
+          if (statKey in stats) {
+            stats[statKey] += 1;
+          } else {
+            stats[statKey] = 1;
+          }
+
+          continue;
+        }
+
+        span.addEventListener("click", (pClickEvent) => {
+          const cmdArr = ["state.sls_id", data.__id__, "mods=", data.__sls__];
+          this.runCommand("", minionId, cmdArr);
+          pClickEvent.stopPropagation();
+        });
+
+        tasksTd.append(span);
+      }
+
+      if (Object.keys(stats).length > 0) {
+
+        const summarySpan = Utils.createSpan("tooltip");
+
+        let sep = "";
+
+        // show the summary when one was build up
+        for (const statKey of Object.keys(stats).sort()) {
+          const sepSpan = Utils.createSpan("", sep + stats[statKey] + Character.MULTIPLICATION_SIGN);
+          summarySpan.append(sepSpan);
+          sep = " ";
+
+          // remove the priority indicator from the key
+          const itemSpan = Utils.createSpan(statKey.substring(2), Character.BLACK_CIRCLE);
+          summarySpan.append(itemSpan);
+        }
+
+        // allow similar navigation, but just only to the job level
+        summarySpan.addEventListener("click", (pClickEvent) => {
+          this.router.goTo("job", {"id": pJobId, "minionid": minionId});
+          pClickEvent.stopPropagation();
+        });
+
+        tasksTd.append(summarySpan);
       }
 
       minionTr.appendChild(tasksTd);

--- a/saltgui/static/stylesheets/page.css
+++ b/saltgui/static/stylesheets/page.css
@@ -63,11 +63,13 @@ td.tasks span {
   padding-bottom: 3px;
 }
 
-td.tasks span:first-child {
+td.tasks span.task:first-child,
+td.tasks span.tasksummary {
   padding-left: 2px;
 }
 
-td.tasks span:last-child {
+td.tasks span.task:last-child,
+td.tasks span.tasksummary {
   padding-right: 2px;
 }
 


### PR DESCRIPTION
Hello,

I am using the separate SaltGUI (1.28.0) solution in a nginx container (nginx:1.21.6).
Everything works fine but I have a problem with the hightstate page:

I have a lot of minions and states, and in the highstate page, the result of the highstate is far too long:
Is it possible to have only the final result with one circle ? and the detail if we click on the green/yellow/red circle ?
or another proper solution to reduce the result ?

I already tried this solution: https://github.com/erwindon/SaltGUI#performance, but I didn't see any change, maybe because I use a separate SaltGUI or maybe its not related with.
Screenshots

<img width="905" alt="image" src="https://user-images.githubusercontent.com/102222224/174041989-bc16a21d-dd59-4c6b-a8f9-6666f832b38b.png">

thanks a lot
