### PR TITLE
documentation processing is not compatible with full-return yet

### DIFF
--- a/saltgui/static/scripts/CommandBox.js
+++ b/saltgui/static/scripts/CommandBox.js
@@ -490,7 +490,7 @@ export class CommandBox {
     CommandBox.onRunReturn("ERROR:\n\n" + pMessage, "");
   }
 
-  getRunParams (pTargetType, pTarget, pToRun, pisRunTypeNormalOnly = false) {
+  getRunParams (pTargetType, pTarget, pToRun, pisRunTypeNormalOnly = false, pCanUseFullReturn = true) {
 
     // The leading # was used to indicate a nodegroup
     if (pTargetType === "nodegroup" && pTarget.startsWith("#")) {
@@ -552,7 +552,7 @@ export class CommandBox {
       }
     }
 
-    const fullReturn = Utils.getStorageItemBoolean("session", "full_return");
+    const fullReturn = pCanUseFullReturn && Utils.getStorageItemBoolean("session", "full_return");
 
     let params = {};
     if (functionToRun.startsWith("runners.")) {

--- a/saltgui/static/scripts/Documentation.js
+++ b/saltgui/static/scripts/Documentation.js
@@ -122,7 +122,7 @@ export class Documentation {
 
     const targetType = TargetType.menuTargetType._value;
 
-    const func = this.commandbox.getRunParams(targetType, target, docCommand, true);
+    const func = this.commandbox.getRunParams(targetType, target, docCommand, true, false);
     if (func === null) {
       return;
     }


### PR DESCRIPTION
when documentation is requested using `saltgui_full_return: True`, the presentation fails because the documentation decoder is not prepared for a full-return answer.

2 possible solutions:
1. always request documentation as if full-return is false
2. update the decoder to see whether full-return was used, or not

solution #2 is more flexible, so that is preferred