### PR TITLE
setMsg is called multiple times for one page

### DIFF
--- a/saltgui/static/scripts/Utils.js
+++ b/saltgui/static/scripts/Utils.js
@@ -490,11 +490,7 @@ export class Utils {
     } else {
       txt = pManyText;
     }
-    if (pCnt === undefined) {
-      // just in case
-      txt = txt.replace("{0}", pCnt);
-      console.log(pCnt, pZeroText, pOneText, pManyText);
-    } else {
+    if (pCnt !== undefined) {
       txt = txt.replace("{0}", pCnt.toLocaleString());
     }
     return txt;

--- a/saltgui/static/scripts/issues/Issues.js
+++ b/saltgui/static/scripts/issues/Issues.js
@@ -28,10 +28,10 @@ export class Issues {
     // remove the "loading info..." message
     pPanel.msg2.removeChild(pMsg);
 
-    const txt = Utils.txtZeroOneMany(
+    pPanel.issuesStatus = Utils.txtZeroOneMany(
       pPanel.table.tBodies[0].children.length,
       "No issues", "{0} issue", "{0} issues");
-    pPanel.setMsg(txt);
+    pPanel.updateFooter();
 
     // any category still loading?
     if (pPanel.msg2.childNodes.length > 0) {

--- a/saltgui/static/scripts/panels/Beacons.js
+++ b/saltgui/static/scripts/panels/Beacons.js
@@ -21,6 +21,8 @@ export class BeaconsPanel extends Panel {
     const wheelKeyListAllPromise = this.api.getWheelKeyListAll();
     const localBeaconsListPromise = this.api.getLocalBeaconsList(null);
 
+    this.nrMinions = 0;
+
     wheelKeyListAllPromise.then((pWheelKeyListAllData) => {
       this._handleBeaconsWheelKeyListAll(pWheelKeyListAllData);
       localBeaconsListPromise.then((pLocalBeaconsListData) => {
@@ -83,6 +85,8 @@ export class BeaconsPanel extends Panel {
     }
 
     const keys = pWheelKeyListAllData.return[0].data.return;
+    this.nrMinions = keys.minions.length;
+    this.nrUnaccepted = keys.minions_pre.length;
 
     const minionIds = keys.minions.sort();
     for (const minionId of minionIds) {
@@ -98,11 +102,7 @@ export class BeaconsPanel extends Panel {
       });
     }
 
-    Utils.setStorageItem("session", "minions_pre_length", keys.minions_pre.length);
-
-    const txt = Utils.txtZeroOneMany(minionIds.length,
-      "No minions", "{0} minion", "{0} minions");
-    this.setMsg(txt);
+    this.updateFooter();
   }
 
   updateOfflineMinion (pMinionId, pMinionsDict) {

--- a/saltgui/static/scripts/panels/BeaconsMinion.js
+++ b/saltgui/static/scripts/panels/BeaconsMinion.js
@@ -35,6 +35,8 @@ export class BeaconsMinionPanel extends Panel {
   }
 
   onShow () {
+    this.nrBeacons = 0;
+
     const minionId = decodeURIComponent(Utils.getQueryParam("minionid"));
 
     // preliminary title
@@ -97,9 +99,7 @@ export class BeaconsMinionPanel extends Panel {
 
   updateFooter () {
     // update the footer
-    const tbody = this.table.tBodies[0];
-    const txt = Utils.txtZeroOneMany(tbody.rows.length,
-      "No beacons", "{0} beacon", "{0} beacons");
+    const txt = Utils.txtZeroOneMany(this.nrBeacons, "No beacons", "{0} beacon", "{0} beacons");
     this.setMsg(txt);
   }
 
@@ -185,6 +185,7 @@ export class BeaconsMinionPanel extends Panel {
 
       const tbody = this.table.tBodies[0];
       tbody.appendChild(tr);
+      this.nrBeacons += 1;
 
       // run the command with the original beacon definition
       tr.addEventListener("click", (pClickEvent) => {

--- a/saltgui/static/scripts/panels/Events.js
+++ b/saltgui/static/scripts/panels/Events.js
@@ -26,25 +26,24 @@ export class EventsPanel extends Panel {
   }
 
   onShow () {
+    this.nrEvents = 0;
     this.updateFooter();
   }
 
   updateFooter () {
-    // update the footer
-    const tbody = this.table.tBodies[0];
     // when there are more than a screen-ful of events, the user
     // will not see the "press play" message. but the user already
     // knows that because that caused the events to be shown...
-    let txt = Utils.txtZeroOneMany(tbody.rows.length,
-      "No events", "{0} event", "{0} events");
+    let txt = Utils.txtZeroOneMany(this.nrEvents, "No events", "{0} event", "{0} events");
     if (this.playOrPause === "play") {
+      const tbody = this.table.tBodies[0];
       if (tbody.rows.length) {
         txt += ", waiting for more events";
       } else {
         txt += ", waiting for events";
       }
     }
-    this.setMsg(txt);
+    super.updateFooter(txt);
   }
 
   handleAnyEvent (pTag, pData) {
@@ -88,6 +87,7 @@ export class EventsPanel extends Panel {
       tbody.deleteRow(tbody.rows.length - 1);
     }
 
+    this.nrEvents = tbody.rows.length;
     this.updateFooter();
   }
 }

--- a/saltgui/static/scripts/panels/Grains.js
+++ b/saltgui/static/scripts/panels/Grains.js
@@ -47,6 +47,8 @@ export class GrainsPanel extends Panel {
     const wheelKeyListAllPromise = this.api.getWheelKeyListAll();
     const localGrainsItemsPromise = this.api.getLocalGrainsItems(null);
 
+    this.nrMinions = 0;
+
     wheelKeyListAllPromise.then((pWheelKeyListAllData) => {
       this._handleGrainsWheelKeyListAll(pWheelKeyListAllData);
       localGrainsItemsPromise.then((pLocalGrainsItemsData) => {
@@ -71,6 +73,8 @@ export class GrainsPanel extends Panel {
     }
 
     const keys = pWheelKeyListAllData.return[0].data.return;
+    this.nrMinions = keys.minions.length;
+    this.nrUnaccepted = keys.minions_pre.length;
 
     const minionIds = keys.minions.sort();
     for (const minionId of minionIds) {
@@ -90,11 +94,7 @@ export class GrainsPanel extends Panel {
       });
     }
 
-    Utils.setStorageItem("session", "minions_pre_length", keys.minions_pre.length);
-
-    const txt = Utils.txtZeroOneMany(minionIds.length,
-      "No minions", "{0} minion", "{0} minions");
-    this.setMsg(txt);
+    this.updateFooter();
   }
 
   updateOfflineMinion (pMinionId, pMinionsDict) {

--- a/saltgui/static/scripts/panels/HighState.js
+++ b/saltgui/static/scripts/panels/HighState.js
@@ -49,6 +49,8 @@ export class HighStatePanel extends Panel {
   onShow () {
     const wheelKeyListAllPromise = this.api.getWheelKeyListAll();
 
+    this.nrMinions = 0;
+
     const cmdList = [];
     if (Utils.getStorageItem("local", "use_state_highstate", "true") === "true") {
       cmdList.push("state.highstate");
@@ -132,6 +134,9 @@ export class HighStatePanel extends Panel {
     const keys = pWheelKeyListAll.return[0].data.return;
 
     const minionIds = keys.minions.sort();
+    this.nrMinions = minionIds.length;
+    this.nrUnaccepted = keys.minions_pre.length;
+
     for (const minionId of minionIds) {
       const minionTr = this.addMinion(minionId, 2);
 
@@ -155,13 +160,6 @@ export class HighStatePanel extends Panel {
     }
 
     this.updateFooter();
-  }
-
-  updateFooter () {
-    const tbody = this.table.tBodies[0];
-    const txt = Utils.txtZeroOneMany(tbody.rows.length,
-      "No minions", "{0} minion", "{0} minions");
-    this.setMsg(txt);
   }
 
   _handleHighstateRunnerJobsListJobs (pData) {

--- a/saltgui/static/scripts/panels/Issues.js
+++ b/saltgui/static/scripts/panels/Issues.js
@@ -43,7 +43,8 @@ export class IssuesPanel extends Panel {
   }
 
   updateFooter () {
-    this.setMsg("(loading)");
+    const txt = this.issuesStatus;
+    super.updateFooter(txt ? txt : "(loading)");
   }
 
   onShow () {

--- a/saltgui/static/scripts/panels/Jobs.js
+++ b/saltgui/static/scripts/panels/Jobs.js
@@ -221,7 +221,7 @@ export class JobsPanel extends Panel {
   updateFooter () {
     let txt = Utils.txtZeroOneMany(this.numberOfJobsShown,
       "No jobs shown", "{0} job shown", "{0} jobs shown");
-    if (this.numberOfJobsEligible > this.numberOfJobsShown) {
+    if (this.numberOfJobsEligible > 0 && this.numberOfJobsEligible > this.numberOfJobsShown) {
       txt += Utils.txtZeroOneMany(this.numberOfJobsEligible,
         "", ", {0} job eligible", ", {0} jobs eligible");
     }

--- a/saltgui/static/scripts/panels/Minions.js
+++ b/saltgui/static/scripts/panels/Minions.js
@@ -29,6 +29,8 @@ export class MinionsPanel extends Panel {
   }
 
   onShow () {
+    this.nrMinions = 0;
+
     const wheelKeyListAllPromise = this.api.getWheelKeyListAll();
     const wheelMinionsConnectedPromise = this.api.getWheelMinionsConnected();
     const localGrainsItemsPromise = this.api.getLocalGrainsItems(null);
@@ -79,6 +81,8 @@ export class MinionsPanel extends Panel {
     }
 
     const keys = pWheelKeyListAll.return[0].data.return;
+    this.nrMinions = keys.minions.length;
+    this.nrUnaccepted = keys.minions_pre.length;
 
     const minionIds = keys.minions.sort();
     for (const minionId of minionIds) {
@@ -94,11 +98,7 @@ export class MinionsPanel extends Panel {
       this._addMenuItemShowBeacons(menu, minionId);
     }
 
-    Utils.setStorageItem("session", "minions_pre_length", keys.minions_pre.length);
-
-    const txt = Utils.txtZeroOneMany(minionIds.length,
-      "No minions", "{0} minion", "{0} minions");
-    this.setMsg(txt);
+    this.updateFooter();
   }
 
   static _getShortestTargetClause (pWheelMinionsConnectedData, pWheelKeyListAllData) {

--- a/saltgui/static/scripts/panels/Nodegroups.js
+++ b/saltgui/static/scripts/panels/Nodegroups.js
@@ -22,12 +22,15 @@ export class NodegroupsPanel extends Panel {
   }
 
   onShow () {
+    this.nrMinions = 0;
+
     const wheelKeyListAllPromise = this.api.getWheelKeyListAll();
     const localGrainsItemsPromise = this.api.getLocalGrainsItems(null);
 
     this.loadMinionsTxt();
 
     this._addNodegroupsRows();
+    this.updateFooter();
 
     this.setPlayPauseButton("play");
 
@@ -55,15 +58,11 @@ export class NodegroupsPanel extends Panel {
   }
 
   updateFooter () {
-    const txt = Utils.txtZeroOneMany(this.minionsCnt,
-      "No minions", "{0} minion", "{0} minions");
+    const nodegroups = Utils.getStorageItemObject("session", "nodegroups");
+    const txt = ", " + Utils.txtZeroOneMany(Object.keys(nodegroups).length,
+      "no nodegroups", "{0} nodegroup", "{0} nodegroups");
 
-    // see https://github.com/erwindon/SaltGUI/issues/517
-    // const nodegroups = Utils.getStorageItemObject("session", "nodegroups");
-    // txt += ", " + Utils.txtZeroOneMany(Object.keys(nodegroups).length,
-    //   "no nodegroups", "{0} nodegroup", "{0} nodegroups");
-
-    this.setMsg(txt);
+    super.updateFooter(txt);
   }
 
   updateOfflineMinion (pMinionId, pMinionsDict) {
@@ -319,6 +318,8 @@ export class NodegroupsPanel extends Panel {
     }
 
     const keys = pWheelKeyListAll.return[0].data.return;
+    this.nrMinions = keys.minions.length;
+    this.nrUnaccepted = keys.minions_pre.length;
 
     const minionIds = keys.minions.sort();
     for (const minionId of minionIds) {
@@ -334,9 +335,6 @@ export class NodegroupsPanel extends Panel {
       this._addMenuItemShowBeacons(menu, minionId);
     }
 
-    Utils.setStorageItem("session", "minions_pre_length", keys.minions_pre.length);
-
-    this.minionsCnt = keys.minions.length;
     this.updateFooter();
   }
 

--- a/saltgui/static/scripts/panels/Pillars.js
+++ b/saltgui/static/scripts/panels/Pillars.js
@@ -21,6 +21,8 @@ export class PillarsPanel extends Panel {
     const wheelKeyListAllPromise = this.api.getWheelKeyListAll();
     const localPillarObfuscatePromise = this.api.getLocalPillarObfuscate(null);
 
+    this.nrMinions = 0;
+
     wheelKeyListAllPromise.then((pWheelKeyListAllData) => {
       this._handlePillarsWheelKeyListAll(pWheelKeyListAllData);
       localPillarObfuscatePromise.then((pLocalPillarObfuscateData) => {
@@ -45,6 +47,8 @@ export class PillarsPanel extends Panel {
     }
 
     const keys = pWheelKeyListAllData.return[0].data.return;
+    this.nrMinions = keys.minions.length;
+    this.nrUnaccepted = keys.minions_pre.length;
 
     const minionIds = keys.minions.sort();
     for (const minionId of minionIds) {
@@ -60,9 +64,7 @@ export class PillarsPanel extends Panel {
       });
     }
 
-    const txt = Utils.txtZeroOneMany(minionIds.length,
-      "No minions", "{0} minion", "{0} minions");
-    this.setMsg(txt);
+    this.updateFooter();
   }
 
   updateOfflineMinion (pMinionId, pMinionsDict) {

--- a/saltgui/static/scripts/panels/Schedules.js
+++ b/saltgui/static/scripts/panels/Schedules.js
@@ -21,6 +21,8 @@ export class SchedulesPanel extends Panel {
     const wheelKeyListAllPromise = this.api.getWheelKeyListAll();
     const localScheduleListPromise = this.api.getLocalScheduleList(null);
 
+    this.nrMinions = 0;
+
     wheelKeyListAllPromise.then((pWheelKeyListAllData) => {
       this._handleSchedulesWheelKeyListAll(pWheelKeyListAllData);
       localScheduleListPromise.then((pLocalScheduleListData) => {
@@ -79,6 +81,8 @@ export class SchedulesPanel extends Panel {
     }
 
     const keys = pWheelKeyListAllData.return[0].data.return;
+    this.nrMinions = keys.minions.length;
+    this.nrUnaccepted = keys.minions_pre.length;
 
     const minionIds = keys.minions.sort();
     for (const minionId of minionIds) {
@@ -94,11 +98,7 @@ export class SchedulesPanel extends Panel {
       });
     }
 
-    Utils.setStorageItem("session", "minions_pre_length", keys.minions_pre.length);
-
-    const txt = Utils.txtZeroOneMany(minionIds.length,
-      "No minions", "{0} minion", "{0} minions");
-    this.setMsg(txt);
+    this.updateFooter();
   }
 
   updateOfflineMinion (pMinionId, pMinionsDict) {

--- a/saltgui/static/scripts/panels/Templates.js
+++ b/saltgui/static/scripts/panels/Templates.js
@@ -21,6 +21,8 @@ export class TemplatesPanel extends Panel {
   onShow () {
     const wheelConfigValuesPromise = this.api.getWheelConfigValues();
 
+    this.nrTemplates = 0;
+
     wheelConfigValuesPromise.then((pWheelConfigValuesData) => {
       this._handleTemplatesWheelConfigValues(pWheelConfigValuesData);
       return true;
@@ -37,6 +39,8 @@ export class TemplatesPanel extends Panel {
 
     // should we update it or just use from cache (see commandbox) ?
     let templates = pWheelConfigValuesData.return[0].data.return.saltgui_templates;
+    this.nrTemplates = Object.keys(templates).length;
+
     if (templates) {
       Utils.setStorageItem("session", "templates", JSON.stringify(templates));
       this.setCategoriesTitle(templates);
@@ -52,7 +56,11 @@ export class TemplatesPanel extends Panel {
       this._addTemplate(key, template);
     }
 
-    const txt = Utils.txtZeroOneMany(keys.length,
+    this.updateFooter();
+  }
+
+  updateFooter () {
+    const txt = Utils.txtZeroOneMany(this.nrTemplates,
       "No templates", "{0} template", "{0} templates");
     this.setMsg(txt);
   }


### PR DESCRIPTION
**Describe the bug**
function `setMsg` sets the status line at the bottom of a panel.
most (or all) of the panels that display a list of minions effectively call the function twice.
once from a specific function for that panel, and once from a common location.
but the common location only mentions the number of minions and thus hides the additional details that were set by that panel.
(but currently none of the panels add details, so the effect is limited)

**To Reproduce**
Cannot reproduce with current version.
See PR #515
show page "nodegroups"
the status line should mention the number of nodes and the number of nodegroups.
but that is quickly overwritten by the common function.

**Expected behaviour**
Status line should be determined in only one code location.

**Additional context**
This effect became clear when adding page "nodegroups" that adds additional details to the status line.
this is in development as #515.
treating this as an existing problem.