### PR TITLE
add support for parameter 'state_compress_ids'

### DIFF
--- a/saltgui/static/scripts/output/Output.js
+++ b/saltgui/static/scripts/output/Output.js
@@ -485,6 +485,11 @@ export class Output {
       summarySpan.append(span);
     }
 
+    const stateCompressIds = Utils.getStorageItem("session", "state_compress_ids", "false");
+    if (stateCompressIds === "true") {
+      summarySpan.append(Utils.createSpan("state-details-compressed", Character.NO_BREAK_SPACE + "(state details may be compressed)"));
+    }
+
     pMinionRow.append(summarySpan);
   }
 

--- a/saltgui/static/scripts/panels/Login.js
+++ b/saltgui/static/scripts/panels/Login.js
@@ -381,6 +381,9 @@ export class LoginPanel extends Panel {
     const stateVerbose = wheelConfigValuesData.saltgui_state_verbose;
     Utils.setStorageItem("session", "state_verbose", JSON.stringify(stateVerbose));
 
+    const stateCompressIds = wheelConfigValuesData.state_compress_ids;
+    Utils.setStorageItem("session", "state_compress_ids", stateCompressIds);
+
     const stateOutput = wheelConfigValuesData.saltgui_state_output;
     Utils.setStorageItem("session", "state_output", stateOutput);
 

--- a/saltgui/static/scripts/panels/Options.js
+++ b/saltgui/static/scripts/panels/Options.js
@@ -31,6 +31,10 @@ export class OptionsPanel extends Panel {
       ["perms", "session"],
       ["nodegroups", null, "(none)"],
       [
+        "state-compress-ids", null, "false",
+        [["compress-ids", "true", "false"]]
+      ],
+      [
         "state-output", null, "full",
         [["output", "full", "terse", "mixed", "changes", "full_id", "terse_id", "mixed_id", "changes_id"]]
       ],
@@ -129,6 +133,10 @@ export class OptionsPanel extends Panel {
           if (pName === "state-verbose") {
             radio.addEventListener("change", () => {
               this._newStateVerbose();
+            });
+          } else if (pName === "state-compress-ids") {
+            radio.addEventListener("change", () => {
+              this._newStateCompressIds();
             });
           } else if (pName === "state-output") {
             radio.addEventListener("change", () => {
@@ -366,6 +374,17 @@ export class OptionsPanel extends Panel {
     const stateVerboseTd = this.div.querySelector("#option-state-verbose-value");
     stateVerboseTd.innerText = value;
     Utils.setStorageItem("session", "state_verbose", value);
+  }
+
+  _newStateCompressIds () {
+    let value = "";
+    /* eslint-disable curly */
+    if (this._isSelected("state-compress-ids", "compress-ids", "false")) value = "false";
+    if (this._isSelected("state-compress-ids", "compress-ids", "true")) value = "true";
+    /* eslint-enable curly */
+    const stateCompressIdsTd = this.div.querySelector("#option-state-compress-ids-value");
+    stateCompressIdsTd.innerText = value;
+    Utils.setStorageItem("session", "state_compress_ids", value);
   }
 
   _newStateOutput () {

--- a/saltgui/static/stylesheets/main.css
+++ b/saltgui/static/stylesheets/main.css
@@ -286,3 +286,7 @@ pre.output {
   color: #4caf50;
   cursor: pointer;
 }
+
+.state-details-compressed {
+  color: gray;
+}


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Saltstack recently introduced parameter `state_compress_ids`.
This will change the output for some output models

**Describe the solution you'd like**
Let SaltGUI adjust the output in the same way.

See also https://docs.saltproject.io/en/latest/ref/output/all/salt.output.highstate.html

sample output (`state_compress_ids=false`):
```
salt-minion-1:
  Name: apache-2 xyz - Function: cmd.run - Result: Changed Started: - 01:30:40.995510 Duration: 6.268 ms
  Name: apache-2 xyz - Function: cmd.run - Result: Failed Started: - 01:30:41.019488 Duration: 7.277 ms
  Name: apache-2 xyz - Function: cmd.run - Result: Changed Started: - 01:30:41.045495 Duration: 6.882 ms
  Name: apache-2 xyz - Function: cmd.run - Result: Failed Started: - 01:30:41.069218 Duration: 7.714 ms
```

sample output (`state_compress_ids=true`):
```
salt-minion-1:
  Name: apache-2 xyz (2) - Function: cmd.run - Result: Changed Started: - 01:35:59.463025 Duration: 26.798 ms
  Name: apache-2 xyz (2) - Function: cmd.run - Result: Failed Started: - 01:35:59.509360 Duration: 24.024 ms
```


note:
* count added to name part
* starttime is lowest of all starttimes
* duration is sum of all durations
* original saltstack fails when there is at least one error state; but we can skip those