### PR TITLE
collect_stats=true always causes a forced logout

### DIFF
--- a/saltgui/static/scripts/pages/Logout.js
+++ b/saltgui/static/scripts/pages/Logout.js
@@ -12,7 +12,7 @@ export class LogoutPage extends Page {
   onRegister () {
     // don't verify for invalid sessions too often
     // this happens only when the server was reset
-    window.setInterval(() => {
+    this.logoutTimer = window.setInterval(() => {
       this._logoutTimer();
     }, 60000);
 
@@ -45,7 +45,18 @@ export class LogoutPage extends Page {
     const statsPromise = this.api.getStats();
     // don't act in the callbacks
     // Api.apiRequest will do all the work
-    statsPromise.then(() => true, () => {
+    statsPromise.then(() => true, (pHttpResponse) => {
+      if (pHttpResponse.status === 500) {
+        // assume this error applies only to /stats and
+        // not to any regular api functions
+        // may happen due to https://github.com/saltstack/salt/issues/59620
+        // repeating this is not so useful
+        if (this.logoutTimer) {
+          clearInterval(this.logoutTimer);
+          this.logoutTimer = null;
+        }
+        return;
+      }
       this.api.logout().then(() => {
         this.router.goTo("login", {"reason": "session-cancelled"});
         return false;

--- a/saltgui/static/scripts/panels/Stats.js
+++ b/saltgui/static/scripts/panels/Stats.js
@@ -69,7 +69,9 @@ export class StatsPanel extends Panel {
 
   _handleStats (pStatsData) {
     if (this.showErrorRowInstead(pStatsData)) {
-      this.statsTd.innerText = "(error)";
+      this.statsTd.innerHTML = "<span style='color:red'>this error is typically caused by using the <tt>collect_stats: True</tt> setting in the master configuration file, which is broken in at least the recent versions of salt-api</span>";
+      window.clearInterval(this.updateStatsTimer);
+      this.updateStatsTimer = null;
       return;
     }
 


### PR DESCRIPTION
**Describe the bug**
A bug in SaltStack itself...
When switching on `collect_stats` for salt-api, the call `/stats` fails with an internal server error response (code 500).
this happens at least for salt-versions up to 3006.1, which is the lasted at this moment. 
SaltGUI logs-out on any error from this call.

**Expected behaviour**
SaltGUI should ignore this specific error since it does not actually provide information on the login status.