### PR TITLE
feature request: keyboard shortcuts, ESC key

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,8 @@ such as `yubico_client`, or execution modules such as `boto3_sns`.
 - Define your own custom documentation for commands
 - Match list of minions against reference list
 - Match status of minions against reference list
+- Keyboard control for top-level navigation
+- Keyboard control to apply templates
 
 
 ## Quick start using PAM as authentication method

--- a/docs/README.md
+++ b/docs/README.md
@@ -184,6 +184,7 @@ saltgui_templates:
         description: First template
         target: "*"
         command: test.fib num=10
+        key: "f"
     template2:
         description: Second template
         targettype: glob
@@ -212,6 +213,9 @@ saltgui_templates:
 When at least one template is assigned to a category, then you can select a template category before
 selecting the actual category. Otherwise that choice remains hidden. Templates can be in multiple categories
 when a list of categories is assigned.
+
+When at least one template is assigned to a key, then you can select a template by typing that key
+while using any other screen in SaltGUI. Otherwise that choice remains hidden.
 
 
 ## Jobs

--- a/saltgui/index.html
+++ b/saltgui/index.html
@@ -24,10 +24,12 @@
   <body>
     <header id="header" class="no-print">
       <h1 class='logo'><div id="logo">SaltGUI</div></h1>
-      <svg class='fab' width="36" height="36">
-        <circle id='button-manual-run' cx="18" cy="18" r="18" fill="#4caf50" />
-        <text style='pointer-events: none' fill="white" font-weight="bold" font-size="20" x="6" y="23">&gt;_</text>
-      </svg>
+      <h1 class='fab'>
+        <svg width="36" height="36">
+          <circle id='button-manual-run' cx="18" cy="18" r="18" fill="#4caf50" />
+          <text style='pointer-events: none' fill="white" font-weight="bold" font-size="20" x="6" y="23">&gt;_</text>
+        </svg>
+      </h1>
       <!-- 1F4D6 = OPEN BOOK -->
       <!-- FE0E = VARIATION SELECTOR-15 (render as text) -->
       <h1 id="docu" class='docu'>&#x1F4D6;&#xFE0E;</h1>
@@ -37,7 +39,7 @@
       <div class="minimenu">
         <div class="dropdown">
           <!-- 2261 = MATHEMATICAL OPERATOR IDENTICAL TO (aka "hamburger") -->
-          <div class="menu-item">&#x2261;</div>
+          <div class="menu-item" id="minimenu-top">&#x2261;</div>
           <div class="dropdown-content"></div>
         </div>
       </div>

--- a/saltgui/static/scripts/CommandBox.js
+++ b/saltgui/static/scripts/CommandBox.js
@@ -87,21 +87,26 @@ export class CommandBox {
   }
 
   static _templateTmplMenuItemTitle (pTemplate) {
+    let keyboardHint = "";
+    if (pTemplate.key) {
+      keyboardHint = Character.NO_BREAK_SPACE + "[" + pTemplate.key + "]";
+    }
+
     if (CommandBox.templateTmplMenu._templateCategory === null) {
       // "(all)" selected, return all
-      return pTemplate.description;
+      return pTemplate.description + keyboardHint;
     }
     if (CommandBox.templateTmplMenu._templateCategory === undefined && pTemplate.category === undefined && pTemplate.categories === undefined) {
       // no category selected, return templates without category
-      return pTemplate.description;
+      return pTemplate.description + keyboardHint;
     }
     if (pTemplate.category && pTemplate.category === CommandBox.templateTmplMenu._templateCategory) {
       // item has one category, return when it matches
-      return pTemplate.description;
+      return pTemplate.description + keyboardHint;
     }
     if (pTemplate.categories && pTemplate.categories.indexOf(CommandBox.templateTmplMenu._templateCategory) >= 0) {
       // item has a list of categories, return when one matches
-      return pTemplate.description;
+      return pTemplate.description + keyboardHint;
     }
     return null;
   }

