### PR TITLE
use ESC to close the command-box

### DIFF
--- a/saltgui/static/scripts/CommandBox.js
+++ b/saltgui/static/scripts/CommandBox.js
@@ -416,16 +416,11 @@ export class CommandBox {
 
     const targetField = document.getElementById("target");
     TargetType.autoSelectTargetType(targetField.value);
-    targetField.onkeyup = (keyUpEvent) => {
-      if (keyUpEvent.key === "Escape") {
-        CommandBox.hideManualRun();
-      }
-    };
 
-    const commandField = document.getElementById("command");
-    commandField.onkeyup = (keyUpEvent) => {
+    document.onkeyup = (keyUpEvent) => {
       if (keyUpEvent.key === "Escape") {
         CommandBox.hideManualRun();
+        keyUpEvent.stopPropagation();
       }
     };
 
@@ -454,6 +449,8 @@ export class CommandBox {
       option.value = minionId;
       targetList.appendChild(option);
     }
+
+    const commandField = document.getElementById("command");
 
     // give another field (which does not have a list) focus first
     // because when a field gets focus 2 times in a row,

--- a/saltgui/static/scripts/Utils.js
+++ b/saltgui/static/scripts/Utils.js
@@ -348,11 +348,11 @@ export class Utils {
 
     // hide/show search box (the block may become more complicated later)
     const input = pSearchBlock.querySelector("input");
-    input.onkeyup = (ev) => {
-      if (ev.key === "Escape") {
+    input.onkeyup = (keyUpEvent) => {
+      if (keyUpEvent.key === "Escape") {
         Utils._updateTableFilter(pTable, "", menuItems);
         Utils.hideShowTableSearchBar(pSearchBlock, pTable);
-        // return;
+        keyUpEvent.stopPropagation();
       }
     };
     input.oninput = () => {


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
the command-box can be dismissed by typing ESC while the focus is in the TARGET or COMMAND fields.
but not when the focus is elsewhere, e.g. after clicking "Run Command"

**Describe the solution you'd like**
Accept ESC also when focus is elsewhere