### PR TITLE
Ability to display nodegroups

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ such as `yubico_client`, or execution modules such as `boto3_sns`.
 - View the schedules for a particular minion
 - View the values for pillars for a particular minion
 - View the beacons for a particular minion
+- View the nodegroups with their member minions
 - View the live events on the salt-event bus
 - View internal documentation for any salt command
 - View external documentation for any salt command
@@ -269,6 +270,14 @@ e.g.:
 saltgui_public_pillars:
     - pub_.*
 ```
+
+## Nodegroups
+The Nodegroups page shows all minions, but groups the minions by their nodegroup.
+Since the group membership can only (reliably) be determined by executing salt commands, the overview takes some time to build.
+When a minion happens to be a member of multiple nodegroups, then a row for that minion will appear mutiple times in the overview.
+When using targeting based on nodegroups, the salt-system does not filter out the non-accepted minions.
+Therefore also the rejected, denied and unaccepted minions will show up.
+Even the minion names that are in the nodegroup, but which do not actually exist, will show up as 'unknown'.
 
 ## Highstate
 The Highstate page provides an overview of the minions and their latest state information.

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ such as `yubico_client`, or execution modules such as `boto3_sns`.
 - View the live events on the salt-event bus
 - View internal documentation for any salt command
 - View external documentation for any salt command
+- View minions organized by node-group
 - Define your own custom documentation for commands
 - Match list of minions against reference list
 - Match status of minions against reference list

--- a/saltgui/static/scripts/Api.js
+++ b/saltgui/static/scripts/Api.js
@@ -177,17 +177,22 @@ export class API {
     return this.apiRequest("POST", "/", params);
   }
 
-  getLocalTestProviders (pNodegroup) {
+  getLocalTestProviders () {
     const params = {
       "client": "local",
-      "fun": "test.providers"
+      "fun": "test.providers",
+      "tgt": "*"
     };
-    if (pNodegroup) {
-      params["tgt"] = "N@" + pNodegroup;
-      params["tgt_type"] = "compound";
-    } else {
-      params["tgt"] = "*";
-    }
+    return this.apiRequest("POST", "/", params);
+  }
+
+  getLocalTestVersion (pNodegroup) {
+    const params = {
+      "client": "local",
+      "fun": "test.providers",
+      "tgt": "N@" + pNodegroup,
+      "tgt_type": "compound"
+    };
     return this.apiRequest("POST", "/", params);
   }
 

--- a/saltgui/static/scripts/Api.js
+++ b/saltgui/static/scripts/Api.js
@@ -177,6 +177,16 @@ export class API {
     return this.apiRequest("POST", "/", params);
   }
 
+  getLocalTestPing (pNodegroup) {
+    const params = {
+      "client": "local",
+      "fun": "test.ping",
+      "tgt": "N@" + pNodegroup,
+      "tgt_type": "compound"
+    };
+    return this.apiRequest("POST", "/", params);
+  }
+
   getLocalTestProviders () {
     const params = {
       "client": "local",

--- a/saltgui/static/scripts/Api.js
+++ b/saltgui/static/scripts/Api.js
@@ -177,22 +177,17 @@ export class API {
     return this.apiRequest("POST", "/", params);
   }
 
-  getLocalTestPing (pNodegroup) {
+  getLocalTestProviders (pNodegroup) {
     const params = {
       "client": "local",
-      "fun": "test.ping",
-      "tgt": "N@" + pNodegroup,
-      "tgt_type": "compound"
+      "fun": "test.providers"
     };
-    return this.apiRequest("POST", "/", params);
-  }
-
-  getLocalTestProviders () {
-    const params = {
-      "client": "local",
-      "fun": "test.providers",
-      "tgt": "*"
-    };
+    if (pNodegroup) {
+      params["tgt"] = "N@" + pNodegroup;
+      params["tgt_type"] = "compound";
+    } else {
+      params["tgt"] = "*";
+    }
     return this.apiRequest("POST", "/", params);
   }
 

--- a/saltgui/static/scripts/Api.js
+++ b/saltgui/static/scripts/Api.js
@@ -430,6 +430,7 @@ export class API {
         Router.pillarsMinionPage.handleSaltJobRetEvent(data);
         Router.beaconsPage.handleSaltJobRetEvent(data);
         Router.beaconsMinionPage.handleSaltJobRetEvent(data);
+        Router.nodegroupsPage.handleSaltJobRetEvent(data);
         Router.jobsPage.handleSaltJobRetEvent(data);
         Router.templatesPage.handleSaltJobRetEvent(data);
         Router.reactorsPage.handleSaltJobRetEvent(data);

--- a/saltgui/static/scripts/Character.js
+++ b/saltgui/static/scripts/Character.js
@@ -12,6 +12,7 @@ export class Character {
     Character.MULTIPLICATION_SIGN = "\u00D7";
     Character.NO_BREAK_SPACE = "\u00A0";
     Character.NON_BREAKING_HYPHEN = "\u2011";
+    Character.EM_DASH = "\u2014";
     Character.HORIZONTAL_ELLIPSIS = "\u2026";
     Character._UPWARDS_ARROW = "\u2191";
     Character.RIGHTWARDS_ARROW = "\u2192";

--- a/saltgui/static/scripts/Router.js
+++ b/saltgui/static/scripts/Router.js
@@ -16,6 +16,7 @@ import {KeysPage} from "./pages/Keys.js";
 import {LoginPage} from "./pages/Login.js";
 import {LogoutPage} from "./pages/Logout.js";
 import {MinionsPage} from "./pages/Minions.js";
+import {NodegroupsPage} from "./pages/Nodegroups.js";
 import {OptionsPage} from "./pages/Options.js";
 import {Output} from "./output/Output.js";
 import {PillarsMinionPage} from "./pages/PillarsMinion.js";
@@ -49,6 +50,7 @@ export class Router {
     this._registerPage(Router.pillarsMinionPage = new PillarsMinionPage(this));
     this._registerPage(Router.beaconsPage = new BeaconsPage(this));
     this._registerPage(Router.beaconsMinionPage = new BeaconsMinionPage(this));
+    this._registerPage(Router.nodegroupsPage = new NodegroupsPage(this));
     this._registerPage(Router.jobPage = new JobPage(this));
     this._registerPage(Router.jobsPage = new JobsPage(this));
     this._registerPage(Router.highStatePage = new HighStatePage(this));
@@ -177,6 +179,7 @@ export class Router {
     this._registerMenuItem("minions", "schedules", "schedules");
     this._registerMenuItem("minions", "pillars", "pillars");
     this._registerMenuItem("minions", "beacons", "beacons");
+    this._registerMenuItem("minions", "nodegroups", "nodegroups");
     this._registerMenuItem(null, "keys", "keys");
     this._registerMenuItem(null, "jobs", "jobs");
     this._registerMenuItem("jobs", "highstate", "highstate");
@@ -257,6 +260,7 @@ export class Router {
     Router._showMenuItem(pages, Router.schedulesPage);
     Router._showMenuItem(pages, Router.pillarsPage);
     Router._showMenuItem(pages, Router.beaconsPage);
+    Router._showMenuItem(pages, Router.nodegroupsPage);
     Router._showMenuItem(pages, Router.keysPage);
     Router._showMenuItem(pages, Router.jobsPage, ["highstate", "templates"]);
     Router._showMenuItem(pages, Router.highStatePage);

--- a/saltgui/static/scripts/pages/Nodegroups.js
+++ b/saltgui/static/scripts/pages/Nodegroups.js
@@ -1,0 +1,30 @@
+/* global */
+
+import {JobsSummaryPanel} from "../panels/JobsSummary.js";
+import {NodegroupsPanel} from "../panels/Nodegroups.js";
+import {Page} from "./Page.js";
+import {Utils} from "../Utils.js";
+
+export class NodegroupsPage extends Page {
+
+  constructor (pRouter) {
+    super("nodegroups", "Nodegroups", "page-nodegroups", "button-nodegroups", pRouter);
+
+    this.nodegroups = new NodegroupsPanel();
+    super.addPanel(this.nodegroups);
+    this.jobs = new JobsSummaryPanel();
+    super.addPanel(this.jobs);
+  }
+
+  handleSaltJobRetEvent (pData) {
+    this.jobs.handleSaltJobRetEvent(pData);
+  }
+
+  /* eslint-disable class-methods-use-this */
+  isVisible () {
+  /* eslint-enable class-methods-use-this */
+    // show nodegroups menu item if nodegroups defined
+    const nodegroups = Utils.getStorageItemObject("session", "nodegroups");
+    return Object.keys(nodegroups).length > 0;
+  }
+}

--- a/saltgui/static/scripts/panels/BeaconsMinion.js
+++ b/saltgui/static/scripts/panels/BeaconsMinion.js
@@ -164,11 +164,11 @@ export class BeaconsMinionPanel extends Panel {
       let initialValue = "(waiting)";
       if (beacon.enabled === false) {
         beaconConfigTd.classList.add("beacon-disabled");
-        initialTimestamp = "---";
+        initialTimestamp = Character.EM_DASH;
         initialValue = "(beacon" + Character.NO_BREAK_SPACE + "disabled)";
       } else if (beacons.enabled === false) {
         beaconConfigTd.classList.add("beacon-disabled");
-        initialTimestamp = "---";
+        initialTimestamp = Character.EM_DASH;
         initialValue = "(beacons" + Character.NO_BREAK_SPACE + "disabled)";
       }
       tr.appendChild(beaconConfigTd);

--- a/saltgui/static/scripts/panels/Nodegroups.js
+++ b/saltgui/static/scripts/panels/Nodegroups.js
@@ -238,7 +238,7 @@ export class NodegroupsPanel extends Panel {
   }
 
   _addNodegroupRow (pNodegroup, pAllNodegroups) {
-    const tr = Utils.createTr(null, null, "ng-" + pNodegroup);
+    const tr = Utils.createTr("no-search", null, "ng-" + pNodegroup);
 
     const titleTd = Utils.createTd();
     if (pNodegroup) {

--- a/saltgui/static/scripts/panels/Nodegroups.js
+++ b/saltgui/static/scripts/panels/Nodegroups.js
@@ -1,0 +1,161 @@
+/* global */
+
+import {DropDownMenu} from "../DropDown.js";
+import {Panel} from "./Panel.js";
+import {Utils} from "../Utils.js";
+
+export class NodegroupsPanel extends Panel {
+
+  constructor () {
+    super("nodegroups");
+
+    this.addTitle("Nodegroups");
+    this.addPanelMenu();
+    this._addMenuItemStateApply(this.panelMenu, "*");
+    this._addMenuItemStateApplyTest(this.panelMenu, "*");
+    this.addSearchButton();
+    this.addTable(["Minion", "Status", "Salt version", "OS version", "-menu-"]);
+    this.setTableSortable("Minion", "asc");
+    this.setTableClickable();
+    this.addMsg();
+  }
+
+  onShow () {
+    const wheelKeyListAllPromise = this.api.getWheelKeyListAll();
+    const localGrainsItemsPromise = this.api.getLocalGrainsItems(null);
+
+    this.loadMinionsTxt();
+
+    this._addNodegroupsRows();
+
+    wheelKeyListAllPromise.then((pWheelKeyListAllData) => {
+      this._handleNodegroupsWheelKeyListAll(pWheelKeyListAllData);
+
+      localGrainsItemsPromise.then((pLocalGrainsItemsData) => {
+        this.updateMinions(pLocalGrainsItemsData);
+        return true;
+      }, (pLocalGrainsItemsMsg) => {
+        const allNodegroupsErr = Utils.msgPerMinion(pWheelKeyListAllData.return[0].data.return.minions, JSON.stringify(pLocalGrainsItemsMsg));
+        this.updateMinions({"return": [allNodegroupsErr]});
+        return false;
+      });
+
+      return true;
+    }, (pWheelKeyListAllMsg) => {
+      this._handleNodegroupsWheelKeyListAll(JSON.stringify(pWheelKeyListAllMsg));
+      Utils.ignorePromise(localGrainsItemsPromise);
+      return false;
+    });
+  }
+
+  _addNodegroupsRows () {
+    const nodegroups = Utils.getStorageItemObject("session", "nodegroups");
+    for (const nodegroup of Object.keys(nodegroups).sort()) {
+      this._addNodegroupRow(nodegroup);
+    }
+    this._addNodegroupRow(null);
+  }
+
+  _addNodegroupRow (pNodegroup) {
+    const td = Utils.createTd(null, null, "ng-" + pNodegroup);
+    if (pNodegroup) {
+      td.innerHTML = "--- nodegroup <b>" + pNodegroup + "</b> ---";
+    } else {
+      td.innerText = "--- not in any nodegroup ---";
+    }
+    td.colSpan = 5;
+    const tr = Utils.createTr();
+    tr.append(td);
+    this.table.tBodies[0].appendChild(tr);
+  }
+
+  _handleNodegroupsWheelKeyListAll (pWheelKeyListAll) {
+    if (this.showErrorRowInstead(pWheelKeyListAll)) {
+      return;
+    }
+
+    const keys = pWheelKeyListAll.return[0].data.return;
+
+    const minionIds = keys.minions.sort();
+    for (const minionId of minionIds) {
+      const minionTr = this.addMinion(minionId, 1);
+
+      // preliminary dropdown menu
+      const menu = new DropDownMenu(minionTr, true);
+      this._addMenuItemStateApply(menu, minionId);
+      this._addMenuItemStateApplyTest(menu, minionId);
+      this._addMenuItemShowGrains(menu, minionId);
+      this._addMenuItemShowPillars(menu, minionId);
+      this._addMenuItemShowSchedules(menu, minionId);
+      this._addMenuItemShowBeacons(menu, minionId);
+    }
+
+    Utils.setStorageItem("session", "minions_pre_length", keys.minions_pre.length);
+
+    let txt = Utils.txtZeroOneMany(minionIds.length,
+      "No minions", "{0} minion", "{0} minions");
+
+    const nodegroups = Utils.getStorageItemObject("session", "nodegroups");
+    txt += ", " + Utils.txtZeroOneMany(Object.keys(nodegroups).length,
+      "no nodegroups", "{0} nodegroup", "{0} nodegroups");
+
+    this.setMsg(txt);
+  }
+
+  updateMinion (pMinionData, pMinionId, pAllNodegroupsGrains) {
+    super.updateMinion(pMinionData, pMinionId, pAllNodegroupsGrains);
+
+    const minionTr = this.table.querySelector("#" + Utils.getIdFromMinionId(pMinionId));
+    const menu = new DropDownMenu(minionTr, true);
+    this._addMenuItemStateApply(menu, pMinionId);
+    this._addMenuItemStateApplyTest(menu, pMinionId);
+    this._addMenuItemShowGrains(menu, pMinionId);
+    this._addMenuItemShowPillars(menu, pMinionId);
+    this._addMenuItemShowSchedules(menu, pMinionId);
+    this._addMenuItemShowBeacons(menu, pMinionId);
+
+    minionTr.addEventListener("click", (pClickEvent) => {
+      const cmdArr = ["state.apply"];
+      this.runCommand("", pMinionId, cmdArr);
+      pClickEvent.stopPropagation();
+    });
+  }
+
+  _addMenuItemStateApply (pMenu, pMinionId) {
+    pMenu.addMenuItem("Apply state...", () => {
+      const cmdArr = ["state.apply"];
+      this.runCommand("", pMinionId, cmdArr);
+    });
+  }
+
+  _addMenuItemStateApplyTest (pMenu, pMinionId) {
+    pMenu.addMenuItem("Test state...", () => {
+      const cmdArr = ["state.apply", "test=", true];
+      this.runCommand("", pMinionId, cmdArr);
+    });
+  }
+
+  _addMenuItemShowGrains (pMenu, pMinionId) {
+    pMenu.addMenuItem("Show grains", () => {
+      this.router.goTo("grains-minion", {"minionid": pMinionId});
+    });
+  }
+
+  _addMenuItemShowSchedules (pMenu, pMinionId) {
+    pMenu.addMenuItem("Show schedules", () => {
+      this.router.goTo("schedules-minion", {"minionid": pMinionId});
+    });
+  }
+
+  _addMenuItemShowPillars (pMenu, pMinionId) {
+    pMenu.addMenuItem("Show pillars", () => {
+      this.router.goTo("pillars-minion", {"minionid": pMinionId});
+    });
+  }
+
+  _addMenuItemShowBeacons (pMenu, pMinionId) {
+    pMenu.addMenuItem("Show beacons", () => {
+      this.router.goTo("beacons-minion", {"minionid": pMinionId});
+    });
+  }
+}

--- a/saltgui/static/scripts/panels/Nodegroups.js
+++ b/saltgui/static/scripts/panels/Nodegroups.js
@@ -103,6 +103,13 @@ export class NodegroupsPanel extends Panel {
 
     if (this.allNodegroups.length === 0) {
       this.allNodegroups = null;
+
+      const titleElement = this.table.querySelector("#ng-" + null + " td");
+      const cnt = this.table.rows.length - titleElement.parentElement.rowIndex - 1;
+      titleElement.innerHTML = titleElement.innerHTML.replace(
+        " ---",
+        ", " + Utils.txtZeroOneMany(cnt, "no minions", cnt + " minion", cnt + " minions") + " ---");
+
       return;
     }
 
@@ -118,6 +125,12 @@ export class NodegroupsPanel extends Panel {
       for (const minionId of nodelist) {
         this._moveMinionToNodegroup(minionId, nodegroup);
       }
+
+      const titleElement = this.table.querySelector("#ng-" + nodegroup + " td");
+      const cnt = nodelist.length;
+      titleElement.innerHTML = titleElement.innerHTML.replace(
+        " ---",
+        ", " + Utils.txtZeroOneMany(cnt, "no minions", cnt + " minion", cnt + " minions") + " ---");
 
       // try again for more
       window.setTimeout(() => {

--- a/saltgui/static/scripts/panels/Nodegroups.js
+++ b/saltgui/static/scripts/panels/Nodegroups.js
@@ -1,5 +1,6 @@
 /* global */
 
+import {Character} from "../Character.js";
 import {DropDownMenu} from "../DropDown.js";
 import {Panel} from "./Panel.js";
 import {Utils} from "../Utils.js";
@@ -160,18 +161,16 @@ export class NodegroupsPanel extends Panel {
 
     const titleTd = Utils.createTd();
     if (pNodegroup) {
-      titleTd.innerHTML = "--- nodegroup <b>" + pNodegroup + "</b> ---";
+      titleTd.innerHTML = "--- nodegroup <b>" + pNodegroup + "</b> ---&nbsp;&nbsp;&nbsp;";
     } else {
-      titleTd.innerText = "--- not in any nodegroup ---";
+      titleTd.innerText = "--- not in any nodegroup ---" + Character.NO_BREAK_SPACE + Character.NO_BREAK_SPACE + Character.NO_BREAK_SPACE;
     }
-    titleTd.colSpan = 4;
+    titleTd.colSpan = 5;
     tr.append(titleTd);
 
-    const menuTd = Utils.createTd();
-    const menu = new DropDownMenu(menuTd, true);
+    const menu = new DropDownMenu(titleTd, true);
     this._addMenuItemStateApplyGroup(menu, pNodegroup, pAllNodegroups);
     this._addMenuItemStateApplyTestGroup(menu, pNodegroup, pAllNodegroups);
-    tr.append(menuTd);
 
     tr.addEventListener("click", (pClickEvent) => {
       const cmdArr = ["state.apply"];

--- a/saltgui/static/scripts/panels/Nodegroups.js
+++ b/saltgui/static/scripts/panels/Nodegroups.js
@@ -129,57 +129,7 @@ export class NodegroupsPanel extends Panel {
     }
   }
 
-  _handleStep () {
-
-    // user can decide
-    // system can decide to remove the play/pause button
-    if (this.playOrPause !== "play") {
-      // try again lkater for more
-      window.setTimeout(() => {
-        this._handleStep();
-      }, 100);
-      return;
-    }
-
-    if (this.todoNodegroups.length === 0) {
-      this.setPlayPauseButton("none");
-      this.todoNodegroups = null;
-
-      const titleElement = this.table.querySelector("#ng-" + null + " td");
-      const cnt = this.table.rows.length - titleElement.parentElement.rowIndex - 1;
-
-      if (cnt === 0) {
-        // remove the title of the empty group "not in any nodegroup"
-        titleElement.parentElement.remove();
-        return;
-      }
-
-      let txt = Utils.txtZeroOneMany(cnt, "no minions", cnt + " minion", cnt + " minions");
-      let online = 0;
-      let offline = 0;
-      for (let row = titleElement.parentElement.rowIndex + 1; row < this.table.rows.length; row++) {
-        const tr = this.table.rows[row];
-        if (tr.online === true) {
-          online += 1;
-        }
-        if (tr.offline === true) {
-          offline += 1;
-        }
-      }
-      if (online !== cnt) {
-        txt += ", " + online + " online";
-      }
-      if (offline !== 0) {
-        txt += ", " + offline + " offline";
-      }
-
-      titleElement.innerHTML = titleElement.innerHTML.replace(
-        " " + Character.EM_DASH,
-        " " + Character.EM_DASH + " " + txt + " " + Character.EM_DASH);
-
-      return;
-    }
-
+  _handleStepGroup () {
     const nodegroup = this.todoNodegroups.shift();
 
     // test group membership with function that is typically hidden
@@ -225,6 +175,63 @@ export class NodegroupsPanel extends Panel {
     }, (pLocalTestVersionMsg) => {
       this.showErrorRowInstead(pLocalTestVersionMsg.toString());
     });
+  }
+
+  _handleStepNoGroup () {
+    this.setPlayPauseButton("none");
+    this.todoNodegroups = null;
+
+    const titleElement = this.table.querySelector("#ng-" + null + " td");
+    const cnt = this.table.rows.length - titleElement.parentElement.rowIndex - 1;
+
+    if (cnt === 0) {
+      // remove the title of the empty group "not in any nodegroup"
+      titleElement.parentElement.remove();
+      return;
+    }
+
+    let txt = Utils.txtZeroOneMany(cnt, "no minions", cnt + " minion", cnt + " minions");
+    let online = 0;
+    let offline = 0;
+    for (let row = titleElement.parentElement.rowIndex + 1; row < this.table.rows.length; row++) {
+      const tr = this.table.rows[row];
+      if (tr.online === true) {
+        online += 1;
+      }
+      if (tr.offline === true) {
+        offline += 1;
+      }
+    }
+    if (online !== cnt) {
+      txt += ", " + online + " online";
+    }
+    if (offline !== 0) {
+      txt += ", " + offline + " offline";
+    }
+
+    titleElement.innerHTML = titleElement.innerHTML.replace(
+      " " + Character.EM_DASH,
+      " " + Character.EM_DASH + " " + txt + " " + Character.EM_DASH);
+  }
+
+  _handleStep () {
+
+    // user can decide
+    // system can decide to remove the play/pause button
+    if (this.playOrPause !== "play") {
+      // try again lkater for more
+      window.setTimeout(() => {
+        this._handleStep();
+      }, 100);
+      return;
+    }
+
+    if (this.todoNodegroups.length === 0) {
+      this._handleStepNoGroup();
+      return;
+    }
+
+    this._handleStepGroup();
   }
 
   _addNodegroupsRows () {

--- a/saltgui/static/scripts/panels/Nodegroups.js
+++ b/saltgui/static/scripts/panels/Nodegroups.js
@@ -19,8 +19,6 @@ export class NodegroupsPanel extends Panel {
     this.addTable(["Minion", "Status", "Salt version", "OS version", "-menu-"]);
     this.setTableClickable();
     this.addMsg();
-
-    this.setPlayPauseButton("play");
   }
 
   onShow () {
@@ -30,6 +28,8 @@ export class NodegroupsPanel extends Panel {
     this.loadMinionsTxt();
 
     this._addNodegroupsRows();
+
+    this.setPlayPauseButton("play");
 
     wheelKeyListAllPromise.then((pWheelKeyListAllData) => {
       this._handleNodegroupsWheelKeyListAll(pWheelKeyListAllData);

--- a/saltgui/static/scripts/panels/Nodegroups.js
+++ b/saltgui/static/scripts/panels/Nodegroups.js
@@ -97,12 +97,12 @@ export class NodegroupsPanel extends Panel {
   }
 
   _handleStep () {
-    if (!this.allNodegroups) {
+    if (!this.todoNodegroups) {
       return;
     }
 
-    if (this.allNodegroups.length === 0) {
-      this.allNodegroups = null;
+    if (this.todoNodegroups.length === 0) {
+      this.todoNodegroups = null;
 
       const titleElement = this.table.querySelector("#ng-" + null + " td");
       const cnt = this.table.rows.length - titleElement.parentElement.rowIndex - 1;
@@ -113,7 +113,7 @@ export class NodegroupsPanel extends Panel {
       return;
     }
 
-    const nodegroup = this.allNodegroups.shift();
+    const nodegroup = this.todoNodegroups.shift();
 
     // test group membership with function that is typically hidden
     const localTestProviders = this.api.getLocalTestProviders(nodegroup);
@@ -143,12 +143,12 @@ export class NodegroupsPanel extends Panel {
 
   _addNodegroupsRows () {
     const nodegroups = Utils.getStorageItemObject("session", "nodegroups");
-    const allNodegroups = Object.keys(nodegroups).sort();
-    this.allNodegroups = allNodegroups;
-    for (const nodegroup of allNodegroups) {
+    this.allNodegroups = Object.keys(nodegroups).sort();
+    this.todoNodegroups = Object.keys(nodegroups).sort();
+    for (const nodegroup of this.allNodegroups) {
       this._addNodegroupRow(nodegroup);
     }
-    this._addNodegroupRow(null, allNodegroups);
+    this._addNodegroupRow(null, this.allNodegroups);
   }
 
   _addNodegroupRow (pNodegroup, pAllNodegroups) {

--- a/saltgui/static/scripts/panels/Nodegroups.js
+++ b/saltgui/static/scripts/panels/Nodegroups.js
@@ -79,32 +79,36 @@ export class NodegroupsPanel extends Panel {
 
       // fix the click-to-copy-logic
       const addressSpan = minionTr2.querySelector("td.address span");
-      addressSpan.addEventListener("click", (pClickEvent) => {
-        Panel._copyAddress(addressSpan, pClickEvent.ctrlKey || pClickEvent.altKey);
-        pClickEvent.stopPropagation();
-      });
-      addressSpan.addEventListener("mouseout", () => {
+      if (addressSpan) {
+        addressSpan.addEventListener("click", (pClickEvent) => {
+          Panel._copyAddress(addressSpan, pClickEvent.ctrlKey || pClickEvent.altKey);
+          pClickEvent.stopPropagation();
+        });
+        addressSpan.addEventListener("mouseout", () => {
+          Panel.restoreClickToCopy(addressSpan);
+        });
         Panel.restoreClickToCopy(addressSpan);
-      });
-      Panel.restoreClickToCopy(addressSpan);
+      }
 
       // fix the row menu
       const oldMenuButton = minionTr2.querySelector("td div.run-command-button");
-      oldMenuButton.parentElement.remove();
-      const menu = new DropDownMenu(minionTr2, true);
-      this._addMenuItemStateApplyMinion(menu, pMinionId);
-      this._addMenuItemStateApplyTestMinion(menu, pMinionId);
-      this._addMenuItemShowGrains(menu, pMinionId);
-      this._addMenuItemShowPillars(menu, pMinionId);
-      this._addMenuItemShowSchedules(menu, pMinionId);
-      this._addMenuItemShowBeacons(menu, pMinionId);
+      if (oldMenuButton) {
+        oldMenuButton.parentElement.remove();
+        const menu = new DropDownMenu(minionTr2, true);
+        this._addMenuItemStateApplyMinion(menu, pMinionId);
+        this._addMenuItemStateApplyTestMinion(menu, pMinionId);
+        this._addMenuItemShowGrains(menu, pMinionId);
+        this._addMenuItemShowPillars(menu, pMinionId);
+        this._addMenuItemShowSchedules(menu, pMinionId);
+        this._addMenuItemShowBeacons(menu, pMinionId);
 
-      // fix the row
-      minionTr2.addEventListener("click", (pClickEvent) => {
-        const cmdArr = ["state.apply"];
-        this.runCommand("", pMinionId, cmdArr);
-        pClickEvent.stopPropagation();
-      });
+        // fix the row
+        minionTr2.addEventListener("click", (pClickEvent) => {
+          const cmdArr = ["state.apply"];
+          this.runCommand("", pMinionId, cmdArr);
+          pClickEvent.stopPropagation();
+        });
+      }
     } else {
       // move the row to its proper place
       nodegroupTr.parentNode.insertBefore(minionTr, nodegroupTr.nextSibling);

--- a/saltgui/static/scripts/panels/Nodegroups.js
+++ b/saltgui/static/scripts/panels/Nodegroups.js
@@ -131,8 +131,8 @@ export class NodegroupsPanel extends Panel {
       const titleElement = this.table.querySelector("#ng-" + null + " td");
       const cnt = this.table.rows.length - titleElement.parentElement.rowIndex - 1;
       titleElement.innerHTML = titleElement.innerHTML.replace(
-        " ---",
-        ", " + Utils.txtZeroOneMany(cnt, "no minions", cnt + " minion", cnt + " minions") + " ---");
+        " " + Character.EM_DASH,
+        " " + Character.EM_DASH + " " + Utils.txtZeroOneMany(cnt, "no minions", cnt + " minion", cnt + " minions") + " " + Character.EM_DASH);
       if (cnt === 0) {
         // remove the title of the empty group "not in any nodegroup"
         titleElement.parentElement.remove();
@@ -157,8 +157,8 @@ export class NodegroupsPanel extends Panel {
       const titleElement = this.table.querySelector("#ng-" + nodegroup + " td");
       const cnt = nodelist.length;
       titleElement.innerHTML = titleElement.innerHTML.replace(
-        " ---",
-        ", " + Utils.txtZeroOneMany(cnt, "no minions", cnt + " minion", cnt + " minions") + " ---");
+        " " + Character.EM_DASH,
+        " " + Character.EM_DASH + " " + Utils.txtZeroOneMany(cnt, "no minions", cnt + " minion", cnt + " minions") + " " + Character.EM_DASH);
 
       // try again for more
       window.setTimeout(() => {
@@ -184,9 +184,9 @@ export class NodegroupsPanel extends Panel {
 
     const titleTd = Utils.createTd();
     if (pNodegroup) {
-      titleTd.innerHTML = "--- nodegroup <b>" + pNodegroup + "</b> ---&nbsp;&nbsp;&nbsp;";
+      titleTd.innerHTML = Character.EM_DASH + " nodegroup <b>" + pNodegroup + "</b> " + Character.EM_DASH + "&nbsp;&nbsp;&nbsp;";
     } else {
-      titleTd.innerText = "--- not in any nodegroup ---" + Character.NO_BREAK_SPACE + Character.NO_BREAK_SPACE + Character.NO_BREAK_SPACE;
+      titleTd.innerText = Character.EM_DASH + " not in any nodegroup " + Character.EM_DASH + Character.NO_BREAK_SPACE + Character.NO_BREAK_SPACE + Character.NO_BREAK_SPACE;
     }
     titleTd.colSpan = 5;
     tr.append(titleTd);

--- a/saltgui/static/scripts/panels/Nodegroups.js
+++ b/saltgui/static/scripts/panels/Nodegroups.js
@@ -121,10 +121,10 @@ export class NodegroupsPanel extends Panel {
     const nodegroup = this.todoNodegroups.shift();
 
     // test group membership with function that is typically hidden
-    const localTestProviders = this.api.getLocalTestProviders(nodegroup);
-    localTestProviders.then((pLocalTestProvidersData) => {
+    const localTestVersion = this.api.getLocalTestVersion(nodegroup);
+    localTestVersion.then((pLocalTestVersionData) => {
       // handle the list in reverse order
-      const nodelist = Object.keys(pLocalTestProvidersData.return[0]).sort().
+      const nodelist = Object.keys(pLocalTestVersionData.return[0]).sort().
         reverse();
 
       for (const minionId of nodelist) {
@@ -141,8 +141,8 @@ export class NodegroupsPanel extends Panel {
       window.setTimeout(() => {
         this._handleStep();
       }, 100);
-    }, (pLocalTestProvidersMsg) => {
-      this.showErrorRowInstead(pLocalTestProvidersMsg.toString());
+    }, (pLocalTestVersionMsg) => {
+      this.showErrorRowInstead(pLocalTestVersionMsg.toString());
     });
   }
 

--- a/saltgui/static/scripts/panels/Nodegroups.js
+++ b/saltgui/static/scripts/panels/Nodegroups.js
@@ -66,6 +66,17 @@ export class NodegroupsPanel extends Panel {
     this.setMsg(txt);
   }
 
+  updateOfflineMinion (pMinionId, pMinionsDict) {
+    super.updateOfflineMinion(pMinionId, pMinionsDict);
+
+    const minionTr = this.table.querySelector("#" + Utils.getIdFromMinionId(pMinionId));
+
+    // force same columns on all rows
+    minionTr.appendChild(Utils.createTd("saltversion"));
+    minionTr.appendChild(Utils.createTd("os"));
+    minionTr.appendChild(Utils.createTd("run-command-button"));
+  }
+
   _moveMinionToNodegroup (pMinionId, pNodegroup) {
     const minionTrId = Utils.getIdFromMinionId(pMinionId);
     const minionTr = this.table.querySelector("#" + minionTrId);

--- a/saltgui/static/scripts/panels/Nodegroups.js
+++ b/saltgui/static/scripts/panels/Nodegroups.js
@@ -109,6 +109,10 @@ export class NodegroupsPanel extends Panel {
       titleElement.innerHTML = titleElement.innerHTML.replace(
         " ---",
         ", " + Utils.txtZeroOneMany(cnt, "no minions", cnt + " minion", cnt + " minions") + " ---");
+      if (cnt === 0) {
+        // remove the title of the empty group "not in any nodegroup"
+        titleElement.parentElement.remove();
+      }
 
       return;
     }

--- a/saltgui/static/scripts/panels/Panel.js
+++ b/saltgui/static/scripts/panels/Panel.js
@@ -642,7 +642,7 @@ export class Panel {
 
     minionTr.dataset.minionId = pMinionId;
 
-    let saltversion = "---";
+    let saltversion = Character.EM_DASH;
     if (typeof pMinionData === "string") {
       saltversion = "";
     } else if (pMinionData && pMinionData.saltversion) {
@@ -660,7 +660,7 @@ export class Panel {
       minionTr.appendChild(td);
     }
 
-    let os = "---";
+    let os = Character.EM_DASH;
     if (typeof pMinionData === "string") {
       os = "";
     } else if (pMinionData && pMinionData.os && pMinionData.osrelease) {

--- a/saltgui/static/scripts/panels/Panel.js
+++ b/saltgui/static/scripts/panels/Panel.js
@@ -572,7 +572,7 @@ export class Panel {
     return 1;
   }
 
-  static _restoreClickToCopy (pTarget) {
+  static restoreClickToCopy (pTarget) {
     if (pTarget.dataset.multiIpNumber === pTarget.dataset.singleIpNumber) {
       Utils.addToolTip(pTarget, "Click to copy");
     } else {
@@ -631,9 +631,9 @@ export class Panel {
         pClickEvent.stopPropagation();
       });
       addressSpan.addEventListener("mouseout", () => {
-        Panel._restoreClickToCopy(addressSpan);
+        Panel.restoreClickToCopy(addressSpan);
       });
-      Panel._restoreClickToCopy(addressSpan);
+      Panel.restoreClickToCopy(addressSpan);
       minionTr.appendChild(addressTd);
     } else {
       const accepted = Utils.createTd(["status", "accepted"], "accepted");

--- a/saltgui/static/stylesheets/page.css
+++ b/saltgui/static/stylesheets/page.css
@@ -227,7 +227,7 @@ table tr td:last-of-type {
   color: #f0f;
 }
 
-.unaccepted {
+.unaccepted, .keyunknown {
   color: #f00;
 }
 


### PR DESCRIPTION
Hello! In /etc/salt/master added block with nodegroups:

<img width="228" alt="3" src="https://github.com/erwindon/SaltGUI/assets/89910240/bf281e56-df0f-46aa-a116-a54dd0e0ccd4">
<img width="340" alt="2" src="https://github.com/erwindon/SaltGUI/assets/89910240/c1dd8d66-cacb-4ea2-be8b-54f2378eef6a">

Is it possible to display nodegroups ("sandbox") in SaltGUI on the page with minions?

<img width="283" alt="1" src="https://github.com/erwindon/SaltGUI/assets/89910240/5dede075-3235-45de-8252-10eae5a08ebb">
