### PR TITLE
Show changes on colored state reports

### DIFF
--- a/saltgui/static/scripts/output/Output.js
+++ b/saltgui/static/scripts/output/Output.js
@@ -368,9 +368,9 @@ export class Output {
       txt += "\n" + functionName;
     }
 
-    let nrChanges = 0;
+    let nrChanges;
     if (!pTask.changes) {
-      // no changes
+      nrChanges = 0;
     } else if (typeof pTask.changes !== "object") {
       nrChanges = 1;
       txt += "\n'changes' has type " + typeof pTask.changes;
@@ -378,21 +378,25 @@ export class Output {
       nrChanges = pTask.changes.length;
       txt += "\n'changes' is an array";
       txt += Utils.txtZeroOneMany(nrChanges, "", "\n" + nrChanges + " change", "\n" + nrChanges + " changes");
-    } else if (pTask.changes.ret !== null && typeof pTask.changes.ret === "object") {
-      nrChanges = Object.keys(pTask.changes.ret).length;
-      txt += Utils.txtZeroOneMany(nrChanges, "", "\n" + nrChanges + " change", "\n" + nrChanges + " changes");
+    } else if (typeof pTask.changes === "object" && Object.keys(pTask.changes).length == 0) {
+      // empty changes object does not count as real change
+      nrChanges = 0;
+    } else {
+      nrChanges = 1;
+      txt += "\nchanged";
     }
 
     if (Output.isHiddenTask(pTask)) {
       txt += "\nhidden";
     }
 
+    pSpan.className = "taskcircle";
     if (pTask.result === null) {
-      pSpan.className = "task-skipped";
+      pSpan.classList.add("task-skipped");
     } else if (pTask.result) {
-      pSpan.className = "task-success";
+      pSpan.classList.add("task-success");
     } else {
-      pSpan.className = "task-failure";
+      pSpan.classList.add("task-failure");
     }
     if (nrChanges) {
       pSpan.classList.add("task-changes");

--- a/saltgui/static/scripts/panels/HighState.js
+++ b/saltgui/static/scripts/panels/HighState.js
@@ -473,7 +473,8 @@ export class HighStatePanel extends Panel {
           sep = " ";
 
           // remove the priority indicator from the key
-          const itemSpan = Utils.createSpan(["tasksummary", statKey.substring(2)], Character.BLACK_CIRCLE);
+          const itemSpan = Utils.createSpan(["tasksummary", "taskcircle"], Character.BLACK_CIRCLE);
+          itemSpan.classList.add(...statKey.substring(2).split(" "));
           itemSpan.style.backgroundColor = "black";
           summarySpan.append(itemSpan);
         }

--- a/saltgui/static/stylesheets/page.css
+++ b/saltgui/static/stylesheets/page.css
@@ -307,3 +307,22 @@ table tr td:last-of-type {
     width: auto;
   }
 }
+
+/* taskcircle */
+
+.taskcircle.task-success {
+  color: lime
+}
+
+.taskcircle.task-failure {
+  color: red;
+}
+
+.taskcircle.task-skipped {
+  color: yellow
+}
+
+.taskcircle.task-changes {
+  text-decoration-line: overline underline;
+  text-decoration-style: double;
+}


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
When viewing the results from minion state jobs we see errors (red) and successes (green). I'd also like to see changes (blue).

**Describe the solution you'd like**
Adding changes with blue colors instead of success that are currently green.

**Describe alternatives you've considered**
I am open for discussion!

**Additional context**
Here are some pictures of what I see

This is from the jobs -> highstate ui. I'd also like to see the changes listed (in blue?)
![gui1](https://user-images.githubusercontent.com/899085/206744339-b6c5241a-c81e-45d7-a624-10235adcee60.PNG)

This is from the jobs tab. Again would like to see changes as well. I am also note sure what the red (2) is as there is only one minion with one error in the states?
![gui2](https://user-images.githubusercontent.com/899085/206744364-39553653-5690-4e2b-bb3c-26124069b7be.PNG)

This is from a detailed look at the state. You can see you do show green (for successful) and blue (for changes) here, but the changes are not listed anywhere else?
![gui3](https://user-images.githubusercontent.com/899085/206744379-57fc03de-06a7-4f59-b534-cadcb5f68705.PNG)

Being able to see changes happening on systems would be great for our use case as generally our systems don't have changes unless we are expecting them. Currently we'd need to drill down and find any changes in the ui.

Thank you for reading and I love your ui!