### PR TITLE
add "saltgui_max_show_highstates" and "saltgui_max_highstate_states" in config options

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -310,7 +310,9 @@ Even the minion names that are in the nodegroup, but which do not actually exist
 
 ## Highstate
 The Highstate page provides an overview of the minions and their latest state information.
-At most 10 highstate jobs (`state.apply` or `state.highstate`) are considered.
+At most `saltgui_max_show_highstates` (10 if not set) highstate jobs (`state.apply` or `state.highstate`) are considered.
+
+More than `saltgui_max_highstate_states` (20 if not set) of states switches to summary from detailed view.
 
 Individual low-states can be re-tried by clicking on their state symbol.
 Note that since the output of the `state.sls_id` commands is not considered in this overview,

--- a/saltgui/static/scripts/panels/HighState.js
+++ b/saltgui/static/scripts/panels/HighState.js
@@ -9,16 +9,16 @@ import {Panel} from "./Panel.js";
 import {TargetType} from "../TargetType.js";
 import {Utils} from "../Utils.js";
 
-// only consider this number of latest highstate jobs
-const MAX_HIGHSTATE_JOBS = 10;
-
-// more than this number of states switches to summary
-const MAX_HIGHSTATE_STATES = 20;
 
 export class HighStatePanel extends Panel {
 
   constructor () {
     super("highstate");
+
+    // only consider this number of latest highstate jobs
+    this._maxShowHighstates = Utils.getStorageItem("session", "max_show_highstates", 10);
+    // more than this number of states switches to summary
+    this._maxHighstateStates = Utils.getStorageItem("session", "max_highstate_states", 20);
 
     this.addTitle("HighState");
     this.addPanelMenu();
@@ -31,8 +31,8 @@ export class HighStatePanel extends Panel {
     this.addPlayPauseButton();
     this.addHelpButton([
       "This panel shows the latest state.highstate or state.apply job for each minion.",
-      "Only the latest " + MAX_HIGHSTATE_JOBS + " jobs are verified.",
-      "With more than " + MAX_HIGHSTATE_STATES + " states, a summary is shown instead.",
+      "Only the latest " + this._maxShowHighstates + " jobs are verified.",
+      "With more than " + this._maxHighstateStates + " states, a summary is shown instead.",
       "Click on an individual state to re-apply only that state."
     ]);
     this.addWarningField();
@@ -177,8 +177,8 @@ export class HighStatePanel extends Panel {
     let jobs = JobsPanel._jobsToArray(pData.return[0]);
     JobsPanel._sortJobs(jobs);
 
-    if (jobs.length > MAX_HIGHSTATE_JOBS) {
-      jobs = jobs.slice(0, MAX_HIGHSTATE_JOBS);
+    if (jobs.length > this._maxShowHighstates) {
+      jobs = jobs.slice(0, this._maxShowHighstates);
     }
 
     this.jobs = jobs;
@@ -268,10 +268,10 @@ export class HighStatePanel extends Panel {
       super.setWarningText("info", "no jobs were found");
     } else if (this.jobsCnt === 1) {
       super.setWarningText("info", "only 1 job was found and some minions did not have results in that job");
-    } else if (this.jobsCnt < MAX_HIGHSTATE_JOBS) {
+    } else if (this.jobsCnt < this._maxShowHighstates) {
       super.setWarningText("info", "only " + this.jobsCnt + " jobs were found and some minions did not have results in any of these jobs");
     } else {
-      super.setWarningText("info", "the latest " + MAX_HIGHSTATE_JOBS + " jobs were inspected and some minions did not have results in any of these jobs");
+      super.setWarningText("info", "the latest " + this._maxShowHighstates + " jobs were inspected and some minions did not have results in any of these jobs");
     }
   }
 
@@ -430,8 +430,8 @@ export class HighStatePanel extends Panel {
         data.___key___ = key;
 
         // always create the span for the state
-        // we may use it for presentation (keys.length <= MAX_HIGHSTATE_STATES); or
-        // for information (keys.length > MAX_HIGHSTATE_STATES)
+        // we may use it for presentation (keys.length <= this._maxHighstateStates); or
+        // for information (keys.length > this._maxHighstateStates)
 
         const span = Utils.createSpan("task", Character.BLACK_CIRCLE);
         span.style.backgroundColor = "black";
@@ -442,7 +442,7 @@ export class HighStatePanel extends Panel {
         // add class here again, because it gets lost in _setTaskToolTip
         span.classList.add("task");
 
-        if (keys.length > MAX_HIGHSTATE_STATES) {
+        if (keys.length > this._maxHighstateStates) {
           let statKey = "";
           let prio = 0;
 

--- a/saltgui/static/scripts/panels/Login.js
+++ b/saltgui/static/scripts/panels/Login.js
@@ -371,6 +371,12 @@ export class LoginPanel extends Panel {
     const ipNumberPrefix = wheelConfigValuesData.saltgui_ipnumber_prefix;
     Utils.setStorageItem("session", "ipnumber_prefix", JSON.stringify(ipNumberPrefix));
 
+    const maxShowHighstates = wheelConfigValuesData.saltgui_max_show_highstates;
+    Utils.setStorageItem("session", "max_show_highstates", JSON.stringify(maxShowHighstates));
+
+    const maxHighstateStates = wheelConfigValuesData.saltgui_max_highstate_states;
+    Utils.setStorageItem("session", "max_highstate_states", JSON.stringify(maxHighstateStates));
+
     const showSaltEnvs = wheelConfigValuesData.saltgui_show_saltenvs;
     Utils.setStorageItem("session", "show_saltenvs", JSON.stringify(showSaltEnvs));
     const hideSaltEnvs = wheelConfigValuesData.saltgui_hide_saltenvs;

--- a/saltgui/static/scripts/panels/Options.js
+++ b/saltgui/static/scripts/panels/Options.js
@@ -72,6 +72,9 @@ export class OptionsPanel extends Panel {
       ["ipnumber_field", "saltgui", "fqdn_ip4"],
       ["ipnumber_prefix", "saltgui", "(none)"],
 
+      ["max-show-highstates", "saltgui", "10"],
+      ["max-highstate-states", "saltgui", "20"],
+
       /* note that this is not in the alphabetic order */
       ["show-saltenvs", "saltgui", "(all)"],
       ["hide-saltenvs", "saltgui", "(none)"],


### PR DESCRIPTION
With a large number of salt minions, it is not enough to display only the last 10 highstates. I suggest leaving the default value 10 but adding the ability to change it through the config. I would also like to be able to customize the number of states for detailed display (default is 20)