### PR TITLE
redesign highstate and job results pages

### DIFF
--- a/saltgui/static/scripts/Character.js
+++ b/saltgui/static/scripts/Character.js
@@ -26,6 +26,7 @@ export class Character {
     Character.BLACK_RIGHT_POINTING_POINTER = "\u25BA";
     Character.WHITE_DOWN_POINTING_TRIANGLE = "\u25BD";
     Character.BLACK_CIRCLE = "\u25CF";
+    Character.BLACK_CIRCLE_WITH_OUTLINE = "\u25C9";
     Character.GEAR = "\u2699";
     Character.WARNING_SIGN = "\u26A0" + Character._VARIATION_SELECTOR_16;
     Character.HEAVY_CHECK_MARK = "\u2714";

--- a/saltgui/static/scripts/CommandBox.js
+++ b/saltgui/static/scripts/CommandBox.js
@@ -706,7 +706,7 @@ export class CommandBox {
     }
 
     const span = div.children[eventSeqNr + 2];
-    Output._setTaskToolTip(span, task);
+    Output._setTaskToolTip(span, task, "taskcircle");
   }
 
   static _prepareForAsyncResults (pResponse) {

--- a/saltgui/static/scripts/output/Output.js
+++ b/saltgui/static/scripts/output/Output.js
@@ -336,7 +336,7 @@ export class Output {
     return false;
   }
 
-  static _setTaskToolTip (pSpan, pTask) {
+  static _setTaskToolTip (pSpan, pTask, className) {
 
     if (typeof pTask !== "object") {
       return;
@@ -384,7 +384,7 @@ export class Output {
       txt += "\nhidden";
     }
 
-    pSpan.className = "taskcircle";
+    pSpan.className = className;
     if (pTask.result === null) {
       pSpan.classList.add("task-skipped");
     } else if (pTask.result) {
@@ -445,7 +445,7 @@ export class Output {
 
       const span = Utils.createSpan("", Character.BLACK_CIRCLE);
 
-      Output._setTaskToolTip(span, task);
+      Output._setTaskToolTip(span, task, "taskcircle");
 
       const myNr = nr;
       span.addEventListener("click", (pClickEvent) => {

--- a/saltgui/static/scripts/panels/HighState.js
+++ b/saltgui/static/scripts/panels/HighState.js
@@ -433,11 +433,10 @@ export class HighStatePanel extends Panel {
         // we may use it for presentation (keys.length <= MAX_HIGHSTATE_STATES); or
         // for information (keys.length > MAX_HIGHSTATE_STATES)
 
-        const span = Utils.createSpan("task", Character.BLACK_CIRCLE);
-        span.style.backgroundColor = "black";
+        const span = Utils.createSpan("task", Character.BLACK_CIRCLE_WITH_OUTLINE);
 
         // this also sets the span's class(es)
-        Output._setTaskToolTip(span, data);
+        Output._setTaskToolTip(span, data, "taskcirclehighstate");
 
         // add class here again, because it gets lost in _setTaskToolTip
         span.classList.add("task");
@@ -500,9 +499,8 @@ export class HighStatePanel extends Panel {
           sep = " ";
 
           // remove the priority indicator from the key
-          const itemSpan = Utils.createSpan(["tasksummary", "taskcircle"], Character.BLACK_CIRCLE);
+          const itemSpan = Utils.createSpan(["tasksummary", "taskcirclehighstate"], Character.BLACK_CIRCLE_WITH_OUTLINE);
           itemSpan.classList.add(...statKey.substring(2).split(" "));
-          itemSpan.style.backgroundColor = "black";
           summarySpan.append(itemSpan);
         }
 

--- a/saltgui/static/stylesheets/page.css
+++ b/saltgui/static/stylesheets/page.css
@@ -113,8 +113,6 @@ pre .task-success {
 
 td .task-changes {
   color: aqua;
-  text-decoration-line: overline underline;
-  text-decoration-style: double;
 }
 
 pre .task-changes {
@@ -124,11 +122,6 @@ pre .task-changes {
 .task-summary {
   word-break: break-all;
   line-height: 2em;
-}
-
-pre .task-summary .task-changes {
-  text-decoration-line: overline underline;
-  text-decoration-style: double;
 }
 
 pre span.active {
@@ -322,15 +315,36 @@ table tr td:last-of-type {
 
 .taskcircle.task-failure {
   color: red;
+  text-decoration-line: underline;
+  text-decoration-style: double;
 }
 
 .taskcircle.task-skipped {
   color: yellow;
+  text-decoration-line: underline;
+  text-decoration-style: double;
 }
 
 .taskcircle.task-changes {
-  text-decoration-line: overline underline;
+  color: aqua;
+  text-decoration-line: underline;
   text-decoration-style: double;
+}
+
+.taskcirclehighstate.task-success {
+  color: lime;
+}
+
+.taskcirclehighstate.task-failure {
+  color: red;
+}
+
+.taskcirclehighstate.task-skipped {
+  color: yellow;
+}
+
+.taskcirclehighstate.task-changes {
+  color: aqua;
 }
 
 @media print {


### PR DESCRIPTION
Change state colours and unicode symbol for highstate.
after:
highstate <img width="156" alt="image" src="https://github.com/erwindon/SaltGUI/assets/20047243/66f5c43d-26e9-4729-b953-46bbc9242550">
job results <img width="274" alt="image" src="https://github.com/erwindon/SaltGUI/assets/20047243/5534eb6b-c28e-4c80-a6c2-6dc58992d346">

