### PR TITLE
Update Output.js

### DIFF
--- a/saltgui/static/scripts/output/Output.js
+++ b/saltgui/static/scripts/output/Output.js
@@ -199,7 +199,6 @@ export class Output {
     fractionSecondsPart = fractionSecondsPart.replace(/^.*[.]/, "");
     // remove everything after the digits
     fractionSecondsPart = fractionSecondsPart.replace(/[^0-9].*$/, "");
-    let originalFractionSecondsPart = fractionSecondsPart;
     // truncate digits to maximum length
     fractionSecondsPart = fractionSecondsPart.substring(0, dateTimeFractionDigits);
 
@@ -207,9 +206,6 @@ export class Output {
     const decimalSeparator = 1.1.toLocaleString().substring(1, 2);
     if (fractionSecondsPart !== "") {
       fractionSecondsPart = decimalSeparator + fractionSecondsPart;
-    }
-    if (originalFractionSecondsPart !== "") {
-      originalFractionSecondsPart = decimalSeparator + originalFractionSecondsPart;
     }
 
     // remove the fraction from the original

--- a/saltgui/static/scripts/output/Output.js
+++ b/saltgui/static/scripts/output/Output.js
@@ -300,16 +300,9 @@ export class Output {
     }
 
     if (pDateTimeField) {
-      utcDT = dateObj.toLocaleString(undefined, {"timeZone": "UTC", "timeZoneName": "short"});
-      // place the milliseconds after the seconds (before am/pm indicator and timezone)
-      utcDT = utcDT.replace(/( [a-zA-Z.]*)? [-A-Z0-9]*$/, originalFractionSecondsPart + "$&");
-      localDT = dateObj.toLocaleString(undefined, {"timeZoneName": "short"});
-      localDT = localDT.replace(/( [a-zA-Z.]*)? [-A-Z0-9]*$/, originalFractionSecondsPart + "$&");
       pDateTimeField.innerText = ret;
-      const txt = utcDT + "\n" + localDT;
-      if (txt.search("Invalid") < 0) {
-        Utils.addToolTip(pDateTimeField, txt, pDateTimeStyle);
-      }
+      const txt = utcDTms + " UTC\n" + localDTms + " " + localTZ;
+      Utils.addToolTip(pDateTimeField, txt, pDateTimeStyle);
     }
 
     return ret;

--- a/saltgui/static/scripts/output/Output.js
+++ b/saltgui/static/scripts/output/Output.js
@@ -165,7 +165,7 @@ export class Output {
   // some older browsers cannot produce formatted datetime this way
   // toLocaleString/toLocaleTimeString then return "Invalid Date"
   // silently ignore that, provide an alternative and then do not produce a tooltip
-  static dateTimeStr (pDtStr, pDateTimeField = null, pDateTimeStyle = "bottom-center", pTimeOnly = false) {
+  static dateTimeStr (pDtStr, pDateTimeField = null, pDateTimeStyle = "bottom-left", pTimeOnly = false) {
 
     // no available setting, then return the original
     let dateTimeFractionDigits = Utils.getStorageItemInteger("session", "datetime_fraction_digits", 6);


### PR DESCRIPTION
before: time tooltip ignore config parameter saltgui_datetime_fraction_digits. UTC time with 6 digits, local time with 0 digits after seconds
after: tooltip calculate time with this parameter. (UTC and local with saltgui_datetime_fraction_digits)