### PR TITLE
Limit Permission to specific Minions

### DIFF
--- a/saltgui/static/scripts/Api.js
+++ b/saltgui/static/scripts/Api.js
@@ -94,7 +94,7 @@ export class API {
       params.tgt = pMinionId;
     } else {
       params["tgt_type"] = "glob";
-      params.tgt = "*";
+      params.tgt = Utils.getDefaultMinionTarget();
     }
     return this.apiRequest("POST", "/", params);
   }
@@ -110,7 +110,7 @@ export class API {
       params.tgt = pMinionId;
     } else {
       params["tgt_type"] = "glob";
-      params.tgt = "*";
+      params.tgt = Utils.getDefaultMinionTarget();
     }
     return this.apiRequest("POST", "/", params);
   }
@@ -125,7 +125,7 @@ export class API {
       params.tgt = pMinionId;
     } else {
       params["tgt_type"] = "glob";
-      params.tgt = "*";
+      params.tgt = Utils.getDefaultMinionTarget();
     }
     return this.apiRequest("POST", "/", params);
   }
@@ -140,7 +140,7 @@ export class API {
       params.tgt = pMinionId;
     } else {
       params["tgt_type"] = "glob";
-      params.tgt = "*";
+      params.tgt = Utils.getDefaultMinionTarget();
     }
     return this.apiRequest("POST", "/", params);
   }
@@ -155,7 +155,7 @@ export class API {
       params.tgt = pMinionId;
     } else {
       params["tgt_type"] = "glob";
-      params.tgt = "*";
+      params.tgt = Utils.getDefaultMinionTarget();
     }
     return this.apiRequest("POST", "/", params);
   }
@@ -171,7 +171,7 @@ export class API {
       params.tgt = pMinionId;
     } else {
       params["tgt_type"] = "glob";
-      params.tgt = "*";
+      params.tgt = Utils.getDefaultMinionTarget();
     }
     return this.apiRequest("POST", "/", params);
   }
@@ -180,7 +180,7 @@ export class API {
     const params = {
       "client": "local",
       "fun": "test.providers",
-      "tgt": "*"
+      "tgt": Utils.getDefaultMinionTarget()
     };
     return this.apiRequest("POST", "/", params);
   }

--- a/saltgui/static/scripts/Documentation.js
+++ b/saltgui/static/scripts/Documentation.js
@@ -94,7 +94,7 @@ export class Documentation {
     // the help text is taken from the first minion that answers
     // when no target is selected, just ask all minions
     if (target === "") {
-      target = "*";
+      target = Utils.getDefaultMinionTarget();
     }
 
     const commandField = document.getElementById("command");

--- a/saltgui/static/scripts/Utils.js
+++ b/saltgui/static/scripts/Utils.js
@@ -650,4 +650,29 @@ export class Utils {
       ddc.style.display = pHide ? "none" : "";
     }
   }
+
+  static getDefaultMinionTarget () {
+    const perms = Utils.getStorageItemObject("session", "login_response").perms;
+
+    if (typeof perms !== "object" || !Array.isArray(perms)) {
+      // strange login info, just try the default
+      return "*";
+    }
+
+    for (const obj of perms) {
+      if (typeof obj !== "object" || Array.isArray(obj)) {
+        continue;
+      }
+      // so it is a regular object, but it may still be empty
+      // return the first useable key
+      /* eslint-disable no-unreachable-loop */
+      for (const key in obj) {
+        return key;
+      }
+      /* eslint-enable no-unreachable-loop */
+    }
+
+    // nothing sensible found, just try the default
+    return "*";
+  }
 }

--- a/saltgui/static/scripts/issues/JobsRunning.js
+++ b/saltgui/static/scripts/issues/JobsRunning.js
@@ -1,6 +1,7 @@
 /* global */
 
 import {Issues} from "./Issues.js";
