### PR TITLE
Invalid Date showing with salt 3005.1

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -145,6 +145,8 @@ With `utc-localtime`, the UTC date and time are shown. Additionally, the local t
 With `local-utctime`, the local date and time are shown. Additionally, the UTC time (not the UTC date) is shown.
 In all cases, a tooltip is added to a date+time field that shows the full representation of the date and time in both the local timezone and in UTC.
 
+When using very old browsers, the required date/time functions may not be present. In that case SaltGUI reverts to simply displaying the reported time from the Salt system. The tooltip is then not shown.
+
 
 ## Templates
 SaltGUI supports command templates for easier command entry into the command-box.

--- a/saltgui/static/scripts/output/Output.js
+++ b/saltgui/static/scripts/output/Output.js
@@ -271,8 +271,8 @@ export class Output {
     }
 
     // put the milliseconds in the proper location
-    const utcDTms = utcDT.replace(/( [a-zA-Z.]*)?( [A-Z]*)?$/, fractionSecondsPart + "$&");
-    const localDTms = localDT.replace(/( [a-zA-Z.]*)?( [A-Z]*)?$/, fractionSecondsPart + "$&");
+    const utcDTms = utcDT.replace(/( [a-zA-Z.]*)?( [-A-Z0-9]*)?$/, fractionSecondsPart + "$&");
+    const localDTms = localDT.replace(/( [a-zA-Z.]*)?( [-A-Z0-9]*)?$/, fractionSecondsPart + "$&");
 
     let ret;
     switch (dateTimeRepresentation) {
@@ -296,9 +296,9 @@ export class Output {
     if (pDateTimeField) {
       utcDT = dateObj.toLocaleString(undefined, {"timeZone": "UTC", "timeZoneName": "short"});
       // place the milliseconds after the seconds (before am/pm indicator and timezone)
-      utcDT = utcDT.replace(/( [a-zA-Z.]*)? [A-Z]*$/, originalFractionSecondsPart + "$&");
+      utcDT = utcDT.replace(/( [a-zA-Z.]*)? [-A-Z0-9]*$/, originalFractionSecondsPart + "$&");
       localDT = dateObj.toLocaleString(undefined, {"timeZoneName": "short"});
-      localDT = localDT.replace(/( [a-zA-Z.]*)? [A-Z]*$/, originalFractionSecondsPart + "$&");
+      localDT = localDT.replace(/( [a-zA-Z.]*)? [-A-Z0-9]*$/, originalFractionSecondsPart + "$&");
       pDateTimeField.innerText = ret;
       const txt = utcDT + "\n" + localDT;
       if (txt.search("Invalid") < 0) {

--- a/saltgui/static/scripts/output/Output.js
+++ b/saltgui/static/scripts/output/Output.js
@@ -241,10 +241,16 @@ export class Output {
         // but not the verbose timezone name
         utcDT = dateObj.toTimeString().replace(/ *[(][^)]*[)]$/, "");
       }
+      if (utcDT.search("Invalid") >= 0) {
+        utcDT = pDtStr.replace(/^[-0-9]*T/, "");
+      }
     } else {
       utcDT = dateObj.toLocaleString(undefined, {"timeZone": "UTC", "timeZoneName": "short"});
       if (utcDT.search("Invalid") >= 0) {
         utcDT = dateObj.toString().replace(/ *[(][^)]*[)]$/, "");
+      }
+      if (utcDT.search("Invalid") >= 0) {
+        utcDT = pDtStr;
       }
     }
     utcDT = utcDT.replace(/ *UTC$/, "");
@@ -255,10 +261,16 @@ export class Output {
       if (localDT.search("Invalid") >= 0) {
         localDT = dateObj.toString().replace(/ *[(][^)]*[)]$/, "");
       }
+      if (localDT.search("Invalid") >= 0) {
+        localDT = pDtStr.replace(/^[-0-9]*T/, "");
+      }
     } else {
       localDT = dateObj.toLocaleString(undefined, {"timeZoneName": "short"});
       if (localDT.search("Invalid") >= 0) {
         localDT = dateObj.toString().replace(/ *[(][^)]*[)]$/, "");
+      }
+      if (localDT.search("Invalid") >= 0) {
+        localDT = pDtStr;
       }
     }
     const localTZ = localDT.replace(/^.* /, "");
@@ -271,8 +283,8 @@ export class Output {
     }
 
     // put the milliseconds in the proper location
