### PR TITLE
Converted saltgui_ipnumber_prefix to array

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -262,7 +262,12 @@ replaced with the the best value from grain `fqdn_ip4`.
 The best value is chosen by first eliminating all values that appear for more than one minion.
 Then the first value that has the most specific network prefix is used.
 It is possible to chose a different grain by setting variable `saltgui_ipnumber_field` in salt master configuration file `/etc/salt/master`.
-It is possible to restrict the eligible IP-numbers by setting variable `saltgui_ipnumber_prefix` in salt master configuration file `/etc/salt/master`. Only values with that string-prefix are considered.
+It is possible to restrict the eligible IP-numbers by setting variable `saltgui_ipnumber_prefix` in salt master configuration file `/etc/salt/master`. Only values with that string-prefix are considered. You can specify several prefixes, for example:
+```
+saltgui_ipnumber_prefix:
+    - 192.168
+    - 10.10
+```
 The display of the IP-numbers can simply be disabled by choosing a non-existing grain or by choosing a non-existing prefix.
 
 ## Pillars

--- a/saltgui/static/scripts/panels/Login.js
+++ b/saltgui/static/scripts/panels/Login.js
@@ -360,7 +360,7 @@ export class LoginPanel extends Panel {
     const ipNumberField = wheelConfigValuesData.saltgui_ipnumber_field;
     Utils.setStorageItem("session", "ipnumber_field", ipNumberField);
     const ipNumberPrefix = wheelConfigValuesData.saltgui_ipnumber_prefix;
-    Utils.setStorageItem("session", "ipnumber_prefix", ipNumberPrefix);
+    Utils.setStorageItem("session", "ipnumber_prefix", JSON.stringify(ipNumberPrefix));
 
     const showSaltEnvs = wheelConfigValuesData.saltgui_show_saltenvs;
     Utils.setStorageItem("session", "show_saltenvs", JSON.stringify(showSaltEnvs));

--- a/saltgui/static/scripts/panels/Panel.js
+++ b/saltgui/static/scripts/panels/Panel.js
@@ -433,6 +433,20 @@ export class Panel {
     return cnt;
   }
 
+  static _filterIpAddresses (allIpNumbers, pIpNumberPrefix) {
+    if (pIpNumberPrefix.length > 0) {
+      allIpNumbers = allIpNumbers.filter((item) => {
+        for (const prefix of pIpNumberPrefix) {
+          if (item.startsWith(prefix)) {
+            return true;
+          }
+        }
+        return false;
+      });
+    }
+    return allIpNumbers;
+  }
+
   static _getBestIpNumber (pMinionData, pAllMinionsGrains, pIpNumberField, pIpNumberPrefix) {
     if (!pMinionData) {
       return null;
@@ -447,7 +461,7 @@ export class Panel {
     // so, it is an array
 
     // reduce to only the requested prefix
-    allIpNumbers = allIpNumbers.filter((item) => item.startsWith(pIpNumberPrefix));
+    allIpNumbers = Panel._filterIpAddresses(allIpNumbers, pIpNumberPrefix);
 
     // sort it, so that we get more consistent results
     // when there are minions which report multiple IP
@@ -497,7 +511,7 @@ export class Panel {
     }
 
     // reduce to only the requested prefix
-    allIpNumbers = allIpNumbers.filter((item) => item.startsWith(pIpNumberPrefix));
+    allIpNumbers = Panel._filterIpAddresses(allIpNumbers, pIpNumberPrefix);
 
     return allIpNumbers;
   }
@@ -577,7 +591,7 @@ export class Panel {
     // typical choices are "fqdn_ip4", "ipv4", "fqdn_ip6" or "ipv6"
     // non-existent grains effectively disable the behaviour
     const ipNumberField = Utils.getStorageItem("session", "ipnumber_field", "fqdn_ip4");
-    const ipNumberPrefix = Utils.getStorageItem("session", "ipnumber_prefix", "");
+    const ipNumberPrefix = Utils.getStorageItemList("session", "ipnumber_prefix");
 
     const bestIpNumber = Panel._getBestIpNumber(pMinionData, pAllMinionsGrains, ipNumberField, ipNumberPrefix);
     const allIpNumbers = Panel._getAllIpNumbers(pMinionData, ipNumberField, ipNumberPrefix);


### PR DESCRIPTION
Converted saltgui_ipnumber_prefix to array for make possible set several ip prefixes from different networks