### PR TITLE
Preserve API_URL in response

### DIFF
--- a/saltgui/static/scripts/Router.js
+++ b/saltgui/static/scripts/Router.js
@@ -320,7 +320,7 @@ export class Router {
       }
       // push history state, so that the address bar holds the correct
       // deep-link; and so that we can use the back-button
-      let url = "/";
+      let url = config.NAV_URL ? config.NAV_URL : "/";
       let sep = "?";
       for (const key in pQuery) {
         const value = pQuery[key];

--- a/saltgui/static/scripts/panels/Panel.js
+++ b/saltgui/static/scripts/panels/Panel.js
@@ -885,8 +885,8 @@ export class Panel {
   static addPrefixImage (pElem, pImageName) {
     const img = document.createElement("img");
     const pngName = pImageName.replace(" ", "-").toLowerCase() + ".png";
-    img.setAttribute("src", config.NAV_URL + "/static/images/" + pngName);
-    img.setAttribute("onerror", "this.onerror=null; this.title='Unknown image, please report to SaltGUI team that image \\'" + pngName + "\\' is missing'; this.src='/static/images/UNKNOWN.png'");
+    img.setAttribute("src", "static/images/" + pngName);
+    img.setAttribute("onerror", "this.onerror=null; this.title='Unknown image, please report to SaltGUI team that image \\'" + pngName + "\\' is missing'; this.src='static/images/UNKNOWN.png'");
     img.classList.add("prefiximage");
     pElem.prepend(img);
   }


### PR DESCRIPTION
Hi, 

first of all I would like to thank you for your great GUI

**Is your feature request related to a problem? Please describe.**
I have SaltGUI with API_URL set as `/saltgui`. So I type  `http://example.com/saltgui` in my browser to log in. 
But after logging in I see `http://example.com/#minions` in my browser.

**Describe the solution you'd like**
Is it possible to set any parameter to see `http://example.com/saltgui/#minions` in my browser?

Thank you.