### PR TITLE
change color for changed tasks (before not different from not-changed)

### DIFF
--- a/saltgui/static/scripts/Character.js
+++ b/saltgui/static/scripts/Character.js
@@ -31,7 +31,6 @@ export class Character {
     Character.WARNING_SIGN = "\u26A0" + Character._VARIATION_SELECTOR_16;
     Character.HEAVY_CHECK_MARK = "\u2714";
     Character.HEAVY_MULTIPLICATION_X = "\u2716" + Character._VARIATION_SELECTOR_15;
-    Character.HEAVY_BALLOT_X = "\u2718";
     Character.BLACK_QUESTION_MARK_ORNAMENT = "\u2753" + Character._VARIATION_SELECTOR_15;
     Character._BLACK_MEDIUM_RIGHT_POINTING_TRIANGLE = "\u2BC8";
 

--- a/saltgui/static/scripts/Character.js
+++ b/saltgui/static/scripts/Character.js
@@ -25,7 +25,7 @@ export class Character {
     Character.WHITE_RIGHT_POINTING_TRIANGLE = "\u25B7";
     Character.BLACK_RIGHT_POINTING_POINTER = "\u25BA";
     Character.WHITE_DOWN_POINTING_TRIANGLE = "\u25BD";
-    Character.BLACK_CIRCLE_WITH_OUTLINE = "\u25C9";
+    Character.BLACK_DIAMOND = "\u25C6";
     Character.BLACK_CIRCLE = "\u25CF";
     Character.GEAR = "\u2699";
     Character.WARNING_SIGN = "\u26A0" + Character._VARIATION_SELECTOR_16;

--- a/saltgui/static/scripts/output/Output.js
+++ b/saltgui/static/scripts/output/Output.js
@@ -336,6 +336,83 @@ export class Output {
     return false;
   }
 
+  static _getTaskNrChanges (pTask) {
+    if (!pTask.changes) {
+      return 0;
+    }
+    if (typeof pTask.changes !== "object") {
+      return 1;
+    }
+    if (Array.isArray(pTask.changes)) {
+      return pTask.changes.length;
+    }
+    if (Object.keys(pTask.changes).length === 0) {
+      // empty changes object does not count as real change
+      return 0;
+    }
+    return 1;
+  }
+
+  static getTaskCharacter (pTask) {
+    if (!pTask.changes) {
+      return Character.BLACK_CIRCLE;
+    }
+    if (typeof pTask.changes !== "object") {
+      return Character.BLACK_DIAMOND;
+    }
+    if (Array.isArray(pTask.changes)) {
+      return pTask.changes.length === 0 ? Character.BLACK_CIRCLE : Character.BLACK_DIAMOND;
+    }
+    if (Object.keys(pTask.changes).length === 0) {
+      // empty changes object does not count as real change
+      return Character.BLACK_CIRCLE;
+    }
+    return Character.BLACK_DIAMOND;
+  }
+
+  static _getTaskChanges (pTask) {
+    if (!pTask.changes) {
+      return "";
+    }
+    if (typeof pTask.changes !== "object") {
+      return "\n'changes' has type " + typeof pTask.changes;
+    }
+    if (Array.isArray(pTask.changes)) {
+      const nrChanges = pTask.changes.length;
+      return Utils.txtZeroOneMany(
+        nrChanges,
+        "\n'changes' is an empty array",
+        "\n'changes' is an array\n" + nrChanges + " change",
+        "\n'changes' is an array\n" + nrChanges + " changes");
+    }
+    if (Object.keys(pTask.changes).length === 0) {
+      // empty changes object does not count as real change
+      return "";
+    }
+    return "\nchanged";
+  }
+
+  static getTaskClass (pTask) {
+    if (pTask.result === null) {
+      return "task-skipped";
+    }
+    if (pTask.result === false) {
+      return "task-failure";
+    }
+    if (Array.isArray(pTask.changes)) {
+      return pTask.changes.length ? "task-changes" : "task-success";
+    }
+    if (typeof pTask.changes !== "object") {
+      // pretend 1 change
+      return "task-changes";
+    }
+    if (Object.keys(pTask.changes).length === 0) {
+      // empty changes object does not count as real change
+      return "task-success";
+    }
+    return "task-changes";
+  }
+
   static _setTaskToolTip (pSpan, pTask) {
 
     if (typeof pTask !== "object") {
@@ -362,43 +439,15 @@ export class Output {
       txt += "\n" + functionName;
     }
 
-    let nrChanges;
-    if (!pTask.changes) {
-      nrChanges = 0;
-    } else if (typeof pTask.changes !== "object") {
-      nrChanges = 1;
-      txt += "\n'changes' has type " + typeof pTask.changes;
-    } else if (Array.isArray(pTask.changes)) {
-      nrChanges = pTask.changes.length;
-      txt += "\n'changes' is an array";
-      txt += Utils.txtZeroOneMany(nrChanges, "", "\n" + nrChanges + " change", "\n" + nrChanges + " changes");
-    } else if (typeof pTask.changes === "object" && Object.keys(pTask.changes).length === 0) {
-      // empty changes object does not count as real change
-      nrChanges = 0;
-    } else {
-      nrChanges = 1;
-      txt += "\nchanged";
-    }
+    txt += Output._getTaskChanges(pTask);
 
     if (Output.isHiddenTask(pTask)) {
       txt += "\nhidden";
     }
 
     pSpan.className = "taskcircle";
-    if (pTask.result === null) {
-      pSpan.classList.add("task-skipped");
-    } else if (pTask.result) {
-      if (nrChanges) {
-        pSpan.classList.add("task-changes");
-      } else {
-        pSpan.classList.add("task-success");
-      }
-    } else {
-      pSpan.classList.add("task-failure");
-    }
-    if (nrChanges) {
-      pSpan.innerText = Character.BLACK_DIAMOND;
-    }
+    pSpan.classList.add(Output.getTaskClass(pTask));
+    pSpan.innerText = Output.getTaskCharacter(pTask);
 
     for (const key in pTask) {
       /* eslint-disable curly */

--- a/saltgui/static/scripts/output/Output.js
+++ b/saltgui/static/scripts/output/Output.js
@@ -388,7 +388,11 @@ export class Output {
     if (pTask.result === null) {
       pSpan.classList.add("task-skipped");
     } else if (pTask.result) {
-      pSpan.classList.add("task-success");
+      if (nrChanges) {
+        pSpan.classList.add("task-changes-success");
+      } else {
+        pSpan.classList.add("task-success");
+      }
     } else {
       pSpan.classList.add("task-failure");
     }

--- a/saltgui/static/scripts/output/Output.js
+++ b/saltgui/static/scripts/output/Output.js
@@ -336,7 +336,7 @@ export class Output {
     return false;
   }
 
-  static _getTaskNrChanges (pTask) {
+  static getTaskNrChanges (pTask) {
     if (!pTask.changes) {
       return 0;
     }
@@ -393,24 +393,21 @@ export class Output {
   }
 
   static getTaskClass (pTask) {
+    let className;
+
     if (pTask.result === null) {
-      return "task-skipped";
+      className = "task-skipped";
+    } else if (pTask.result === false) {
+      className = "task-failure";
+    } else {
+      className = "task-success";
     }
-    if (pTask.result === false) {
-      return "task-failure";
+
+    if (Output.getTaskNrChanges(pTask) > 0) {
+      className += "-changes";
     }
-    if (Array.isArray(pTask.changes)) {
-      return pTask.changes.length ? "task-changes" : "task-success";
-    }
-    if (typeof pTask.changes !== "object") {
-      // pretend 1 change
-      return "task-changes";
-    }
-    if (Object.keys(pTask.changes).length === 0) {
-      // empty changes object does not count as real change
-      return "task-success";
-    }
-    return "task-changes";
+
+    return className;
   }
 
   static _setTaskToolTip (pSpan, pTask) {

--- a/saltgui/static/scripts/output/Output.js
+++ b/saltgui/static/scripts/output/Output.js
@@ -397,7 +397,7 @@ export class Output {
       pSpan.classList.add("task-failure");
     }
     if (nrChanges) {
-      pSpan.innerText = Character.BLACK_CIRCLE_WITH_OUTLINE;
+      pSpan.innerText = Character.BLACK_DIAMOND;
     }
 
     for (const key in pTask) {

--- a/saltgui/static/scripts/output/Output.js
+++ b/saltgui/static/scripts/output/Output.js
@@ -389,7 +389,7 @@ export class Output {
       pSpan.classList.add("task-skipped");
     } else if (pTask.result) {
       if (nrChanges) {
-        pSpan.classList.add("task-changes-success");
+        pSpan.classList.add("task-changes");
       } else {
         pSpan.classList.add("task-success");
       }
@@ -397,7 +397,6 @@ export class Output {
       pSpan.classList.add("task-failure");
     }
     if (nrChanges) {
-      pSpan.classList.add("task-changes");
       pSpan.innerText = Character.BLACK_CIRCLE_WITH_OUTLINE;
     }
 

--- a/saltgui/static/scripts/output/OutputHighstate.js
+++ b/saltgui/static/scripts/output/OutputHighstate.js
@@ -126,20 +126,8 @@ export class OutputHighstate {
 
       const functionName = components[0] + "." + components[3];
 
-      let hasChanges = false;
-      let chgs = null;
-      if (task["changes"] !== undefined) {
-        chgs = task.changes;
-        const keys = Object.keys(chgs);
-        if (keys.length === 2 && keys[0] === "out" && keys[1] === "ret") {
-          chgs = chgs["ret"];
-        }
-        const str = JSON.stringify(chgs);
-        if (str !== "{}") {
-          hasChanges = true;
-        }
-        changesDetail += Object.keys(chgs).length;
-      }
+      const nrChanges = Output.getTaskNrChanges(task);
+      changesDetail += nrChanges;
 
       const taskId = components[1];
       let taskName = components[2];
@@ -156,7 +144,7 @@ export class OutputHighstate {
         taskSpan = OutputHighstateTaskTerse.getStateOutput(task, taskName, functionName);
       } else if (Output.isStateOutputSelected("mixed") && task.result) {
         taskSpan = OutputHighstateTaskTerse.getStateOutput(task, taskName, functionName);
-      } else if (Output.isStateOutputSelected("changes") && task.result && hasChanges) {
+      } else if (Output.isStateOutputSelected("changes") && task.result && nrChanges) {
         taskSpan = OutputHighstateTaskTerse.getStateOutput(task, taskName, functionName);
       } else if (Output.isOutputFormatAllowed("saltguihighstate")) {
         taskSpan = OutputHighstateTaskSaltGui.getStateOutput(task, taskId, taskName, functionName, pMinionId, pJobId);
@@ -164,15 +152,13 @@ export class OutputHighstate {
         taskSpan = OutputHighstateTaskFull.getStateOutput(task, taskId, taskName, functionName);
       }
 
+      taskSpan.classList.add(Output.getTaskClass(task));
       if (task.result === null) {
-        taskSpan.classList.add("task-skipped");
+        // VOID
       } else if (!task.result) {
-        taskSpan.classList.add("task-failure");
-      } else if (hasChanges) {
-        taskSpan.classList.add("task-changes");
+        // VOID
+      } else if (nrChanges) {
         changesSummary += 1;
-      } else {
-        taskSpan.classList.add("task-success");
       }
       const taskDiv = Utils.createDiv("", "", Utils.getIdFromMinionId(pMinionId + "." + nr));
       taskDiv.append(taskSpan);

--- a/saltgui/static/scripts/output/OutputHighstateSummaryOriginal.js
+++ b/saltgui/static/scripts/output/OutputHighstateSummaryOriginal.js
@@ -28,7 +28,7 @@ export class OutputHighstateSummaryOriginal {
       pDiv.append(oSpan);
 
       txt = "changed=" + pChangesSummary;
-      const changedSpan = Utils.createSpan("task-changes", txt);
+      const changedSpan = Utils.createSpan("task-success-changes", txt);
       pDiv.append(changedSpan);
 
       txt = ")";

--- a/saltgui/static/scripts/output/OutputHighstateTaskSaltGui.js
+++ b/saltgui/static/scripts/output/OutputHighstateTaskSaltGui.js
@@ -94,17 +94,8 @@ export class OutputHighstateTaskSaltGui {
     const taskDiv = Utils.createDiv();
 
     const span = Utils.createSpan("task-icon");
-    if (pTask.result === null) {
-      span.innerText = Character.HEAVY_CHECK_MARK;
-      span.classList.add("task-skipped");
-    } else if (pTask.result) {
-      span.innerText = Character.HEAVY_CHECK_MARK;
-      span.classList.add("task-success");
-    } else {
-      span.innerText = Character.HEAVY_BALLOT_X;
-      span.classList.add("task-failure");
-    }
-    // don't use task-changes here
+    span.innerText = Output.getTaskCharacter(pTask);
+    span.classList.add(Output.getTaskClass(pTask));
     taskDiv.append(span);
 
     taskDiv.append(document.createTextNode(pTaskName));

--- a/saltgui/static/scripts/panels/HighState.js
+++ b/saltgui/static/scripts/panels/HighState.js
@@ -459,7 +459,7 @@ export class HighStatePanel extends Panel {
           if (span.classList.contains("task-changes")) {
             prio -= 1;
             statKey += " task-changes";
-            span.innerText = Character.BLACK_CIRCLE_WITH_OUTLINE;
+            span.innerText = Character.BLACK_DIAMOND;
           }
 
           // allow keys to be sortable
@@ -499,7 +499,7 @@ export class HighStatePanel extends Panel {
           const itemSpan = Utils.createSpan(["tasksummary", "taskcircle"], Character.BLACK_CIRCLE);
           itemSpan.classList.add(...statKey.substring(2).split(" "));
           if(itemSpan.classList.contains("task-changes")) {
-            itemSpan.innerText = Character.BLACK_CIRCLE_WITH_OUTLINE;
+            itemSpan.innerText = Character.BLACK_DIAMOND;
           }
           itemSpan.style.backgroundColor = "black";
           summarySpan.append(itemSpan);

--- a/saltgui/static/stylesheets/page.css
+++ b/saltgui/static/stylesheets/page.css
@@ -73,15 +73,6 @@ td.tasks span.tasksummary {
   padding-right: 2px;
 }
 
-td .task-failure {
-  color: red;
-}
-
-pre .task-failure {
-  cursor: pointer;
-  color: red;
-}
-
 pre .minion-id.host-skips,
 pre #summary-jobs-active .host-skips,
 pre .minion-id.host-no-response,
@@ -89,34 +80,8 @@ pre #summary-jobs-active .host-no-response {
   color: yellow;
 }
 
-td .task-skipped {
-  color: yellow;
-}
-
-pre .task-skipped {
-  cursor: pointer;
-  color: yellow;
-}
-
 pre .minion-id {
   color: #4caf50;
-}
-
-td .task-success {
-  color: lime;
-}
-
-pre .task-success {
-  cursor: pointer;
-  color: lime;
-}
-
-td .task-changes {
-  color: aqua;
-}
-
-pre .task-changes {
-  color: aqua;
 }
 
 .task-summary {
@@ -311,18 +276,33 @@ table tr td:last-of-type {
   }
 }
 
-/* taskcircle */
+/* tasks */
 
-.taskcircle.task-success {
+.task-success {
   color: lime;
 }
 
-.taskcircle.task-failure {
+.task-success-changes {
+  color: aqua;
+}
+
+.task-failure,
+.task-failure-changes {
   color: red;
 }
 
-.taskcircle.task-skipped {
+.task-skipped,
+.task-skipped-changes {
   color: yellow;
+}
+
+pre .task-success,
+pre .task-success-changes,
+pre .task-skipped,
+pre .task-skipped-changes,
+pre .task-failure,
+pre .task-failure-changes {
+  cursor: pointer;
 }
 
 @media print {

--- a/saltgui/static/stylesheets/page.css
+++ b/saltgui/static/stylesheets/page.css
@@ -317,10 +317,6 @@ table tr td:last-of-type {
   color: lime;
 }
 
-.taskcircle.task-changes-success {
-  color: aqua;
-}
-
 .taskcircle.task-failure {
   color: red;
 }

--- a/saltgui/static/stylesheets/page.css
+++ b/saltgui/static/stylesheets/page.css
@@ -317,6 +317,10 @@ table tr td:last-of-type {
   color: lime;
 }
 
+.taskcircle.task-changes-success {
+  color: aqua;
+}
+
 .taskcircle.task-failure {
   color: red;
 }


### PR DESCRIPTION
<img width="506" alt="image" src="https://github.com/erwindon/SaltGUI/assets/20047243/d628d6e7-2cc8-4dec-a7f2-fb7c81d0829d">


I suggest changing the task-changed display color for better readability of states