--- a/saltgui/static/scripts/CommandBox.js
+++ b/saltgui/static/scripts/CommandBox.js
@@ -130,7 +130,7 @@ export class CommandBox {
       menu.addMenuItem(
         () => CommandBox._templateTmplMenuItemTitle(template),
         () => {
-          CommandBox._applyTemplate(template);
+          CommandBox.applyTemplateByTemplate(template);
         }
       );
     }
@@ -250,33 +250,44 @@ export class CommandBox {
       });
   }
 
-  static _applyTemplate (template) {
-
-    if (template.targettype) {
-      let targetType = template.targettype;
+  static applyTemplateByProperties (pTargetType, pTarget, pCommand) {
+    if (pTargetType) {
       const targetbox = document.getElementById("target-box");
       // show the extended selection controls when
       targetbox.style.display = "inherit";
-      if (targetType !== "glob" && targetType !== "list" && targetType !== "compound" && targetType !== "nodegroup") {
+      if (pTargetType !== "glob" && pTargetType !== "list" && pTargetType !== "compound" && pTargetType !== "nodegroup") {
         // we don't support that, revert to standard (not default)
-        targetType = "glob";
+        pTargetType = "glob";
       }
-      TargetType.setTargetType(targetType);
+      TargetType.setTargetType(pTargetType);
     } else {
       // not in the template, revert to default
       TargetType.setTargetTypeDefault();
     }
 
-    if (template.target) {
+    if (pTarget) {
       const targetField = document.getElementById("target");
-      targetField.value = template.target;
+      targetField.value = pTarget;
       TargetType.autoSelectTargetType(targetField.value);
     }
 
-    if (template.command) {
+    if (pCommand) {
       const commandField = document.getElementById("command");
-      commandField.value = template.command;
+      commandField.value = pCommand;
     }
+  }
+
+  static applyTemplateByTemplate (pTemplate) {
+    CommandBox.applyTemplateByProperties(pTemplate.targettype, pTemplate.target, pTemplate.command);
+  }
+
+  static applyTemplateByName (pTemplateName) {
+    const templates = Utils.getStorageItemObject("session", "templates");
+    const template = templates[pTemplateName];
+    if (!template) {
+      return;
+    }
+    CommandBox.applyTemplateByTemplate(template);
   }
 
   static getScreenModifyingCommands () {

--- a/saltgui/static/scripts/Router.js
+++ b/saltgui/static/scripts/Router.js
@@ -66,6 +66,9 @@ export class Router {
     const logo = document.getElementById("logo");
     Utils.addToolTip(logo, "ctrl-click to see\nOptions and Stats", "logo");
 
+    const fab = document.querySelector(".fab");
+    Utils.addToolTip(fab, "Type 'c' to show\nmanual run", "fab");
+
     Router.updateMainMenu();
 
     const hash = window.location.hash.replace(/^#/, "");
@@ -102,10 +105,10 @@ export class Router {
         dropdownContent = Utils.createDiv("dropdown-content", "", "dropdown-content-" + pParentId);
         dropDownDiv.append(dropdownContent);
       }
-      const itemDiv = Utils.createDiv("run-command-button menu-item", pButtonId, "button-" + pButtonId + "1");
+      const itemDiv = Utils.createDiv("run-command-button menu-item menu-item-first-letter", pButtonId, "button-" + pButtonId + "1");
       dropdownContent.append(itemDiv);
     } else {
-      const topItemDiv = Utils.createDiv("menu-item", pButtonId, "button-" + pButtonId + "1");
+      const topItemDiv = Utils.createDiv("menu-item menu-item-first-letter", pButtonId, "button-" + pButtonId + "1");
       dropDownDiv.append(topItemDiv);
     }
 
@@ -113,7 +116,14 @@ export class Router {
 
     const miniMenuDiv = document.querySelector(".minimenu");
     const dropdownContent2 = miniMenuDiv.querySelector(".dropdown-content");
-    const menuItemDiv = Utils.createDiv("run-command-button menu-item", (pParentId ? "-" + Character.NO_BREAK_SPACE : "") + pButtonId, "button-" + pButtonId + "2");
+    let menuItemDiv;
+    if (pParentId) {
+      menuItemDiv = Utils.createDiv("run-command-button menu-item");
+      menuItemDiv.append(Utils.createSpan("", "-" + Character.NO_BREAK_SPACE, ""));
+      menuItemDiv.append(Utils.createSpan("menu-item-first-letter", pButtonId, "button-" + pButtonId + "2"));
+    } else {
+      menuItemDiv = Utils.createDiv("run-command-button menu-item menu-item-first-letter", pButtonId, "button-" + pButtonId + "2");
+    }
     dropdownContent2.append(menuItemDiv);
 
     // activate the menu items as needed

--- a/saltgui/static/scripts/Router.js
+++ b/saltgui/static/scripts/Router.js
@@ -105,24 +105,30 @@ export class Router {
         dropdownContent = Utils.createDiv("dropdown-content", "", "dropdown-content-" + pParentId);
         dropDownDiv.append(dropdownContent);
       }
-      const itemDiv = Utils.createDiv("run-command-button menu-item menu-item-first-letter", pButtonId, "button-" + pButtonId + "1");
+      const itemDiv = Utils.createDiv("run-command-button menu-item", pButtonId, "button-" + pButtonId + "1");
+      if (pKey) {
+        // currently applies to all, but just in case
+        itemDiv.classList.add("menu-item-first-letter");
+      }
       dropdownContent.append(itemDiv);
     } else {
-      const topItemDiv = Utils.createDiv("menu-item menu-item-first-letter", pButtonId, "button-" + pButtonId + "1");
+      const topItemDiv = Utils.createDiv("menu-item", pButtonId, "button-" + pButtonId + "1");
       dropDownDiv.append(topItemDiv);
+      if (pKey) {
+        topItemDiv.classList.add("menu-item-first-letter");
+      }
     }
 
     // mini menu
 
     const miniMenuDiv = document.querySelector(".minimenu");
     const dropdownContent2 = miniMenuDiv.querySelector(".dropdown-content");
-    let menuItemDiv;
+    const menuItemDiv = Utils.createDiv("run-command-button menu-item", pButtonId, "button-" + pButtonId + "2");
     if (pParentId) {
-      menuItemDiv = Utils.createDiv("run-command-button menu-item");
-      menuItemDiv.append(Utils.createSpan("", "-" + Character.NO_BREAK_SPACE, ""));
-      menuItemDiv.append(Utils.createSpan("menu-item-first-letter", pButtonId, "button-" + pButtonId + "2"));
-    } else {
-      menuItemDiv = Utils.createDiv("run-command-button menu-item menu-item-first-letter", pButtonId, "button-" + pButtonId + "2");
+      menuItemDiv.style.paddingLeft = "50px";
+    }
+    if (pKey) {
+      menuItemDiv.classList.add("menu-item-first-letter");
     }
     dropdownContent2.append(menuItemDiv);
 

--- a/saltgui/static/scripts/Router.js
+++ b/saltgui/static/scripts/Router.js
@@ -77,7 +77,13 @@ export class Router {
     /* eslint-enable compat/compat */
   }
 
-  _registerMenuItem (pParentId, pButtonId, pUrl) {
+  _registerMenuItem (pParentId, pButtonId, pUrl, pKey) {
+
+    // shortcut
+
+    if (pKey) {
+      Utils.setStorageItem("session", "menu_" + pKey, pUrl);
+    }
 
     // full menu
 
@@ -177,19 +183,20 @@ export class Router {
       /* eslint-enable compat/compat */
     });
 
-    this._registerMenuItem(null, "minions", "minions");
-    this._registerMenuItem("minions", "grains", "grains");
-    this._registerMenuItem("minions", "schedules", "schedules");
-    this._registerMenuItem("minions", "pillars", "pillars");
-    this._registerMenuItem("minions", "beacons", "beacons");
-    this._registerMenuItem("minions", "nodegroups", "nodegroups");
-    this._registerMenuItem(null, "keys", "keys");
-    this._registerMenuItem(null, "jobs", "jobs");
-    this._registerMenuItem("jobs", "highstate", "highstate");
-    this._registerMenuItem("jobs", "templates", "templates");
-    this._registerMenuItem(null, "events", "events");
-    this._registerMenuItem("events", "reactors", "reactors");
-    this._registerMenuItem(null, "issues", "issues");
+    this._registerMenuItem(null, "minions", "minions", "m");
+    this._registerMenuItem("minions", "grains", "grains", "g");
+    this._registerMenuItem("minions", "schedules", "schedules", "s");
+    this._registerMenuItem("minions", "pillars", "pillars", "p");
+    this._registerMenuItem("minions", "beacons", "beacons", "b");
+    this._registerMenuItem("minions", "nodegroups", "nodegroups", "n");
+    this._registerMenuItem(null, "keys", "keys", "k");
+    this._registerMenuItem(null, "jobs", "jobs", "j");
+    this._registerMenuItem("jobs", "highstate", "highstate", "h");
+    this._registerMenuItem("jobs", "templates", "templates", "t");
+    this._registerMenuItem(null, "events", "events", "e");
+    this._registerMenuItem("events", "reactors", "reactors", "r");
+    this._registerMenuItem(null, "issues", "issues", "i");
+    // no shortcut for logout
     this._registerMenuItem(null, "logout", "logout");
   }
 

--- a/saltgui/static/scripts/Utils.js
+++ b/saltgui/static/scripts/Utils.js
@@ -663,9 +663,13 @@ export class Utils {
     if (pKeyUpEvent.isComposing) {
       return false;
     }
+    if (pKeyUpEvent.target !== document.body) {
+      // not when focus is in a text field
+      return false;
+    }
     if (pKeyUpEvent.key.length > 1) {
       // not a simple key
-      // return false;
+      return false;
     }
     return true;
   }

--- a/saltgui/static/scripts/Utils.js
+++ b/saltgui/static/scripts/Utils.js
@@ -646,4 +646,27 @@ export class Utils {
       ddc.style.display = pHide ? "none" : "";
     }
   }
+
+  static isValidKeyUpEvent (pKeyUpEvent) {
+    if (pKeyUpEvent.altKey) {
+      return false;
+    }
+    if (pKeyUpEvent.ctrlKey) {
+      return false;
+    }
+    if (pKeyUpEvent.metaKey) {
+      return false;
+    }
+    if (pKeyUpEvent.shiftKey) {
+      return false;
+    }
+    if (pKeyUpEvent.isComposing) {
+      return false;
+    }
+    if (pKeyUpEvent.key.length > 1) {
+      // not a simple key
+      // return false;
+    }
+    return true;
+  }
 }

--- a/saltgui/static/scripts/pages/Page.js
+++ b/saltgui/static/scripts/pages/Page.js
@@ -1,6 +1,7 @@
 /* global */
 
 import {CommandBox} from "../CommandBox.js";
+import {Router} from "../Router.js";
 import {Utils} from "../Utils.js";
 
 export class Page {
@@ -33,11 +34,16 @@ export class Page {
 
     const body = document.querySelector("body");
     body.onkeyup = (keyUpEvent) => {
+      if (!Utils.isValidKeyUpEvent(keyUpEvent)) {
+        return;
+      }
+
       if (this._handleTemplateKey(keyUpEvent)) {
         keyUpEvent.stopPropagation();
         return;
       }
-      if (Page._handleMenuKey(keyUpEvent)) {
+
+      if (this._handleMenuKey(keyUpEvent)) {
         keyUpEvent.stopPropagation();
         // return;
       }
@@ -45,15 +51,6 @@ export class Page {
   }
 
   _handleTemplateKey (keyUpEvent) {
-    if (!Utils.isValidKeyUpEvent(keyUpEvent)) {
-      return false;
-    }
-
-    if (keyUpEvent.target !== document.body) {
-      // not when focus is in a text field
-      return false;
-    }
-
     const templateName = Utils.getStorageItem("session", "template_" + keyUpEvent.key, "");
     if (templateName === "") {
       // key not bound to a template
@@ -64,6 +61,23 @@ export class Page {
     CommandBox.applyTemplateByName(templateName);
     CommandBox.showManualRun(this.api);
     return true;
+  }
+
+  _handleMenuKey (keyUpEvent) {
+    if (keyUpEvent.key === "c") {
+      CommandBox.showManualRun(this.api);
+      return true;
+    }
+
+    const pages = Router._getPagesList();
+    const page = Utils.getStorageItem("session", "menu_" + keyUpEvent.key, "");
+    // Arrays.includes() is only available from ES7/2016
+    if (page && (pages.length === 0 || pages.indexOf(page) >= 0)) {
+      this.router.goTo(page);
+      return true;
+    }
+
+    return false;
   }
 
   addPanel (pPanel) {

--- a/saltgui/static/scripts/pages/Page.js
+++ b/saltgui/static/scripts/pages/Page.js
@@ -37,6 +37,10 @@ export class Page {
         keyUpEvent.stopPropagation();
         return;
       }
+      if (Page._handleMenuKey(keyUpEvent)) {
+        keyUpEvent.stopPropagation();
+        // return;
+      }
     };
   }
 

--- a/saltgui/static/scripts/pages/Page.js
+++ b/saltgui/static/scripts/pages/Page.js
@@ -1,5 +1,6 @@
 /* global */
 
+import {CommandBox} from "../CommandBox.js";
 import {Utils} from "../Utils.js";
 
 export class Page {
@@ -29,6 +30,36 @@ export class Page {
 
     this.panels = [];
     this.api = pRouter.api;
+
+    const body = document.querySelector("body");
+    body.onkeyup = (keyUpEvent) => {
+      if (this._handleTemplateKey(keyUpEvent)) {
+        keyUpEvent.stopPropagation();
+        return;
+      }
+    };
+  }
+
+  _handleTemplateKey (keyUpEvent) {
+    if (!Utils.isValidKeyUpEvent(keyUpEvent)) {
+      return false;
+    }
+
+    if (keyUpEvent.target !== document.body) {
+      // not when focus is in a text field
+      return false;
+    }
+
+    const templateName = Utils.getStorageItem("session", "template_" + keyUpEvent.key, "");
+    if (templateName === "") {
+      // key not bound to a template
+      return false;
+    }
+
+    // apply template
+    CommandBox.applyTemplateByName(templateName);
+    CommandBox.showManualRun(this.api);
+    return true;
   }
 
   addPanel (pPanel) {

--- a/saltgui/static/scripts/panels/Login.js
+++ b/saltgui/static/scripts/panels/Login.js
@@ -345,6 +345,13 @@ export class LoginPanel extends Panel {
     const templates = wheelConfigValuesData.saltgui_templates;
     Utils.setStorageItem("session", "templates", JSON.stringify(templates));
 
+    for (const templateName in templates) {
+      const template = templates[templateName];
+      if (template.key !== undefined) {
+        Utils.setStorageItem("session", "template_" + template.key, templateName);
+      }
+    }
+
     const reactors = wheelConfigValuesData.reactor;
     Utils.setStorageItem("session", "reactors", JSON.stringify(reactors));
 

--- a/saltgui/static/scripts/panels/Panel.js
+++ b/saltgui/static/scripts/panels/Panel.js
@@ -176,25 +176,6 @@ export class Panel {
   addTable (pColumnNames, pFieldList = null) {
     const table = Utils.createElem("table", this.key, "", this.key + "-table");
 
-    let anyHiddenColumns = false;
-    if (pColumnNames) {
-      for (const colName of pColumnNames) {
-        if (colName.startsWith("@")) {
-          anyHiddenColumns = true;
-        }
-      }
-    }
-
-    if (anyHiddenColumns) {
-      for (const colName of pColumnNames) {
-        const col = Utils.createElem("col");
-        if (colName.startsWith("@")) {
-          col.style.visibility = "collapse";
-        }
-        table.append(col);
-      }
-    }
-
     if (pColumnNames) {
       const thead = Utils.createElem("thead");
       thead.id = this.key + "-table-thead";
@@ -889,6 +870,44 @@ export class Panel {
     }
     if (!pElem.innerText.startsWith(pIconChar)) {
       pElem.innerText = pIconChar + pElem.innerText;
+    }
+  }
+
+  hideColumn (colTitle) {
+
+    let colNr = -1;
+    // find a column with this name
+    for (let i = 0; i < this.table.tHead.children[0].children.length; i++) {
+      const td = this.table.tHead.children[0].children[i];
+      if (td.innerText === colTitle) {
+        colNr = i;
+        break;
+      }
+    }
+    if (colNr < 0) {
+      // column by that name already gone
+      return;
+    }
+
+    for (const tr of this.table.tBodies[0].children) {
+      const td = tr.children[colNr];
+      if (!td.classList.contains("value-none")) {
+        // column has an interesting value on this row
+        // do not hide the column
+        return;
+      }
+    }
+
+    // all column-values are trivial, remove the column
+    // title
+    for (const tr of this.table.tHead.children) {
+      const td = tr.children[colNr];
+      td.remove();
+    }
+    // data
+    for (const tr of this.table.tBodies[0].children) {
+      const td = tr.children[colNr];
+      td.remove();
     }
   }
 }

--- a/saltgui/static/scripts/panels/Templates.js
+++ b/saltgui/static/scripts/panels/Templates.js
@@ -12,7 +12,7 @@ export class TemplatesPanel extends Panel {
 
     this.addTitle("Templates");
     this.addSearchButton();
-    this.addTable(["Name", "@Category", "Description", "Target", "Command", "-menu-"], "data-list-templates");
+    this.addTable(["Name", "Category", "Description", "Target", "Command", "-menu-"], "data-list-templates");
     this.setTableSortable("Name", "asc");
     this.setTableClickable();
     this.addMsg();
@@ -25,6 +25,7 @@ export class TemplatesPanel extends Panel {
 
     wheelConfigValuesPromise.then((pWheelConfigValuesData) => {
       this._handleTemplatesWheelConfigValues(pWheelConfigValuesData);
+      this.hideColumn("Category");
       return true;
     }, (pWheelConfigValuesMsg) => {
       this._handleTemplatesWheelConfigValues(JSON.stringify(pWheelConfigValuesMsg));
@@ -43,8 +44,6 @@ export class TemplatesPanel extends Panel {
 
     if (templates) {
       Utils.setStorageItem("session", "templates", JSON.stringify(templates));
-      this.setCategoriesTitle(templates);
-      this.showCategoriesColumn(templates);
       TemplatesPanel.getTemplatesCategories(templates);
       Router.updateMainMenu();
     } else {
@@ -63,33 +62,6 @@ export class TemplatesPanel extends Panel {
     const txt = Utils.txtZeroOneMany(this.nrTemplates,
       "No templates", "{0} template", "{0} templates");
     this.setMsg(txt);
-  }
-
-  setCategoriesTitle (templates) {
-    const categoryTh = this.table.querySelectorAll("th")[1];
-    const keys = Object.keys(templates);
-    for (const key of keys) {
-      const template = templates[key];
-      const categories = TemplatesPanel.getTemplateCategories(template);
-      if (categories.length > 1) {
-        categoryTh.innerText = "Categories";
-      }
-    }
-  }
-
-  showCategoriesColumn (templates) {
-    const keys = Object.keys(templates);
-    for (const key of keys) {
-      const template = templates[key];
-      const categories = TemplatesPanel.getTemplateCategories(template);
-      if (categories.length > 1 || categories.length > 0 && categories[0] !== undefined) {
-        const categoryColumn = this.table.querySelectorAll("col")[1];
-        // show the categories column only when a category was filled in somewhere
-        // and it is not the only category
-        categoryColumn.removeAttribute("style");
-        return;
-      }
-    }
   }
 
   static getTemplateCategories (template) {

--- a/saltgui/static/scripts/panels/Templates.js
+++ b/saltgui/static/scripts/panels/Templates.js
@@ -12,7 +12,7 @@ export class TemplatesPanel extends Panel {
 
     this.addTitle("Templates");
     this.addSearchButton();
-    this.addTable(["Name", "Category", "Description", "Target", "Command", "-menu-"], "data-list-templates");
+    this.addTable(["Name", "Category", "Key", "Description", "Target", "Command", "-menu-"], "data-list-templates");
     this.setTableSortable("Name", "asc");
     this.setTableClickable();
     this.addMsg();
@@ -26,6 +26,7 @@ export class TemplatesPanel extends Panel {
     wheelConfigValuesPromise.then((pWheelConfigValuesData) => {
       this._handleTemplatesWheelConfigValues(pWheelConfigValuesData);
       this.hideColumn("Category");
+      this.hideColumn("Key");
       return true;
     }, (pWheelConfigValuesMsg) => {
       this._handleTemplatesWheelConfigValues(JSON.stringify(pWheelConfigValuesMsg));
@@ -123,6 +124,14 @@ export class TemplatesPanel extends Panel {
       categoryTd.className = "value-none";
     }
     tr.appendChild(categoryTd);
+
+    // calculate key
+    const key = template["key"];
+    if (key) {
+      tr.appendChild(Utils.createTd("", key));
+    } else {
+      tr.appendChild(Utils.createTd("value-none", "(none)"));
+    }
 
     // calculate description
     const description = template["description"];

--- a/saltgui/static/stylesheets/main.css
+++ b/saltgui/static/stylesheets/main.css
@@ -99,14 +99,10 @@ h1 {
 }
 
 .fab {
-  display: block;
+  display: inline-block;
   float: right;
   margin-top: 8px;
   margin-right: 8px;
-}
-
-.fab:hover circle {
-  fill: gray;
 }
 
 #button-manual-run {
@@ -189,6 +185,17 @@ h1 {
   background: rgba(0, 0, 0, 15%);
   color: #4caf50;
   cursor: pointer;
+}
+
+.menu-item-first-letter#button-logout1:hover::first-letter,
+.menu-item-first-letter#button-logout2:hover::first-letter,
+.menu-item-first-letter#minimenu-top:hover::first-letter {
+  text-decoration: none;
+}
+
+.menu-item-first-letter:hover::first-letter {
+  text-decoration: underline #4caf50 double;
+  text-decoration-skip-ink: none;
 }
 
 @media (width >= 950px) {

--- a/saltgui/static/stylesheets/tooltip.css
+++ b/saltgui/static/stylesheets/tooltip.css
@@ -50,6 +50,11 @@
   transform: translate(-95%, 0);
 }
 
+.tooltip > .tooltip-text-fab {
+  text-align: right;
+  transform: translate(-138px, 52px);
+}
+
 .tooltip:hover {
   /* only slightly darker than 'whitesmoke(#f5f5f5)' */
   background-color: #e0e0e0;
@@ -88,6 +93,11 @@ pre.output .tooltip:hover {
 }
 
 .tooltip > .tooltip-text-logo::after {
+  /* hide the tooltip pointer */
+  display: none;
+}
+
+.tooltip > .tooltip-text-fab::after {
   /* hide the tooltip pointer */
   display: none;
 }


### PR DESCRIPTION
In addition to clicking to [X] on the Manual Run modal window, it would be great to have the same effect by pressing the ESC key. Also, on the main page, some keyboard shortcuts could make tasks easier. For example:

- "r" for opening the Manual Run modal
- "m" for minions
- ...and so on.
- "t" for templates. on this page, "1", "2", "3" etc. could apply the relevant template