### PR TITLE
allow custom title for the custom-grains

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -253,6 +253,10 @@ The names can be specified as simple names like the example above.
 Alternatively, the [grains.get](https://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.grains.html#salt.modules.grains.get) notation can be used to get more detailed information. The separator is always `:`. e.g. `locale_info:timezone`.
 Alternatively, the [jsonpath](https://www.w3resource.com/JSON/JSONPath-with-JavaScript.php) notation can be used to allow even more freedom. Jsonpath is used when the text starts with a `$`. e.g. `$.ip4_interfaces.eth0[0]`.
 
+The configured value can be prefixed with a title and an '=' sign to specify the title to be used on the screen.
+e.g. `IP-Number=$.ip4_interfaces.eth0[0]` shows `IP-Number` as title, but uses the value `$.ip4_interfaces.eth0[0]` for each minion.
+Note that when the value somehow contains an '=' sign, then a title must be provided to prevent confusion.
+
 In any table where the the minion status is shown and where the grain-values of the minion are also known, the minion status is
 replaced with the the best value from grain `fqdn_ip4`.
 The best value is chosen by first eliminating all values that appear for more than one minion.

--- a/saltgui/static/scripts/panels/Grains.js
+++ b/saltgui/static/scripts/panels/Grains.js
@@ -35,7 +35,8 @@ export class GrainsPanel extends Panel {
       // the div is not added to the DOM yet
       const tr = this.div.querySelector("#grains-table-thead-tr");
       for (const previewGrain of this.previewGrains) {
-        const th = Utils.createElem("th", "", previewGrain);
+        const previewGrainTitle = previewGrain.replaceAll(/[=].*$/g, "");
+        const th = Utils.createElem("th", "", previewGrainTitle);
         tr.appendChild(th);
       }
       this.previewColumsAdded = true;
@@ -134,23 +135,24 @@ export class GrainsPanel extends Panel {
 
     // add the preview columns
     /* eslint-disable max-depth */
-    for (const grainName of this.previewGrains) {
+    for (const previewGrain of this.previewGrains) {
       const td = Utils.createTd();
       if (typeof pMinionData === "object") {
-        if (grainName.startsWith("$")) {
+        const previewGrainValue = previewGrain.replaceAll(/^[^=]*=/g, "");
+        if (previewGrainValue.startsWith("$")) {
           // it is a json path
-          const obj = jsonPath(pMinionData, grainName);
+          const obj = jsonPath(pMinionData, previewGrainValue);
           if (Array.isArray(obj)) {
             td.innerText = Output.formatObject(obj[0]);
             td.classList.add("grain-value");
           }
         } else {
           // a plain grain-name or a path in the grains.get style
-          const grainNames = grainName.split(":");
+          const grainNames = previewGrainValue.split(":");
           let obj = pMinionData;
-          for (const gn of grainNames) {
+          for (const grainName of grainNames) {
             if (obj) {
-              obj = obj[gn];
+              obj = obj[grainName];
             }
           }
           if (obj) {


### PR DESCRIPTION
In the Grains page, additional columns can be added based on selected grain information.
Currently, the title of such column is always the same as the grain-name and/or grain-expression.
Specifically the grain-expression can be a bit complicated and distracting.
Add possibility to add own title to a custom-grain column.