### PR TITLE
prevent problem showing output with output from 0 minions

### DIFF
--- a/saltgui/static/scripts/output/Output.js
+++ b/saltgui/static/scripts/output/Output.js
@@ -505,7 +505,7 @@ export class Output {
       // note that really old minions do not return 'retcode'
       return pMinionResponse.retcode === 0;
     }
-    if (pMinionResponse.Error) {
+    if (pMinionResponse && pMinionResponse.Error) {
       // e.g. runners.jobs.list_job blahblah
       return false;
     }


### PR DESCRIPTION
when retrieving the output from an API call before any results are available leads to an error message about variable `pMinionResponse` in `Output.js(508)`.

replay with something like `salt --async '*' test.sleep 60` and looking at the details for that job within those 60 seconds.