+import {Utils} from "../Utils.js";
 
 export class JobsRunningIssues extends Issues {
 
@@ -49,9 +50,9 @@ export class JobsRunningIssues extends Issues {
       const tr = Issues.addIssue(pPanel, "active-jobs", jobId);
       Issues.addIssueMsg(tr, "Job '" + jobId + "' (" + job.Function + ") is still running");
       Issues.addIssueNav(tr, "job", {"id": jobId});
-      Issues.addIssueCmd(tr, "Terminate job", "*", ["saltutil.term_job", jobId]);
-      Issues.addIssueCmd(tr, "Kill job", "*", ["saltutil.kill_job", jobId]);
-      Issues.addIssueCmd(tr, "Signal job", "*", ["saltutil.signal_job", jobId, "signal=", "<signalnumber>"]);
+      Issues.addIssueCmd(tr, "Terminate job", Utils.getDefaultMinionTarget(), ["saltutil.term_job", jobId]);
+      Issues.addIssueCmd(tr, "Kill job", Utils.getDefaultMinionTarget(), ["saltutil.kill_job", jobId]);
+      Issues.addIssueCmd(tr, "Signal job", Utils.getDefaultMinionTarget(), ["saltutil.signal_job", jobId, "signal=", "<signalnumber>"]);
     }
   }
 }

