### PR TITLE
Filter to show only changes for highstates

### DIFF
--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -23,7 +23,7 @@
 
   <body>
     <header id="header" class="no-print">
-      <h1 id="logo" class='logo'>SaltGUI</h1>
+      <h1 class='logo'><div id="logo">SaltGUI</div></h1>
       <svg class='fab' width="36" height="36">
         <circle id='button-manual-run' cx="18" cy="18" r="18" fill="#4caf50" />
         <text style='pointer-events: none' fill="white" font-weight="bold" font-size="20" x="6" y="23">&gt;_</text>

--- a/saltgui/static/scripts/Router.js
+++ b/saltgui/static/scripts/Router.js
@@ -63,6 +63,9 @@ export class Router {
 
     this._registerRouterEventListeners();
 
+    const logo = document.getElementById("logo");
+    Utils.addToolTip(logo, "ctrl-click to see\nOptions and Stats", "logo");
+
     Router.updateMainMenu();
 
     const hash = window.location.hash.replace(/^#/, "");

--- a/saltgui/static/scripts/panels/Options.js
+++ b/saltgui/static/scripts/panels/Options.js
@@ -20,6 +20,10 @@ export class OptionsPanel extends Panel {
       "Other names are regular variables from the master file.",
       "Changes made in this screen are valid for this session ONLY."
     ]);
+
+    const txt = Utils.createDiv("", Character.CIRCLED_INFORMATION_SOURCE + " Any changes made here are for this login session only");
+    this.div.append(txt);
+
     this.addTable(["Name", "Value"]);
 
     this.options = [

--- a/saltgui/static/stylesheets/tooltip.css
+++ b/saltgui/static/stylesheets/tooltip.css
@@ -81,6 +81,17 @@ pre.output .tooltip:hover {
   border-color: rgba(76, 175, 80, 80%) transparent transparent transparent;
 }
 
+.tooltip > .tooltip-text-logo {
+  left: 110px;
+  top: -5px;
+  height: calc(150% - 5px);
+}
+
+.tooltip > .tooltip-text-logo::after {
+  /* hide the tooltip pointer */
+  display: none;
+}
+
 .tooltip > .tooltip-text-bottom-left::after {
   left: calc(5% - 2.5px);
 }


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
I takes time to scroll on SaltGui even if most of the state_id have not been updated on the minions.

**Describe the solution you'd like**
It could be great to be able to have a toggle in order not to show state_ids that have not been updated.

**Describe alternatives you've considered**
Keep scrolling

**Additional context**
We use SaltGui to manage dozens of minions, each made of os dozens of state_ids :)
