### PR TITLE
use cache.grains function to display inventory data

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@ such as `yubico_client`, or execution modules such as `boto3_sns`.
 - Match status of minions against reference list
 - Keyboard control for top-level navigation
 - Keyboard control to apply templates
+- Choose between live info and cached info for grains/pillar
 
 
 ## Quick start using PAM as authentication method
@@ -276,6 +277,10 @@ saltgui_ipnumber_prefix:
 ```
 The display of the IP-numbers can simply be disabled by choosing a non-existing grain or by choosing a non-existing prefix.
 
+SaltGUI will retrieve cached grains information when variable `saltgui_use_cache_for_grains` is set to `true`.
+In that case, unreachable minions will appear without warnings for that.
+In all cases, the information may be less accurate.
+
 ## Pillars
 Pillars potentially contain security senstitive information.
 Therefore their values are initially hidden.
@@ -289,6 +294,10 @@ e.g.:
 saltgui_public_pillars:
     - pub_.*
 ```
+
+SaltGUI will retrieve cached pillar information when variable `saltgui_use_cache_for_pillar` is set to `true`.
+In that case, unreachable minions will appear without warnings for that.
+In all cases, the information may be less accurate.
 
 ## Nodegroups
 The Nodegroups page shows all minions, but groups the minions by their nodegroup.

--- a/docs/README.md
+++ b/docs/README.md
@@ -280,6 +280,7 @@ The display of the IP-numbers can simply be disabled by choosing a non-existing 
 SaltGUI will retrieve cached grains information when variable `saltgui_use_cache_for_grains` is set to `true`.
 In that case, unreachable minions will appear without warnings for that.
 In all cases, the information may be less accurate.
+A warning for offline minions is only shown on the Minions panel.
 
 ## Pillars
 Pillars potentially contain security senstitive information.
@@ -298,6 +299,7 @@ saltgui_public_pillars:
 SaltGUI will retrieve cached pillar information when variable `saltgui_use_cache_for_pillar` is set to `true`.
 In that case, unreachable minions will appear without warnings for that.
 In all cases, the information may be less accurate.
+A warning for offline minions is only shown on the Minions panel.
 
 ## Nodegroups
 The Nodegroups page shows all minions, but groups the minions by their nodegroup.

--- a/saltgui/static/scripts/Api.js
+++ b/saltgui/static/scripts/Api.js
@@ -200,6 +200,24 @@ export class API {
     return this.apiRequest("POST", "/", params);
   }
 