-    const utcDTms = utcDT.replace(/( [a-zA-Z.]*)?( [-A-Z0-9]*)?$/, fractionSecondsPart + "$&");
-    const localDTms = localDT.replace(/( [a-zA-Z.]*)?( [-A-Z0-9]*)?$/, fractionSecondsPart + "$&");
+    const utcDTms = utcDT.replace(/( [a-zA-Z.]*)?( [-A-Z0-9]*|Z)?$/, fractionSecondsPart + "$&");
+    const localDTms = localDT.replace(/( [a-zA-Z.]*)?( [-A-Z0-9]*|Z)?$/, fractionSecondsPart + "$&");
 
     let ret;
     switch (dateTimeRepresentation) {

--- a/saltgui/static/scripts/output/Output.js
+++ b/saltgui/static/scripts/output/Output.js
@@ -290,9 +290,10 @@ export class Output {
 
     if (pDateTimeField) {
       utcDT = dateObj.toLocaleString(undefined, {"timeZone": "UTC", "timeZoneName": "short"});
-      utcDT = utcDT.replace(/ [A-Z]*$/, originalFractionSecondsPart + "$&");
+      // place the milliseconds after the seconds (before am/pm indicator and timezone)
+      utcDT = utcDT.replace(/( [a-zA-Z.]*)? [A-Z]*$/, originalFractionSecondsPart + "$&");
       localDT = dateObj.toLocaleString(undefined, {"timeZoneName": "short"});
-      localDT = localDT.replace(/ [A-Z]*$/, originalFractionSecondsPart + "$&");
+      localDT = localDT.replace(/( [a-zA-Z.]*)? [A-Z]*$/, originalFractionSecondsPart + "$&");
       pDateTimeField.innerText = ret;
       const txt = utcDT + "\n" + localDT;
       if (txt.search("Invalid") < 0) {

--- a/saltgui/static/scripts/output/Output.js
+++ b/saltgui/static/scripts/output/Output.js
@@ -242,7 +242,7 @@ export class Output {
         utcDT = dateObj.toTimeString().replace(/ *[(][^)]*[)]$/, "");
       }
       if (utcDT.search("Invalid") >= 0) {
-        utcDT = pDtStr.replace(/^[-0-9]*T/, "");
+        utcDT = pDtStr.replace(/^[-0-9]*T/, "").replace(/^1999, Sep 9 /, "");
       }
     } else {
       utcDT = dateObj.toLocaleString(undefined, {"timeZone": "UTC", "timeZoneName": "short"});
@@ -262,7 +262,7 @@ export class Output {
         localDT = dateObj.toString().replace(/ *[(][^)]*[)]$/, "");
       }
       if (localDT.search("Invalid") >= 0) {
-        localDT = pDtStr.replace(/^[-0-9]*T/, "");
+        localDT = pDtStr.replace(/^[-0-9]*T/, "").replace(/^1999, Sep 9 /, "");
       }
     } else {
       localDT = dateObj.toLocaleString(undefined, {"timeZoneName": "short"});

--- a/saltgui/static/scripts/output/Output.js
+++ b/saltgui/static/scripts/output/Output.js
@@ -238,6 +238,7 @@ export class Output {
     if (pTimeOnly || dateTimeRepresentation === "local-utctime") {
       utcDT = dateObj.toLocaleTimeString(undefined, {"timeZone": "UTC", "timeZoneName": "short"});
       if (utcDT.search("Invalid") >= 0) {
+        // but not the verbose timezone name
         utcDT = dateObj.toTimeString().replace(/ *[(][^)]*[)]$/, "");
       }
     } else {
@@ -269,23 +270,27 @@ export class Output {
       localDT = days + localDT;
     }
 
+    // put the milliseconds in the proper location
+    const utcDTms = utcDT.replace(/( [a-zA-Z.]*)?( [A-Z]*)?$/, fractionSecondsPart + "$&");
+    const localDTms = localDT.replace(/( [a-zA-Z.]*)?( [A-Z]*)?$/, fractionSecondsPart + "$&");
+
     let ret;
     switch (dateTimeRepresentation) {
     case "utc":
-      ret = utcDT + fractionSecondsPart;
+      ret = utcDTms;
       break;
     case "local":
-      ret = localDT + fractionSecondsPart + " " + localTZ;
+      ret = localDTms + " " + localTZ;
       break;
     case "utc-localtime":
-      ret = utcDT + fractionSecondsPart + " (" + localDT + " " + localTZ + ")";
+      ret = utcDTms + " (" + localDT + " " + localTZ + ")";
       break;
     case "local-utctime":
-      ret = localDT + fractionSecondsPart + " " + localTZ + " (" + utcDT + ")";
+      ret = localDTms + " " + localTZ + " (" + utcDT + ")";
       break;
     default:
       // unknown format, use traditional representation
-      ret = utcDT + fractionSecondsPart;
+      ret = utcDTms;
     }
 
     if (pDateTimeField) {

--- a/saltgui/static/scripts/output/Output.js
+++ b/saltgui/static/scripts/output/Output.js
@@ -161,6 +161,10 @@ export class Output {
   // (datetime) 2019, Jan 26 19:05:22.808348
   // current action is (only):
   // - reduce the number of digits for the fractional seconds
+
+  // some older browsers cannot produce formatted datetime this way
+  // toLocaleString/toLocaleTimeString then return "Invalid Date"
+  // silently ignore that, provide an alternative and then do not produce a tooltip
   static dateTimeStr (pDtStr, pDateTimeField = null, pDateTimeStyle = "bottom-center", pTimeOnly = false) {
 
     // no available setting, then return the original
@@ -233,16 +237,28 @@ export class Output {
     let utcDT;
     if (pTimeOnly || dateTimeRepresentation === "local-utctime") {
       utcDT = dateObj.toLocaleTimeString(undefined, {"timeZone": "UTC", "timeZoneName": "short"});
+      if (utcDT.search("Invalid") >= 0) {
+        utcDT = dateObj.toTimeString().replace(/ *[(][^)]*[)]$/, "");
+      }
     } else {
       utcDT = dateObj.toLocaleString(undefined, {"timeZone": "UTC", "timeZoneName": "short"});
+      if (utcDT.search("Invalid") >= 0) {
+        utcDT = dateObj.toString().replace(/ *[(][^)]*[)]$/, "");
+      }
     }
     utcDT = utcDT.replace(/ *UTC$/, "");
 
     let localDT;
     if (pTimeOnly || dateTimeRepresentation === "utc-localtime") {
       localDT = dateObj.toLocaleTimeString(undefined, {"timeZoneName": "short"});
+      if (localDT.search("Invalid") >= 0) {
+        localDT = dateObj.toString().replace(/ *[(][^)]*[)]$/, "");
+      }
     } else {
       localDT = dateObj.toLocaleString(undefined, {"timeZoneName": "short"});
+      if (localDT.search("Invalid") >= 0) {
+        localDT = dateObj.toString().replace(/ *[(][^)]*[)]$/, "");
+      }
     }
     const localTZ = localDT.replace(/^.* /, "");
     localDT = localDT.replace(/ [^ ]*$/, "");
@@ -279,7 +295,9 @@ export class Output {
       localDT = localDT.replace(/ [A-Z]*$/, originalFractionSecondsPart + "$&");
       pDateTimeField.innerText = ret;
       const txt = utcDT + "\n" + localDT;
-      Utils.addToolTip(pDateTimeField, txt, pDateTimeStyle);
+      if (txt.search("Invalid") < 0) {
+        Utils.addToolTip(pDateTimeField, txt, pDateTimeStyle);
+      }
     }
 
     return ret;


### PR DESCRIPTION
**Describe the bug**
Salt-master 3005.1 on Ubuntu 20.04, UI shows "Invalid.731210 Date" as and example for all the start times.

Here is the output from the master's console for ```salt '*' state.apply```

```
octopi:
----------
          ID: timezone_packages
    Function: pkg.installed
        Name: tzdata
      Result: True
     Comment: All specified packages are already installed
     Started: 12:09:31.983339
    Duration: 274.309 ms
     Changes:
----------
          ID: dbus_for_timezone
    Function: pkg.installed
        Name: dbus
      Result: True
     Comment: All specified packages are already installed
     Started: 12:09:32.258763
    Duration: 88.489 ms
     Changes:
----------
          ID: dbus_for_timezone
    Function: service.running
        Name: dbus
      Result: True
     Comment: The service dbus is already running
     Started: 12:09:32.356435
    Duration: 189.594 ms
     Changes:
----------
          ID: timezone_setting
    Function: timezone.system
        Name: America/Toronto
      Result: True
     Comment: Timezone America/Toronto already set, UTC already set to America/Toronto
     Started: 12:09:32.554879
    Duration: 214.925 ms
     Changes:

Summary for octopi
------------
Succeeded: 4
Failed:    0
------------
Total states run:     4
Total run time: 767.317 ms
```
Note the timestamp formats for the started time.

**Screenshots**

![Screen Shot 2022-10-20 at 12 16 44](https://user-images.githubusercontent.com/10076016/197003440-f0dd77ca-8a68-4953-a21b-77bdc355d93c.png)

