### PR TITLE
prevent problems with long job argument list

### DIFF
--- a/saltgui/static/scripts/CommandBox.js
+++ b/saltgui/static/scripts/CommandBox.js
@@ -398,7 +398,7 @@ export class CommandBox {
       minions = ["WHEEL"];
     }
     // do not suppress the jobId (even when we can)
-    Output.addResponseOutput(outputContainer, null, minions, pResponse, pCommand, "done", undefined);
+    Output.addResponseOutput(outputContainer, null, minions, pResponse, pCommand, "done", undefined, undefined);
     const targetField = document.getElementById("target");
     const commandField = document.getElementById("command");
     const button = document.querySelector(".run-command input[type='submit']");

--- a/saltgui/static/scripts/output/Output.js
+++ b/saltgui/static/scripts/output/Output.js
@@ -615,7 +615,7 @@ export class Output {
 
   // the orchestrator for the output
   // determines what format should be used and uses that
-  static addResponseOutput (pOutputContainer, pJobId, pMinionData, pResponse, pCommand, pInitialStatus, pHighlightMinionId) {
+  static addResponseOutput (pOutputContainer, pJobId, pMinionData, pResponse, pCommand, pInitialStatus, pHighlightMinionId, pArguments) {
 
     // remove old content
     pOutputContainer.innerText = "";
@@ -735,6 +735,12 @@ export class Output {
 
       summaryJobsListJobSpan.innerText = txt;
       topSummaryDiv.appendChild(summaryJobsListJobSpan);
+    }
+
+    if (pArguments) {
+      const div = Utils.createDiv("", pArguments);
+      div.style.lineBreak = "anywhere";
+      pOutputContainer.appendChild(div);
     }
 
     const masterTriangle = Utils.createSpan();

--- a/saltgui/static/scripts/panels/Job.js
+++ b/saltgui/static/scripts/panels/Job.js
@@ -178,8 +178,7 @@ export class JobPanel extends Panel {
     this.output.innerText = "";
 
     // use same formatter as direct commands
-    const argumentsText = JobPanel.decodeArgumentsArray(info.Arguments);
-    const commandText = info.Function + argumentsText;
+    let argumentsText = JobPanel.decodeArgumentsArray(info.Arguments);
 
     this.targettype = info["Target-type"];
     if (Array.isArray(info.Target)) {
@@ -187,7 +186,7 @@ export class JobPanel extends Panel {
     } else {
       this.target = info.Target;
     }
-    this.commandtext = commandText;
+    this.commandtext = info.Function + argumentsText;
     this.jobid = pJobId;
     this.minions = info.Minions;
     this.result = info.Result;
@@ -197,7 +196,13 @@ export class JobPanel extends Panel {
 
     // ============================
 
-    const functionText = commandText + " on " +
+    const maxTextLength = 50;
+    if (argumentsText.length > maxTextLength) {
+      // prevent column becoming too wide
+      argumentsText = argumentsText.substring(0, maxTextLength) + "...";
+    }
+
+    const functionText = info.Function + argumentsText + " on " +
       TargetType.makeTargetText(info);
     this.updateTitle(functionText);
 
@@ -229,7 +234,7 @@ export class JobPanel extends Panel {
       initialStatus = "(loading)";
       this.jobIsTerminated = false;
     }
-    Output.addResponseOutput(this.output, pJobId, minions, info.Result, info.Function, initialStatus, pMinionId);
+    Output.addResponseOutput(this.output, pJobId, minions, info.Result, info.Function, initialStatus, pMinionId, this.commandtext);
 
     // replace any jobid
     // Don't do this with output.innerHTML as there are already

--- a/saltgui/static/scripts/panels/Job.js
+++ b/saltgui/static/scripts/panels/Job.js
@@ -197,8 +197,10 @@ export class JobPanel extends Panel {
     // ============================
 
     const maxTextLength = 50;
+    let displayArguments = null;
     if (argumentsText.length > maxTextLength) {
       // prevent column becoming too wide
+      displayArguments = this.commandtext;
       argumentsText = argumentsText.substring(0, maxTextLength) + "...";
     }
 
@@ -234,7 +236,7 @@ export class JobPanel extends Panel {
       initialStatus = "(loading)";
       this.jobIsTerminated = false;
     }
-    Output.addResponseOutput(this.output, pJobId, minions, info.Result, info.Function, initialStatus, pMinionId, this.commandtext);
+    Output.addResponseOutput(this.output, pJobId, minions, info.Result, info.Function, initialStatus, pMinionId, displayArguments);
 
     // replace any jobid
     // Don't do this with output.innerHTML as there are already


### PR DESCRIPTION
some salt command have long arguments lists.

the full argument list was used as the title of the Job page.
this should be shortened to the first 50 characters only.

but when that title is shortened, there is no more insight in the argument list of the command.
therefore, in that case, add the full command at the top of the output panel.