+  getRunnerCacheGrains (pTgt) {
+    const params = {
+      "client": "runner",
+      "fun": "cache.grains",
+      "tgt": pTgt || "*"
+    };
+    return this.apiRequest("POST", "/", params);
+  }
+
+  getRunnerCachePillar (pTgt) {
+    const params = {
+      "client": "runner",
+      "fun": "cache.pillar",
+      "tgt": pTgt || "*"
+    };
+    return this.apiRequest("POST", "/", params);
+  }
+
   getRunnerJobsActive () {
     const params = {
       "client": "runner",

--- a/saltgui/static/scripts/panels/Grains.js
+++ b/saltgui/static/scripts/panels/Grains.js
@@ -17,6 +17,7 @@ export class GrainsPanel extends Panel {
       "columns by configuring their name in the server-side configuration file.",
       "See README.md for more details."
     ]);
+    this.addWarningField();
     this.addTable(["Minion", "Status", "Salt version", "OS version", "Grains", "-menu-"]);
     this.setTableClickable();
 
@@ -45,8 +46,11 @@ export class GrainsPanel extends Panel {
     // initialize sorting after all columns are present
     this.setTableSortable("Minion", "asc");
 
+    const useCacheGrains = Utils.getStorageItemBoolean("session", "use_cache_for_grains", false);
+    this.setWarningText("info", useCacheGrains ? "the content of this screen is based on cached grains info, minion status or grain info may not be accurate" : "");
+
     const wheelKeyListAllPromise = this.api.getWheelKeyListAll();
-    const localGrainsItemsPromise = this.api.getLocalGrainsItems(null);
+    const localGrainsItemsPromise = useCacheGrains ? this.api.getRunnerCacheGrains(null) : this.api.getLocalGrainsItems(null);
 
     this.nrMinions = 0;
 

--- a/saltgui/static/scripts/panels/GrainsMinion.js
+++ b/saltgui/static/scripts/panels/GrainsMinion.js
@@ -18,6 +18,7 @@ export class GrainsMinionPanel extends Panel {
 
     this.addSearchButton();
     this.addCloseButton();
+    this.addWarningField();
     this.addTable(["Name", "-menu-", "Value"]);
     this.setTableSortable("Name", "asc");
     this.setTableClickable();
@@ -29,7 +30,10 @@ export class GrainsMinionPanel extends Panel {
 
     this.updateTitle("Grains on " + minionId);
 
-    const localGrainsItemsPromise = this.api.getLocalGrainsItems(minionId);
+    const useCacheGrains = Utils.getStorageItemBoolean("session", "use_cache_for_grains", false);
+    this.setWarningText("info", useCacheGrains ? "the content of this screen is based on cached grains info, minion status or grain info may not be accurate" : "");
+
+    const localGrainsItemsPromise = useCacheGrains ? this.api.getRunnerCacheGrains(minionId) : this.api.getLocalGrainsItems(minionId);
 
     localGrainsItemsPromise.then((pLocalGrainsItemsData) => {
       this._handleLocalGrainsItems(pLocalGrainsItemsData, minionId);

--- a/saltgui/static/scripts/panels/Jobs.js
+++ b/saltgui/static/scripts/panels/Jobs.js
@@ -167,6 +167,8 @@ export class JobsPanel extends Panel {
     this._hideJobs.push("schedule.run_job");
     this._hideJobs.push("sys.doc");
     // runner jobs
+    this._hideJobs.push("runner.cache.grains");
+    this._hideJobs.push("runner.cache.pillar");
     this._hideJobs.push("runner.doc.runner");
     this._hideJobs.push("runner.doc.wheel");
     this._hideJobs.push("runner.jobs.active");

--- a/saltgui/static/scripts/panels/Login.js
+++ b/saltgui/static/scripts/panels/Login.js
@@ -381,6 +381,12 @@ export class LoginPanel extends Panel {
     const hideJobs = wheelConfigValuesData.saltgui_hide_jobs;
     Utils.setStorageItem("session", "hide_jobs", JSON.stringify(hideJobs));
 
+    const useCacheForGrains = wheelConfigValuesData.saltgui_use_cache_for_grains;
+    Utils.setStorageItem("session", "use_cache_for_grains", JSON.stringify(useCacheForGrains));
+
+    const useCacheForPillar = wheelConfigValuesData.saltgui_use_cache_for_pillar;
+    Utils.setStorageItem("session", "use_cache_for_pillar", JSON.stringify(useCacheForPillar));
+
     const syndicMaster = wheelConfigValuesData.syndic_master;
     Utils.setStorageItem("session", "syndic_master", syndicMaster);
 

--- a/saltgui/static/scripts/panels/Minions.js
+++ b/saltgui/static/scripts/panels/Minions.js
@@ -22,6 +22,7 @@ export class MinionsPanel extends Panel {
     this._addMenuItemStateApply(this.panelMenu, "*");
     this._addMenuItemStateApplyTest(this.panelMenu, "*");
     this.addSearchButton();
+    this.addWarningField();
     this.addTable(["Minion", "Status", "Salt version", "OS version", "-menu-"]);
     this.setTableSortable("Minion", "asc");
     this.setTableClickable();
@@ -31,9 +32,13 @@ export class MinionsPanel extends Panel {
   onShow () {
     this.nrMinions = 0;
 
+    const useCacheGrains = Utils.getStorageItemBoolean("session", "use_cache_for_grains", false);
+    this.setWarningText("info", useCacheGrains ? "the content of this screen is based on cached grains info, minion status or grain info may not be accurate" : "");
+
     const wheelKeyListAllPromise = this.api.getWheelKeyListAll();
     const wheelMinionsConnectedPromise = this.api.getWheelMinionsConnected();
-    const localGrainsItemsPromise = this.api.getLocalGrainsItems(null);
+    const localGrainsItemsPromise = useCacheGrains ? this.api.getRunnerCacheGrains(null) : this.api.getLocalGrainsItems(null);
+
     const runnerManageVersionsPromise = this.api.getRunnerManageVersions();
 
     this.loadMinionsTxt();

--- a/saltgui/static/scripts/panels/Minions.js
+++ b/saltgui/static/scripts/panels/Minions.js
@@ -157,7 +157,9 @@ export class MinionsPanel extends Panel {
     const minionIds = pWheelMinionsConnectedData.return[0].data.return;
 
     for (const tr of this.table.tBodies[0].childNodes) {
-      if (minionIds.indexOf(tr.dataset.minionId) >= 0) {
+      tr.dataset.isConnected = minionIds.indexOf(tr.dataset.minionId) >= 0;
+
+      if (tr.dataset.isConnected) {
         // skip the connected minions
         continue;
       }

--- a/saltgui/static/scripts/panels/Nodegroups.js
+++ b/saltgui/static/scripts/panels/Nodegroups.js
@@ -16,6 +16,7 @@ export class NodegroupsPanel extends Panel {
     this._addMenuItemStateApplyTestMinion(this.panelMenu, "*");
     this.addSearchButton();
     this.addPlayPauseButton();
+    this.addWarningField();
     this.addTable(["Minion", "Status", "Salt version", "OS version", "-menu-"]);
     this.setTableClickable();
     this.addMsg();
@@ -24,8 +25,11 @@ export class NodegroupsPanel extends Panel {
   onShow () {
     this.nrMinions = 0;
 
+    const useCacheGrains = Utils.getStorageItemBoolean("session", "use_cache_for_grains", false);
+    this.setWarningText("info", useCacheGrains ? "the content of this screen is based on cached grains info, minion status or grain info may not be accurate" : "");
+
     const wheelKeyListAllPromise = this.api.getWheelKeyListAll();
-    const localGrainsItemsPromise = this.api.getLocalGrainsItems(null);
+    const localGrainsItemsPromise = useCacheGrains ? this.api.getRunnerCacheGrains(null) : this.api.getLocalGrainsItems(null);
 
     this.loadMinionsTxt();
 

--- a/saltgui/static/scripts/panels/Options.js
+++ b/saltgui/static/scripts/panels/Options.js
@@ -88,6 +88,14 @@ export class OptionsPanel extends Panel {
       ],
       ["preview-grains", "saltgui", "(none)"],
       ["public-pillars", "saltgui", "(none)"],
+      [
+        "use-cache-for-grains", "saltgui", "false",
+        [["grains", "true", "false"]]
+      ],
+      [
+        "use-cache-for-pillar", "saltgui", "false",
+        [["pillar", "true", "false"]]
+      ],
       ["templates", "saltgui", "(none)"],
       [
         "tooltip-mode", "saltgui", "full",
@@ -178,6 +186,14 @@ export class OptionsPanel extends Panel {
           } else if (pName === "full-return") {
             radio.addEventListener("change", () => {
               this._newFullReturn();
+            });
+          } else if (pName === "use-cache-for-grains") {
+            radio.addEventListener("change", () => {
+              this._newUseCacheForGrains();
+            });
+          } else if (pName === "use-cache-for-pillar") {
+            radio.addEventListener("change", () => {
+              this._newUseCacheForPillar();
             });
           }
 
@@ -458,6 +474,30 @@ export class OptionsPanel extends Panel {
     // refresh the right-hand panel based on the new option value
     Router.currentPage.stats.clearTable();
     Router.currentPage.stats.onShow();
+  }
+
+  _newUseCacheForGrains () {
+    let value = "";
+    /* eslint-disable curly */
+    if (this._isSelected("use-cache-for-grains", "grains", "false")) value = "false";
+    if (this._isSelected("use-cache-for-grains", "grains", "true")) value = "true";
+    value = value.replace(/^,/, "");
+    /* eslint-enable curly */
+    const useCacheForGrainsTd = this.div.querySelector("#option-use-cache-for-grains-value");
+    useCacheForGrainsTd.innerText = value || "(none)";
+    Utils.setStorageItem("session", "use_cache_for_grains", value);
+  }
+
+  _newUseCacheForPillar () {
+    let value = "";
+    /* eslint-disable curly */
+    if (this._isSelected("use-cache-for-pillar", "pillar", "false")) value = "false";
+    if (this._isSelected("use-cache-for-pillar", "pillar", "true")) value = "true";
+    value = value.replace(/^,/, "");
+    /* eslint-enable curly */
+    const useCacheForPillarTd = this.div.querySelector("#option-use-cache-for-pillar-value");
+    useCacheForPillarTd.innerText = value || "(none)";
+    Utils.setStorageItem("session", "use_cache_for_pillar", value);
   }
 
   _newDatetimeFractionDigits () {

--- a/saltgui/static/scripts/panels/Panel.js
+++ b/saltgui/static/scripts/panels/Panel.js
@@ -153,6 +153,9 @@ export class Panel {
   }
 
   setWarningText (pIcon = "", pTxt = "") {
+    if (!pTxt) {
+      pIcon = "";
+    }
     let newTxt;
     switch (pIcon) {
     case "info":
@@ -670,6 +673,7 @@ export class Panel {
       const minionInfo = minions[minionId];
 
       // minions can be offline, then the info will be false
+      // for grains/pillar we may receive data anyway when using cached data
       if (minionInfo === false) {
         this.updateOfflineMinion(minionId, minionsDict);
         this.nrOffline += 1;

--- a/saltgui/static/scripts/panels/Panel.js
+++ b/saltgui/static/scripts/panels/Panel.js
@@ -569,7 +569,10 @@ export class Panel {
 
     const minionTr = this.getElement(Utils.getIdFromMinionId(pMinionId));
 
-    minionTr.appendChild(Utils.createTd("minion-id", pMinionId));
+    const minionSpan = Utils.createSpan("minion-id", pMinionId);
+    const minionTd = Utils.createTd();
+    minionTd.append(minionSpan);
+    minionTr.appendChild(minionTd);
 
     // which grain to use for IP-number display
     // typical choices are "fqdn_ip4", "ipv4", "fqdn_ip6" or "ipv6"
@@ -609,6 +612,14 @@ export class Panel {
     } else {
       const accepted = Utils.createTd(["status", "accepted"], "accepted");
       minionTr.appendChild(accepted);
+    }
+
+    if (minionTr.dataset.isConnected === "false") {
+      Panel.addPrefixIcon(minionSpan, Character.WARNING_SIGN);
+      Utils.addToolTip(
+        minionSpan,
+        "This minion is currently not connected",
+        "bottom-left");
     }
 
     minionTr.dataset.minionId = pMinionId;

--- a/saltgui/static/scripts/panels/Pillars.js
+++ b/saltgui/static/scripts/panels/Pillars.js
@@ -11,6 +11,7 @@ export class PillarsPanel extends Panel {
 
     this.addTitle("Pillars");
     this.addSearchButton();
+    this.addWarningField();
     this.addTable(["Minion", "Status", "Pillars", "-menu-"]);
     this.setTableSortable("Minion", "asc");
     this.setTableClickable();
@@ -18,8 +19,11 @@ export class PillarsPanel extends Panel {
   }
 
   onShow () {
+    const useCachePillar = Utils.getStorageItemBoolean("session", "use_cache_for_pillar", false);
+    this.setWarningText("info", useCachePillar ? "the content of this screen is based on cached grains info, minion status or pillar info may not be accurate" : "");
+
     const wheelKeyListAllPromise = this.api.getWheelKeyListAll();
-    const localPillarObfuscatePromise = this.api.getLocalPillarObfuscate(null);
+    const localPillarObfuscatePromise = useCachePillar ? this.api.getRunnerCachePillar(null) : this.api.getLocalPillarObfuscate(null);
 
     this.nrMinions = 0;
 

--- a/saltgui/static/scripts/panels/PillarsMinion.js
+++ b/saltgui/static/scripts/panels/PillarsMinion.js
@@ -21,6 +21,7 @@ export class PillarsMinionPanel extends Panel {
       "automatically by configuring their name in the server-side configuration file.",
       "See README.md for more details."
     ]);
+    this.addWarningField();
     this.addTable(["Name", "Value"]);
     this.setTableSortable("Name", "asc");
     this.addMsg();
@@ -31,7 +32,10 @@ export class PillarsMinionPanel extends Panel {
 
     this.updateTitle("Pillars on " + minionId);
 
-    const localPillarItemsPromise = this.api.getLocalPillarItems(minionId);
+    const useCachePillar = Utils.getStorageItemBoolean("session", "use_cache_for_pillar", false);
+    this.setWarningText("info", useCachePillar ? "the content of this screen is based on cached grains info, minion status or pillar info may not be accurate" : "");
+
+    const localPillarItemsPromise = useCachePillar ? this.api.getRunnerCachePillar(minionId) : this.api.getLocalPillarItems(minionId);
 
     localPillarItemsPromise.then((pLocalPillarItemsData) => {
       this._handleLocalPillarItems(pLocalPillarItemsData, minionId);


### PR DESCRIPTION
Hi,

When doing some research on why i never get cached minion data on SaltGUI i discovered https://github.com/erwindon/SaltGUI/issues/538 which mentions there is a need for a database, however i found another possible solution:

Instead of using a Backend-Database to display some inventory/stored grains data of minions it should be possible to use the cache.grains function as documented in https://docs.saltproject.io/en/latest/topics/cache/index.html it looks like this cache also supports multiple backends/modules, see https://docs.saltproject.io/en/latest/ref/cache/all/index.html#all-salt-cache for a list so the database question is also answered.

It looks like implementing this could be really easy, actually a config-file option which exchanges the "normal grains command" with the "cached grains command" should do the job perfectly. After that only the documentation of salt for cached grains has to be followed.

If somebody wants to implement, just ensure to not hit https://github.com/saltstack/salt/issues/48694

As we are just starting with salt, i would be willing to test.

Kind regards

Mike