### PR TITLE
syndic: add warning to Keys screen when syndic is in use

### DIFF
--- a/saltgui/static/scripts/Api.js
+++ b/saltgui/static/scripts/Api.js
@@ -433,6 +433,8 @@ export class API {
       } else if (tag.startsWith("salt/job/") && tag.includes("/prog/")) {
         // progress value (exists only for states)
         CommandBox.handleSaltJobProgEvent(tag, data);
+      } else if (tag.startsWith("syndic/")) {
+        pRouter.keysPage.handleSyndicEvent();
       }
 
       pRouter.eventsPage.handleAnyEvent(tag, data);

--- a/saltgui/static/scripts/pages/Keys.js
+++ b/saltgui/static/scripts/pages/Keys.js
@@ -26,4 +26,8 @@ export class KeysPage extends Page {
   handleSaltJobRetEvent (pData) {
     this.jobs.handleSaltJobRetEvent(pData);
   }
+
+  handleSyndicEvent () {
+    this.keys.handleSyndicEvent();
+  }
 }

--- a/saltgui/static/scripts/panels/Keys.js
+++ b/saltgui/static/scripts/panels/Keys.js
@@ -64,36 +64,30 @@ export class KeysPanel extends Panel {
   }
 
   showSyndicInfo (pSyndicEventFound) {
-    const syndicInfo = Utils.getStorageItem("session", "syndic_info", "false-masterofmasters");
-    if (syndicInfo === "true-masterofmasters") {
-      this.setWarningText(
-        "This overview contains only the keys of minions that are connected to this salt-master or to one of its backup instances." +
-        " Keys for minions that are connected to other salt-masters are not shown in this SaltGUI." +
-        " However, commands and information retrieval should be possible for all minions." +
-        " This salt-master is commanding all other salt-masters and salt-minions." +
-        " The minion-list should be complete, but indirectly reachable minions may show a small delay.");
-    } else if (syndicInfo.startsWith("true-")) {
-      this.setWarningText(
-        "This overview contains only the keys of minions that are connected to this salt-master or to one of its backup instances." +
-        " Keys for minions that are connected to other salt-masters are not shown in this SaltGUI." +
-        " Commands and information retrieval should be possible for all directly and indirectly reachable minions." +
-        " This salt-master is commanded by another salt-master, and it is commanding other salt-masters and salt-minions." +
-        " The minion-list will be incomplete, and indirectly reachable minions may show a small delay.");
-    } else if (syndicInfo === "false-masterofmasters") {
-      if (pSyndicEventFound) {
-        this.setWarningText(
-          "This overview contains only the keys of minions that are connected to this salt-master or to one of its backup instances." +
-          " Keys for minions that are connected to other salt-masters are not shown in this SaltGUI." +
-          " Commands and information retrieval should be possible for all directly reachable minions." +
-          " This salt-master is commanded by another salt-master, and it is not commanding other salt-masters and salt-minions." +
-          " The minion-list will be incomplete.");
-      } else {
-        // we are not sure yet, this may be regular standalone salt-master
-      }
-    } else if (syndicInfo.startsWith("false-")) {
-      console.warn("Strange value '" + syndicInfo + "' for syndicInfo, please review the relevant settings");
+    const syndicMaster = Utils.getStorageItem("session", "syndic_master", "");
+    const orderMasters = Utils.getStorageItem("session", "order_masters", "false") === "true";
+
+    let warningText = "";
+
+    if (syndicMaster !== "" && syndicMaster !== "masterofmasters") {
+      warningText += " The syndic-master of this salt-master is '" + syndicMaster + "'.";
+    }
+
+    if (orderMasters) {
+      warningText += " This salt-master is ready to work with salt-syndic nodes.";
+    }
+
+    if (pSyndicEventFound) {
+      warningText += " Events related to salt-syndic are seen in the salt-event-bus.";
+    }
+
+    if (warningText === "") {
+      this.setWarningText();
     } else {
-      console.error("Unknown value '" + syndicInfo + "' for syndicInfo, please report as issue for SaltGUI");
+      warningText += " This overview contains only the keys of minions that are connected to this salt-master.";
+      warningText += " Keys for minions that are connected to other salt-masters are not always shown in this SaltGUI.";
+      warningText += " Commands issued from this salt-master may involve minions that are not listed in SaltGUI.";
+      this.setWarningText("info", warningText.trim());
     }
   }
 

--- a/saltgui/static/scripts/panels/Login.js
+++ b/saltgui/static/scripts/panels/Login.js
@@ -346,8 +346,11 @@ export class LoginPanel extends Panel {
     const showJobs = wheelConfigValuesData.saltgui_show_jobs;
     Utils.setStorageItem("session", "show_jobs", JSON.stringify(showJobs));
 
-    const syndicInfo = wheelConfigValuesData.order_masters + "-" + wheelConfigValuesData.syndic_master;
-    Utils.setStorageItem("session", "syndic_info", syndicInfo);
+    const syndicMaster = wheelConfigValuesData.syndic_master;
+    Utils.setStorageItem("session", "syndic_master", syndicMaster);
+
+    const orderMasters = wheelConfigValuesData.order_masters;
+    Utils.setStorageItem("session", "order_masters", orderMasters);
 
     let nodeGroups = wheelConfigValuesData.nodegroups;
     // Even when not set, the api server gives this an actual value "{}" here.

--- a/saltgui/static/scripts/panels/Login.js
+++ b/saltgui/static/scripts/panels/Login.js
@@ -346,6 +346,9 @@ export class LoginPanel extends Panel {
     const showJobs = wheelConfigValuesData.saltgui_show_jobs;
     Utils.setStorageItem("session", "show_jobs", JSON.stringify(showJobs));
 
+    const syndicInfo = wheelConfigValuesData.order_masters + "-" + wheelConfigValuesData.syndic_master;
+    Utils.setStorageItem("session", "syndic_info", syndicInfo);
+
     let nodeGroups = wheelConfigValuesData.nodegroups;
     // Even when not set, the api server gives this an actual value "{}" here.
     // Let's assume the user never sets that value. Sounds reasonable because

--- a/saltgui/static/scripts/panels/Minions.js
+++ b/saltgui/static/scripts/panels/Minions.js
@@ -93,12 +93,6 @@ export class MinionsPanel extends Panel {
       this._addMenuItemShowPillars(menu, minionId);
       this._addMenuItemShowSchedules(menu, minionId);
       this._addMenuItemShowBeacons(menu, minionId);
-
-      minionTr.addEventListener("click", (pClickEvent) => {
-        const cmdArr = ["state.apply"];
-        this.runCommand("", minionId, cmdArr);
-        pClickEvent.stopPropagation();
-      });
     }
 
     Utils.setStorageItem("session", "minions_pre_length", keys.minions_pre.length);
@@ -197,6 +191,12 @@ export class MinionsPanel extends Panel {
     this._addMenuItemShowPillars(menu, pMinionId);
     this._addMenuItemShowSchedules(menu, pMinionId);
     this._addMenuItemShowBeacons(menu, pMinionId);
+
+    minionTr.addEventListener("click", (pClickEvent) => {
+      const cmdArr = ["state.apply"];
+      this.runCommand("", pMinionId, cmdArr);
+      pClickEvent.stopPropagation();
+    });
   }
 
   _addMenuItemStateApply (pMenu, pMinionId) {

--- a/saltgui/static/scripts/panels/Panel.js
+++ b/saltgui/static/scripts/panels/Panel.js
@@ -653,6 +653,8 @@ export class Panel {
       minionTr.appendChild(accepted);
     }
 
+    minionTr.dataset.minionId = pMinionId;
+
     let saltversion = "---";
     if (typeof pMinionData === "string") {
       saltversion = "";


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
When salt-syndic is in use, there is a difference between the list of keys and the list of minions.
Since the list of keys is then shorter, the user may have the feeling that keys are missing.

**Describe the solution you'd like**
When salt-syndic is in use, show a warning about the possible limited list of keys.

**Additional context**
solution is to read configuration from master file
(previous solution mentioned reacting on specific salt-events)