--- a/saltgui/static/scripts/panels/Beacons.js
+++ b/saltgui/static/scripts/panels/Beacons.js
@@ -11,6 +11,7 @@ export class BeaconsPanel extends Panel {
 
     this.addTitle("Beacons");
     this.addSearchButton();
+    this.addWarningField();
     this.addTable(["Minion", "Status", "Beacons", "-menu-"]);
     this.setTableSortable("Minion", "asc");
     this.setTableClickable();

--- a/saltgui/static/scripts/panels/Beacons.js
+++ b/saltgui/static/scripts/panels/Beacons.js
@@ -25,6 +25,7 @@ export class BeaconsPanel extends Panel {
       this._handleBeaconsWheelKeyListAll(pWheelKeyListAllData);
       localBeaconsListPromise.then((pLocalBeaconsListData) => {
         this.updateMinions(pLocalBeaconsListData);
+        this.removeMinionsWithoutAnswer();
         return true;
       }, (pLocalBeaconsListMsg) => {
         const allMinionsErr = Utils.msgPerMinion(pWheelKeyListAllData.return[0].data.return.minions, JSON.stringify(pLocalBeaconsListMsg));

--- a/saltgui/static/scripts/panels/Grains.js
+++ b/saltgui/static/scripts/panels/Grains.js
@@ -43,6 +43,7 @@ export class GrainsPanel extends Panel {
       this._handleGrainsWheelKeyListAll(pWheelKeyListAllData);
       localGrainsItemsPromise.then((pLocalGrainsItemsData) => {
         this.updateMinions(pLocalGrainsItemsData);
+        this.removeMinionsWithoutAnswer();
         return true;
       }, (pLocalGrainsItemsMsg) => {
         const allMinionsErr = Utils.msgPerMinion(pWheelKeyListAllData.return[0].data.return.minions, JSON.stringify(pLocalGrainsItemsMsg));

--- a/saltgui/static/scripts/panels/Grains.js
+++ b/saltgui/static/scripts/panels/Grains.js
@@ -17,6 +17,7 @@ export class GrainsPanel extends Panel {
       "columns by configuring their name in the server-side configuration file.",
       "See README.md for more details."
     ]);
+    this.addWarningField();
     this.addTable(["Minion", "Status", "Salt version", "OS version", "Grains", "-menu-"]);
     this.setTableClickable();
 

--- a/saltgui/static/scripts/panels/HighState.js
+++ b/saltgui/static/scripts/panels/HighState.js
@@ -22,8 +22,8 @@ export class HighStatePanel extends Panel {
 
     this.addTitle("HighState");
     this.addPanelMenu();
-    this._addMenuItemStateApply(this.panelMenu, "*");
-    this._addMenuItemStateApplyTest(this.panelMenu, "*");
+    this._addMenuItemStateApply(this.panelMenu, Utils.getDefaultMinionTarget());
+    this._addMenuItemStateApplyTest(this.panelMenu, Utils.getDefaultMinionTarget());
     this.addSettingsMenu();
     this._addMenuItemUseStateHighstate();
     this._addMenuItemUseStateApply();

--- a/saltgui/static/scripts/panels/Issues.js
+++ b/saltgui/static/scripts/panels/Issues.js
@@ -21,6 +21,7 @@ export class IssuesPanel extends Panel {
       "This page contains an overview of problems",
       "that are observed in various categories."
     ]);
+    this.addWarningField();
     this.addTable(["-menu-", "Description"]);
     this.setTableClickable();
     this.addMsg();
@@ -47,6 +48,10 @@ export class IssuesPanel extends Panel {
   }
 
   onShow () {
+    if (Utils.getDefaultMinionTarget() !== "*") {
+      this.setWarningText("info", "due to user permission restrictions, for some categories, only a subset of the minions is used here");
+    }
+
     const p1 = this.keysIssues.onGetIssues(this);
     const p2 = this.jobsIssues.onGetIssues(this);
     const p3 = this.beaconsIssues.onGetIssues(this);

--- a/saltgui/static/scripts/panels/Minions.js
+++ b/saltgui/static/scripts/panels/Minions.js
@@ -22,6 +22,7 @@ export class MinionsPanel extends Panel {
     this._addMenuItemStateApply(this.panelMenu, Utils.getDefaultMinionTarget());
     this._addMenuItemStateApplyTest(this.panelMenu, Utils.getDefaultMinionTarget());
     this.addSearchButton();
+    this.addWarningField();
     this.addTable(["Minion", "Status", "Salt version", "OS version", "-menu-"]);
     this.setTableSortable("Minion", "asc");
     this.setTableClickable();

--- a/saltgui/static/scripts/panels/Minions.js
+++ b/saltgui/static/scripts/panels/Minions.js
@@ -49,6 +49,7 @@ export class MinionsPanel extends Panel {
 
       localGrainsItemsPromise.then((pLocalGrainsItemsData) => {
         this.updateMinions(pLocalGrainsItemsData);
+        this.removeMinionsWithoutAnswer();
         return true;
       }, (pLocalGrainsItemsMsg) => {
         const allMinionsErr = Utils.msgPerMinion(pWheelKeyListAllData.return[0].data.return.minions, JSON.stringify(pLocalGrainsItemsMsg));

--- a/saltgui/static/scripts/panels/Minions.js
+++ b/saltgui/static/scripts/panels/Minions.js
@@ -19,8 +19,8 @@ export class MinionsPanel extends Panel {
 
     this.addTitle("Minions");
     this.addPanelMenu();
-    this._addMenuItemStateApply(this.panelMenu, "*");
-    this._addMenuItemStateApplyTest(this.panelMenu, "*");
+    this._addMenuItemStateApply(this.panelMenu, Utils.getDefaultMinionTarget());
+    this._addMenuItemStateApplyTest(this.panelMenu, Utils.getDefaultMinionTarget());
     this.addSearchButton();
     this.addTable(["Minion", "Status", "Salt version", "OS version", "-menu-"]);
     this.setTableSortable("Minion", "asc");
@@ -108,7 +108,7 @@ export class MinionsPanel extends Panel {
 
     // construct a target string of connected minions
     if (connectedMinionIds.length === wheelKeyListMinionIds.length) {
-      return "*";
+      return Utils.getDefaultMinionTarget();
     }
 
     connectedMinionIds.sort();

--- a/saltgui/static/scripts/panels/Panel.js
+++ b/saltgui/static/scripts/panels/Panel.js
@@ -898,5 +898,8 @@ export class Panel {
         tr.remove();
       }
     }
+    if (Utils.getDefaultMinionTarget() !== "*") {
+      this.setWarningText("info", "due to user permission restrictions, only a subset of the minions is shown here");
+    }
   }
 }

--- a/saltgui/static/scripts/panels/Panel.js
+++ b/saltgui/static/scripts/panels/Panel.js
@@ -415,6 +415,7 @@ export class Panel {
     minionTr.appendChild(minionTd);
 
     minionTr.appendChild(Utils.createTd("os", "loading..."));
+    minionTr.dataset.loading = true;
 
     // fill out the number of columns to that of the header
     while (this.table.tHead.rows[0] && minionTr.cells.length < this.table.tHead.rows[0].cells.length - freeColumns) {
@@ -699,6 +700,11 @@ export class Panel {
     for (const minionId of minionIds) {
       const minionInfo = minions[minionId];
 
+      const minionTr = this.table.querySelector("#" + Utils.getIdFromMinionId(minionId));
+      if (minionTr) {
+        delete minionTr.dataset.loading;
+      }
+
       // minions can be offline, then the info will be false
       if (minionInfo === false) {
         this.updateOfflineMinion(minionId, minionsDict);
@@ -880,6 +886,17 @@ export class Panel {
     }
     if (!pElem.innerText.startsWith(pIconChar)) {
       pElem.innerText = pIconChar + pElem.innerText;
+    }
+  }
+
+  // remove all rows from the table where we did not get a response from the server
+  // probably the access rights are restricted to only a subset of the minions
+  removeMinionsWithoutAnswer () {
+    const tbody = this.table.tBodies[0];
+    for (const tr of tbody.rows) {
+      if (tr.dataset.loading) {
+        tr.remove();
+      }
     }
   }
 }

--- a/saltgui/static/scripts/panels/Pillars.js
+++ b/saltgui/static/scripts/panels/Pillars.js
@@ -25,6 +25,7 @@ export class PillarsPanel extends Panel {
       this._handlePillarsWheelKeyListAll(pWheelKeyListAllData);
       localPillarObfuscatePromise.then((pLocalPillarObfuscateData) => {
         this.updateMinions(pLocalPillarObfuscateData);
+        this.removeMinionsWithoutAnswer();
         return true;
       }, (pLocalPillarObfuscateMsg) => {
         const allMinionsErr = Utils.msgPerMinion(pWheelKeyListAllData.return[0].data.return.minions, JSON.stringify(pLocalPillarObfuscateMsg));

--- a/saltgui/static/scripts/panels/Pillars.js
+++ b/saltgui/static/scripts/panels/Pillars.js
@@ -11,6 +11,7 @@ export class PillarsPanel extends Panel {
 
     this.addTitle("Pillars");
     this.addSearchButton();
+    this.addWarningField();
     this.addTable(["Minion", "Status", "Pillars", "-menu-"]);
     this.setTableSortable("Minion", "asc");
     this.setTableClickable();

--- a/saltgui/static/scripts/panels/Schedules.js
+++ b/saltgui/static/scripts/panels/Schedules.js
@@ -25,6 +25,7 @@ export class SchedulesPanel extends Panel {
       this._handleSchedulesWheelKeyListAll(pWheelKeyListAllData);
       localScheduleListPromise.then((pLocalScheduleListData) => {
         this.updateMinions(pLocalScheduleListData);
+        this.removeMinionsWithoutAnswer();
         return true;
       }, (pLocalScheduleListMsg) => {
         const allMinionsErr = Utils.msgPerMinion(pWheelKeyListAllData.return[0].data.return.minions, JSON.stringify(pLocalScheduleListMsg));

--- a/saltgui/static/scripts/panels/Schedules.js
+++ b/saltgui/static/scripts/panels/Schedules.js
@@ -11,6 +11,7 @@ export class SchedulesPanel extends Panel {
 
     this.addTitle("Schedules");
     this.addSearchButton();
+    this.addWarningField();
     this.addTable(["Minion", "Status", "Schedules", "-menu-"]);
     this.setTableSortable("Minion", "asc");
     this.setTableClickable();


### PR DESCRIPTION
Limiting SaltGUI access for different users to specific minions seems not to work.
Following the SaltGUI [permissions guide](https://github.com/erwindon/SaltGUI/blob/master/docs/PERMISSIONS.md) and saltstack [external authentication](https://docs.saltproject.io/en/latest/topics/eauth/index.html) docu, it should be possible to limit access for API.

Steps to reproduce the behaviour:
Configure salt master with:
```
external_auth:
  pam:
    user1:
      - 'test*':
        - .*
        - '@runner'
        - '@wheel'
        - '@jobs'
```
Restart master and api.

SaltGUI only shows "(error)", no minions are listed.
When removing the test* line, everything works fine.

Salt master log shows the following lines, a token auth error seems to 
```
salt.auth         Compiled auth_list: [{'test*': ['.*', '@runner', '@wheel', '@jobs']}]
salt.utils.minions minions: {'test1', 'test2', 'prod1', 'prod2'}
salt.utils.minions Evaluating final compound matching expr: {'test1', 'test2'}
salt.master       Authentication failure of type "token" occurred.
```

Used Software:
salt 3004 on SUSE openleap 15.4, patched to latest.
SaltGUI 1.29.0