### PR TITLE
Open a row/link in a new tab

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ such as `yubico_client`, or execution modules such as `boto3_sns`.
 - View internal documentation for any salt command
 - View external documentation for any salt command
 - View minions organized by node-group
+- View details optionally in a separate windows
 - Define your own custom documentation for commands
 - Match list of minions against reference list
 - Match status of minions against reference list
@@ -114,6 +115,16 @@ Note that SaltGUI cannot inspect the `master` file to see which authentication m
 This is because the salt-api can only read the file after login.
 
 See the [EAUTH documentation](https://docs.saltstack.com/en/latest/topics/eauth/index.html) and the [Salt auth source code](https://github.com/saltstack/salt/tree/master/salt/auth) for more information.
+
+
+## Browser tabs
+SaltGUI is a single page web-application.
+In cases where you would zoom in on details, it is possible to open a new browser tab with the requested details.
+Use CTRL-click to open the page in a new tab.
+Use ALT-click to open the page in a new tab and also make that the current tab.
+This works for clicks on table-rows and for clicks on popup-menu items.
+These functions are a bit browser-dependent, but all major browsers seem to follow this behavior.
+When a new tab is opened by SaltGUI, it does not contain the menu bar items, secondary panels or a close-button inside the page.
 
 
 ## Command Box

--- a/saltgui/static/scripts/Router.js
+++ b/saltgui/static/scripts/Router.js
@@ -278,6 +278,18 @@ export class Router {
     }
   }
 
+  static _cancelSelections () {
+    // see https://stackoverflow.com/questions/3169786/clear-text-selection-with-javascript
+    const sel = window.getSelection ? window.getSelection() : document.selection;
+    if (sel) {
+      if (sel.removeAllRanges) {
+        sel.removeAllRanges();
+      } else if (sel.empty) {
+        sel.empty();
+      }
+    }
+  }
+
   static updateMainMenu () {
     const pages = Router._getPagesList();
 
@@ -370,6 +382,7 @@ export class Router {
         // forward navigation
         if (inNewWindow) {
           // in a new window
+          Router._cancelSelections();
           window.open(url);
           return;
         }

--- a/saltgui/static/scripts/Router.js
+++ b/saltgui/static/scripts/Router.js
@@ -300,7 +300,7 @@ export class Router {
   // pForward = 0 --> normal navigation
   // pForward = 1 --> back navigation using regular gui
   // pForward = 2 --> back navigation using browser
-  goTo (pHash, pQuery = {}, pForward = 0) {
+  goTo (pHash, pQuery = {}, pForward = 0, pEvent = null) {
 
     // close the command-box when it is stil open
     CommandBox.hideManualRun();
@@ -335,6 +335,11 @@ export class Router {
     const parentQuery = Object.fromEntries(new URLSearchParams(search));
     /* eslint-enable compat/compat */
 
+    let inNewWindow = false;
+    if (pEvent) {
+      inNewWindow = pEvent.altKey || pEvent.ctrlKey;
+    }
+
     for (const route of this.pages) {
       if (route.path !== pHash) {
         continue;
@@ -351,6 +356,10 @@ export class Router {
         url += sep + key + "=" + encodeURIComponent(value);
         sep = "&";
       }
+      if (inNewWindow) {
+        url += sep + "popup=true";
+        sep = "&";
+      }
       url += "#" + pHash;
       if (parentHash === route.path) {
         // page refresh
@@ -359,6 +368,11 @@ export class Router {
         window.history.replaceState({}, undefined, url);
       } else if (pForward === 0) {
         // forward navigation
+        if (inNewWindow) {
+          // in a new window
+          window.open(url);
+          return;
+        }
         window.history.pushState({}, undefined, url);
         route.parentHash = parentHash;
         route.parentQuery = parentQuery;

--- a/saltgui/static/scripts/issues/Issues.js
+++ b/saltgui/static/scripts/issues/Issues.js
@@ -98,8 +98,8 @@ export class Issues {
     } else {
       title = "Go to " + pPage + " page";
     }
-    pTr.menu.addMenuItem(title, () => {
-      pTr.panel.router.goTo(pPage, pArgs);
+    pTr.menu.addMenuItem(title, (pClickEvent) => {
+      pTr.panel.router.goTo(pPage, pArgs, undefined, pClickEvent);
     });
 
     if (pTr.hasClick !== true) {

--- a/saltgui/static/scripts/pages/Beacons.js
+++ b/saltgui/static/scripts/pages/Beacons.js
@@ -3,6 +3,7 @@
 import {BeaconsPanel} from "../panels/Beacons.js";
 import {JobsSummaryPanel} from "../panels/JobsSummary.js";
 import {Page} from "./Page.js";
+import {Utils} from "../Utils.js";
 
 export class BeaconsPage extends Page {
 
@@ -11,11 +12,15 @@ export class BeaconsPage extends Page {
 
     this.beacons = new BeaconsPanel();
     super.addPanel(this.beacons);
-    this.jobs = new JobsSummaryPanel();
-    super.addPanel(this.jobs);
+    if (Utils.getQueryParam("popup") !== "true") {
+      this.jobs = new JobsSummaryPanel();
+      super.addPanel(this.jobs);
+    }
   }
 
   handleSaltJobRetEvent (pData) {
-    this.jobs.handleSaltJobRetEvent(pData);
+    if (this.jobs) {
+      this.jobs.handleSaltJobRetEvent(pData);
+    }
   }
 }

--- a/saltgui/static/scripts/pages/BeaconsMinion.js
+++ b/saltgui/static/scripts/pages/BeaconsMinion.js
@@ -3,6 +3,7 @@
 import {BeaconsMinionPanel} from "../panels/BeaconsMinion.js";
 import {JobsSummaryPanel} from "../panels/JobsSummary.js";
 import {Page} from "./Page.js";
+import {Utils} from "../Utils.js";
 
 export class BeaconsMinionPage extends Page {
 
@@ -11,8 +12,10 @@ export class BeaconsMinionPage extends Page {
 
     this.beaconsminion = new BeaconsMinionPanel();
     super.addPanel(this.beaconsminion);
-    this.jobs = new JobsSummaryPanel();
-    super.addPanel(this.jobs);
+    if (Utils.getQueryParam("popup") !== "true") {
+      this.jobs = new JobsSummaryPanel();
+      super.addPanel(this.jobs);
+    }
   }
 
   handleSaltBeaconEvent (pTag, pData) {
@@ -20,6 +23,8 @@ export class BeaconsMinionPage extends Page {
   }
 
   handleSaltJobRetEvent (pData) {
-    this.jobs.handleSaltJobRetEvent(pData);
+    if (this.jobs) {
+      this.jobs.handleSaltJobRetEvent(pData);
+    }
   }
 }

--- a/saltgui/static/scripts/pages/Grains.js
+++ b/saltgui/static/scripts/pages/Grains.js
@@ -3,6 +3,7 @@
 import {GrainsPanel} from "../panels/Grains.js";
 import {JobsSummaryPanel} from "../panels/JobsSummary.js";
 import {Page} from "./Page.js";
+import {Utils} from "../Utils.js";
 
 export class GrainsPage extends Page {
 
@@ -11,11 +12,15 @@ export class GrainsPage extends Page {
 
     this.grains = new GrainsPanel();
     super.addPanel(this.grains);
-    this.jobs = new JobsSummaryPanel();
-    super.addPanel(this.jobs);
+    if (Utils.getQueryParam("popup") !== "true") {
+      this.jobs = new JobsSummaryPanel();
+      super.addPanel(this.jobs);
+    }
   }
 
   handleSaltJobRetEvent (pData) {
-    this.jobs.handleSaltJobRetEvent(pData);
+    if (this.jobs) {
+      this.jobs.handleSaltJobRetEvent(pData);
+    }
   }
 }

--- a/saltgui/static/scripts/pages/GrainsMinion.js
+++ b/saltgui/static/scripts/pages/GrainsMinion.js
@@ -3,6 +3,7 @@
 import {GrainsMinionPanel} from "../panels/GrainsMinion.js";
 import {JobsSummaryPanel} from "../panels/JobsSummary.js";
 import {Page} from "./Page.js";
+import {Utils} from "../Utils.js";
 
 export class GrainsMinionPage extends Page {
 
@@ -11,11 +12,15 @@ export class GrainsMinionPage extends Page {
 
     this.grainsminion = new GrainsMinionPanel();
     super.addPanel(this.grainsminion);
-    this.jobs = new JobsSummaryPanel();
-    super.addPanel(this.jobs);
+    if (Utils.getQueryParam("popup") !== "true") {
+      this.jobs = new JobsSummaryPanel();
+      super.addPanel(this.jobs);
+    }
   }
 
   handleSaltJobRetEvent (pData) {
-    this.jobs.handleSaltJobRetEvent(pData);
+    if (this.jobs) {
+      this.jobs.handleSaltJobRetEvent(pData);
+    }
   }
 }

--- a/saltgui/static/scripts/pages/HighState.js
+++ b/saltgui/static/scripts/pages/HighState.js
@@ -3,6 +3,7 @@
 import {HighStatePanel} from "../panels/HighState.js";
 import {JobsSummaryPanel} from "../panels/JobsSummary.js";
 import {Page} from "./Page.js";
+import {Utils} from "../Utils.js";
 
 export class HighStatePage extends Page {
 
@@ -11,11 +12,15 @@ export class HighStatePage extends Page {
 
     this.highstate = new HighStatePanel();
     super.addPanel(this.highstate);
-    this.jobs = new JobsSummaryPanel();
-    super.addPanel(this.jobs);
+    if (Utils.getQueryParam("popup") !== "true") {
+      this.jobs = new JobsSummaryPanel();
+      super.addPanel(this.jobs);
+    }
   }
 
   handleSaltJobRetEvent (pData) {
-    this.jobs.handleSaltJobRetEvent(pData);
+    if (this.jobs) {
+      this.jobs.handleSaltJobRetEvent(pData);
+    }
   }
 }

--- a/saltgui/static/scripts/pages/Issues.js
+++ b/saltgui/static/scripts/pages/Issues.js
@@ -3,6 +3,7 @@
 import {IssuesPanel} from "../panels/Issues.js";
 import {JobsSummaryPanel} from "../panels/JobsSummary.js";
 import {Page} from "./Page.js";
+import {Utils} from "../Utils.js";
 
 export class IssuesPage extends Page {
 
@@ -11,11 +12,15 @@ export class IssuesPage extends Page {
 
     this.issues = new IssuesPanel();
     super.addPanel(this.issues);
-    this.jobs = new JobsSummaryPanel();
-    super.addPanel(this.jobs);
+    if (Utils.getQueryParam("popup") !== "true") {
+      this.jobs = new JobsSummaryPanel();
+      super.addPanel(this.jobs);
+    }
   }
 
   handleSaltJobRetEvent (pData) {
-    this.jobs.handleSaltJobRetEvent(pData);
+    if (this.jobs) {
+      this.jobs.handleSaltJobRetEvent(pData);
+    }
   }
 }

--- a/saltgui/static/scripts/pages/Keys.js
+++ b/saltgui/static/scripts/pages/Keys.js
@@ -3,6 +3,7 @@
 import {JobsSummaryPanel} from "../panels/JobsSummary.js";
 import {KeysPanel} from "../panels/Keys.js";
 import {Page} from "./Page.js";
+import {Utils} from "../Utils.js";
 
 export class KeysPage extends Page {
 
@@ -11,8 +12,10 @@ export class KeysPage extends Page {
 
     this.keys = new KeysPanel();
     super.addPanel(this.keys);
-    this.jobs = new JobsSummaryPanel();
-    super.addPanel(this.jobs);
+    if (Utils.getQueryParam("popup") !== "true") {
+      this.jobs = new JobsSummaryPanel();
+      super.addPanel(this.jobs);
+    }
   }
 
   handleSaltAuthEvent (pData) {
@@ -24,7 +27,9 @@ export class KeysPage extends Page {
   }
 
   handleSaltJobRetEvent (pData) {
-    this.jobs.handleSaltJobRetEvent(pData);
+    if (this.jobs) {
+      this.jobs.handleSaltJobRetEvent(pData);
+    }
   }
 
   handleSyndicEvent () {

--- a/saltgui/static/scripts/pages/Minions.js
+++ b/saltgui/static/scripts/pages/Minions.js
@@ -3,6 +3,7 @@
 import {JobsSummaryPanel} from "../panels/JobsSummary.js";
 import {MinionsPanel} from "../panels/Minions.js";
 import {Page} from "./Page.js";
+import {Utils} from "../Utils.js";
 
 export class MinionsPage extends Page {
 
@@ -11,11 +12,15 @@ export class MinionsPage extends Page {
 
     this.minions = new MinionsPanel();
     super.addPanel(this.minions);
-    this.jobs = new JobsSummaryPanel();
-    super.addPanel(this.jobs);
+    if (Utils.getQueryParam("popup") !== "true") {
+      this.jobs = new JobsSummaryPanel();
+      super.addPanel(this.jobs);
+    }
   }
 
   handleSaltJobRetEvent (pData) {
-    this.jobs.handleSaltJobRetEvent(pData);
+    if (this.jobs) {
+      this.jobs.handleSaltJobRetEvent(pData);
+    }
   }
 }

--- a/saltgui/static/scripts/pages/Nodegroups.js
+++ b/saltgui/static/scripts/pages/Nodegroups.js
@@ -12,12 +12,16 @@ export class NodegroupsPage extends Page {
 
     this.nodegroups = new NodegroupsPanel();
     super.addPanel(this.nodegroups);
-    this.jobs = new JobsSummaryPanel();
-    super.addPanel(this.jobs);
+    if (Utils.getQueryParam("popup") !== "true") {
+      this.jobs = new JobsSummaryPanel();
+      super.addPanel(this.jobs);
+    }
   }
 
   handleSaltJobRetEvent (pData) {
-    this.jobs.handleSaltJobRetEvent(pData);
+    if (this.jobs) {
+      this.jobs.handleSaltJobRetEvent(pData);
+    }
   }
 
   /* eslint-disable class-methods-use-this */

--- a/saltgui/static/scripts/pages/Options.js
+++ b/saltgui/static/scripts/pages/Options.js
@@ -3,6 +3,7 @@
 import {OptionsPanel} from "../panels/Options.js";
 import {Page} from "./Page.js";
 import {StatsPanel} from "../panels/Stats.js";
+import {Utils} from "../Utils.js";
 
 export class OptionsPage extends Page {
 
@@ -11,12 +12,16 @@ export class OptionsPage extends Page {
 
     this.options = new OptionsPanel();
     super.addPanel(this.options);
-    this.stats = new StatsPanel();
-    super.addPanel(this.stats);
+    if (Utils.getQueryParam("popup") !== "true") {
+      this.stats = new StatsPanel();
+      super.addPanel(this.stats);
+    }
   }
 
   onHide () {
     this.options.onHide();
-    this.stats.onHide();
+    if (this.stats) {
+      this.stats.onHide();
+    }
   }
 }

--- a/saltgui/static/scripts/pages/Page.js
+++ b/saltgui/static/scripts/pages/Page.js
@@ -32,6 +32,13 @@ export class Page {
     this.panels = [];
     this.api = pRouter.api;
 
+    if (Utils.getQueryParam("popup") === "true") {
+      const fullmenu = document.querySelector(".fullmenu");
+      fullmenu.style.display = "none";
+      const minimenu = document.querySelector(".minimenu");
+      minimenu.style.display = "none";
+    }
+
     const body = document.querySelector("body");
     body.onkeyup = (keyUpEvent) => {
       if (!Utils.isValidKeyUpEvent(keyUpEvent)) {

--- a/saltgui/static/scripts/pages/Pillars.js
+++ b/saltgui/static/scripts/pages/Pillars.js
@@ -3,6 +3,7 @@
 import {JobsSummaryPanel} from "../panels/JobsSummary.js";
 import {Page} from "./Page.js";
 import {PillarsPanel} from "../panels/Pillars.js";
+import {Utils} from "../Utils.js";
 
 export class PillarsPage extends Page {
 
@@ -11,11 +12,15 @@ export class PillarsPage extends Page {
 
     this.pillars = new PillarsPanel();
     super.addPanel(this.pillars);
-    this.jobs = new JobsSummaryPanel();
-    super.addPanel(this.jobs);
+    if (Utils.getQueryParam("popup") !== "true") {
+      this.jobs = new JobsSummaryPanel();
+      super.addPanel(this.jobs);
+    }
   }
 
   handleSaltJobRetEvent (pData) {
-    this.jobs.handleSaltJobRetEvent(pData);
+    if (this.jobs) {
+      this.jobs.handleSaltJobRetEvent(pData);
+    }
   }
 }

--- a/saltgui/static/scripts/pages/PillarsMinion.js
+++ b/saltgui/static/scripts/pages/PillarsMinion.js
@@ -3,6 +3,7 @@
 import {JobsSummaryPanel} from "../panels/JobsSummary.js";
 import {Page} from "./Page.js";
 import {PillarsMinionPanel} from "../panels/PillarsMinion.js";
+import {Utils} from "../Utils.js";
 
 export class PillarsMinionPage extends Page {
 
@@ -11,11 +12,15 @@ export class PillarsMinionPage extends Page {
 
     this.pillarsminion = new PillarsMinionPanel();
     super.addPanel(this.pillarsminion);
-    this.jobs = new JobsSummaryPanel();
-    super.addPanel(this.jobs);
+    if (Utils.getQueryParam("popup") !== "true") {
+      this.jobs = new JobsSummaryPanel();
+      super.addPanel(this.jobs);
+    }
   }
 
   handleSaltJobRetEvent (pData) {
-    this.jobs.handleSaltJobRetEvent(pData);
+    if (this.jobs) {
+      this.jobs.handleSaltJobRetEvent(pData);
+    }
   }
 }

--- a/saltgui/static/scripts/pages/Reactors.js
+++ b/saltgui/static/scripts/pages/Reactors.js
@@ -12,12 +12,16 @@ export class ReactorsPage extends Page {
 
     this.reactors = new ReactorsPanel();
     super.addPanel(this.reactors);
-    this.jobs = new JobsSummaryPanel();
-    super.addPanel(this.jobs);
+    if (Utils.getQueryParam("popup") !== "true") {
+      this.jobs = new JobsSummaryPanel();
+      super.addPanel(this.jobs);
+    }
   }
 
   handleSaltJobRetEvent (pData) {
-    this.jobs.handleSaltJobRetEvent(pData);
+    if (this.jobs) {
+      this.jobs.handleSaltJobRetEvent(pData);
+    }
   }
 
   /* eslint-disable class-methods-use-this */

--- a/saltgui/static/scripts/pages/Schedules.js
+++ b/saltgui/static/scripts/pages/Schedules.js
@@ -3,6 +3,7 @@
 import {JobsSummaryPanel} from "../panels/JobsSummary.js";
 import {Page} from "./Page.js";
 import {SchedulesPanel} from "../panels/Schedules.js";
+import {Utils} from "../Utils.js";
 
 export class SchedulesPage extends Page {
 
@@ -11,11 +12,15 @@ export class SchedulesPage extends Page {
 
     this.schedules = new SchedulesPanel();
     super.addPanel(this.schedules);
-    this.jobs = new JobsSummaryPanel();
-    super.addPanel(this.jobs);
+    if (Utils.getQueryParam("popup") !== "true") {
+      this.jobs = new JobsSummaryPanel();
+      super.addPanel(this.jobs);
+    }
   }
 
   handleSaltJobRetEvent (pData) {
-    this.jobs.handleSaltJobRetEvent(pData);
+    if (this.jobs) {
+      this.jobs.handleSaltJobRetEvent(pData);
+    }
   }
 }

--- a/saltgui/static/scripts/pages/SchedulesMinion.js
+++ b/saltgui/static/scripts/pages/SchedulesMinion.js
@@ -3,6 +3,7 @@
 import {JobsSummaryPanel} from "../panels/JobsSummary.js";
 import {Page} from "./Page.js";
 import {SchedulesMinionPanel} from "../panels/SchedulesMinion.js";
+import {Utils} from "../Utils.js";
 
 export class SchedulesMinionPage extends Page {
 
@@ -11,11 +12,15 @@ export class SchedulesMinionPage extends Page {
 
     this.schedulesminion = new SchedulesMinionPanel();
     super.addPanel(this.schedulesminion);
-    this.jobs = new JobsSummaryPanel();
-    super.addPanel(this.jobs);
+    if (Utils.getQueryParam("popup") !== "true") {
+      this.jobs = new JobsSummaryPanel();
+      super.addPanel(this.jobs);
+    }
   }
 
   handleSaltJobRetEvent (pData) {
-    this.jobs.handleSaltJobRetEvent(pData);
+    if (this.jobs) {
+      this.jobs.handleSaltJobRetEvent(pData);
+    }
   }
 }

--- a/saltgui/static/scripts/pages/Templates.js
+++ b/saltgui/static/scripts/pages/Templates.js
@@ -12,12 +12,16 @@ export class TemplatesPage extends Page {
 
     this.templates = new TemplatesPanel();
     super.addPanel(this.templates);
-    this.jobs = new JobsSummaryPanel();
-    super.addPanel(this.jobs);
+    if (Utils.getQueryParam("popup") !== "true") {
+      this.jobs = new JobsSummaryPanel();
+      super.addPanel(this.jobs);
+    }
   }
 
   handleSaltJobRetEvent (pData) {
-    this.jobs.handleSaltJobRetEvent(pData);
+    if (this.jobs) {
+      this.jobs.handleSaltJobRetEvent(pData);
+    }
   }
 
   /* eslint-disable class-methods-use-this */

--- a/saltgui/static/scripts/panels/Beacons.js
+++ b/saltgui/static/scripts/panels/Beacons.js
@@ -144,8 +144,8 @@ export class BeaconsPanel extends Panel {
   }
 
   _addMenuItemShowBeacons (pMenu, pMinionId) {
-    pMenu.addMenuItem("Show beacons", () => {
-      this.router.goTo("beacons-minion", {"minionid": pMinionId});
+    pMenu.addMenuItem("Show beacons", (pClickEvent) => {
+      this.router.goTo("beacons-minion", {"minionid": pMinionId}, undefined, pClickEvent);
     });
   }
 }

--- a/saltgui/static/scripts/panels/Beacons.js
+++ b/saltgui/static/scripts/panels/Beacons.js
@@ -97,7 +97,7 @@ export class BeaconsPanel extends Panel {
       this._addMenuItemShowBeacons(menu, minionId);
 
       minionTr.addEventListener("click", (pClickEvent) => {
-        this.router.goTo("beacons-minion", {"minionid": minionId});
+        this.router.goTo("beacons-minion", {"minionid": minionId}, undefined, pClickEvent);
         pClickEvent.stopPropagation();
       });
     }

--- a/saltgui/static/scripts/panels/BeaconsMinion.js
+++ b/saltgui/static/scripts/panels/BeaconsMinion.js
@@ -21,7 +21,9 @@ export class BeaconsMinionPanel extends Panel {
     this._addPanelMenuItemBeaconsSave();
     this.addSearchButton();
     this.addPlayPauseButton();
-    this.addCloseButton();
+    if (Utils.getQueryParam("popup") !== "true") {
+      this.addCloseButton();
+    }
     this.addHelpButton([
       "The content of column 'Value' is automatically refreshed.",
       "The content of column 'Config' is simplified to reduce its formatted size.",

--- a/saltgui/static/scripts/panels/Grains.js
+++ b/saltgui/static/scripts/panels/Grains.js
@@ -173,8 +173,8 @@ export class GrainsPanel extends Panel {
   }
 
   _addMenuItemShowGrains (pMenu, pMinionId) {
-    pMenu.addMenuItem("Show grains", () => {
-      this.router.goTo("grains-minion", {"minionid": pMinionId});
+    pMenu.addMenuItem("Show grains", (pClickEvent) => {
+      this.router.goTo("grains-minion", {"minionid": pMinionId}, undefined, pClickEvent);
     });
   }
 }

--- a/saltgui/static/scripts/panels/Grains.js
+++ b/saltgui/static/scripts/panels/Grains.js
@@ -94,7 +94,7 @@ export class GrainsPanel extends Panel {
       }
 
       minionTr.addEventListener("click", (pClickEvent) => {
-        this.router.goTo("grains-minion", {"minionid": minionId});
+        this.router.goTo("grains-minion", {"minionid": minionId}, undefined, pClickEvent);
         pClickEvent.stopPropagation();
       });
     }

--- a/saltgui/static/scripts/panels/GrainsMinion.js
+++ b/saltgui/static/scripts/panels/GrainsMinion.js
@@ -17,7 +17,9 @@ export class GrainsMinionPanel extends Panel {
     this._addPanelMenuItemSaltUtilRefreshGrains();
 
     this.addSearchButton();
-    this.addCloseButton();
+    if (Utils.getQueryParam("popup") !== "true") {
+      this.addCloseButton();
+    }
     this.addWarningField();
     this.addTable(["Name", "-menu-", "Value"]);
     this.setTableSortable("Name", "asc");

--- a/saltgui/static/scripts/panels/HighState.js
+++ b/saltgui/static/scripts/panels/HighState.js
@@ -526,8 +526,8 @@ export class HighStatePanel extends Panel {
   }
 
   _addJobsMenuItemShowDetails (pMenu, pJob, pMinionId) {
-    pMenu.addMenuItem("Show details", () => {
-      this.router.goTo("job", {"id": pJob.jid, "minionid": pMinionId});
+    pMenu.addMenuItem("Show details", (pClickEvent) => {
+      this.router.goTo("job", {"id": pJob.jid, "minionid": pMinionId}, undefined, pClickEvent);
     });
   }
 }

--- a/saltgui/static/scripts/panels/HighState.js
+++ b/saltgui/static/scripts/panels/HighState.js
@@ -370,7 +370,7 @@ export class HighStatePanel extends Panel {
       const jobIdTd = Utils.createTd();
       const jobIdSpan = Utils.createSpan("tooltip", pJobId);
       jobIdSpan.addEventListener("click", (pClickEvent) => {
-        this.router.goTo("job", {"id": pJobId, "minionid": minionId});
+        this.router.goTo("job", {"id": pJobId, "minionid": minionId}, undefined, pClickEvent);
         pClickEvent.stopPropagation();
       });
       jobIdTd.appendChild(jobIdSpan);
@@ -512,7 +512,7 @@ export class HighStatePanel extends Panel {
 
         // allow similar navigation, but just only to the job level
         summarySpan.addEventListener("click", (pClickEvent) => {
-          this.router.goTo("job", {"id": pJobId, "minionid": minionId});
+          this.router.goTo("job", {"id": pJobId, "minionid": minionId}, undefined, pClickEvent);
           pClickEvent.stopPropagation();
         });
 

--- a/saltgui/static/scripts/panels/Job.js
+++ b/saltgui/static/scripts/panels/Job.js
@@ -269,7 +269,7 @@ export class JobPanel extends Panel {
         Utils.addToolTip(link, "this job");
       } else {
         link.addEventListener("click", (pClickEvent) => {
-          this.router.goTo("job", {"id": linkToJid});
+          this.router.goTo("job", {"id": linkToJid}, undefined, pClickEvent);
           pClickEvent.stopPropagation();
         });
       }

--- a/saltgui/static/scripts/panels/Job.js
+++ b/saltgui/static/scripts/panels/Job.js
@@ -14,7 +14,9 @@ export class JobPanel extends Panel {
     super("job");
 
     this.addTitle(Character.HORIZONTAL_ELLIPSIS + " on " + Character.HORIZONTAL_ELLIPSIS);
-    this.addCloseButton();
+    if (Utils.getQueryParam("popup") !== "true") {
+      this.addCloseButton();
+    }
     this.addPanelMenu();
     this.addSearchButton();
 

--- a/saltgui/static/scripts/panels/JobsDetails.js
+++ b/saltgui/static/scripts/panels/JobsDetails.js
@@ -402,7 +402,7 @@ export class JobsDetailsPanel extends JobsPanel {
     tbody.appendChild(tr);
 
     tr.addEventListener("click", (pClickEvent) => {
-      this.router.goTo("job", {"id": job.id});
+      this.router.goTo("job", {"id": job.id}, undefined, pClickEvent);
       pClickEvent.stopPropagation();
     });
   }

--- a/saltgui/static/scripts/panels/JobsDetails.js
+++ b/saltgui/static/scripts/panels/JobsDetails.js
@@ -408,8 +408,8 @@ export class JobsDetailsPanel extends JobsPanel {
   }
 
   _addJobsMenuItemShowDetails (pMenu, job) {
-    pMenu.addMenuItem("Show details", () => {
-      this.router.goTo("job", {"id": job.id});
+    pMenu.addMenuItem("Show details", (pClickEvent) => {
+      this.router.goTo("job", {"id": job.id}, undefined, pClickEvent);
     });
   }
 

--- a/saltgui/static/scripts/panels/JobsSummary.js
+++ b/saltgui/static/scripts/panels/JobsSummary.js
@@ -84,8 +84,8 @@ export class JobsSummaryPanel extends JobsPanel {
   }
 
   _addMenuItemShowDetails (pMenu, job) {
-    pMenu.addMenuItem("Show details", () => {
-      this.router.goTo("job", {"id": job.id});
+    pMenu.addMenuItem("Show details", (pClickEvent) => {
+      this.router.goTo("job", {"id": job.id}, undefined, pClickEvent);
     });
   }
 

--- a/saltgui/static/scripts/panels/JobsSummary.js
+++ b/saltgui/static/scripts/panels/JobsSummary.js
@@ -78,7 +78,7 @@ export class JobsSummaryPanel extends JobsPanel {
     tbody.appendChild(tr);
 
     tr.addEventListener("click", (pClickEvent) => {
-      this.router.goTo("job", {"id": job.id});
+      this.router.goTo("job", {"id": job.id}, undefined, pClickEvent);
       pClickEvent.stopPropagation();
     });
   }

--- a/saltgui/static/scripts/panels/Minions.js
+++ b/saltgui/static/scripts/panels/Minions.js
@@ -220,26 +220,26 @@ export class MinionsPanel extends Panel {
   }
 
   _addMenuItemShowGrains (pMenu, pMinionId) {
-    pMenu.addMenuItem("Show grains", () => {
-      this.router.goTo("grains-minion", {"minionid": pMinionId});
+    pMenu.addMenuItem("Show grains", (pClickEvent) => {
+      this.router.goTo("grains-minion", {"minionid": pMinionId}, undefined, pClickEvent);
     });
   }
 
   _addMenuItemShowSchedules (pMenu, pMinionId) {
-    pMenu.addMenuItem("Show schedules", () => {
-      this.router.goTo("schedules-minion", {"minionid": pMinionId});
+    pMenu.addMenuItem("Show schedules", (pClickEvent) => {
+      this.router.goTo("schedules-minion", {"minionid": pMinionId}, undefined, pClickEvent);
     });
   }
 
   _addMenuItemShowPillars (pMenu, pMinionId) {
-    pMenu.addMenuItem("Show pillars", () => {
-      this.router.goTo("pillars-minion", {"minionid": pMinionId});
+    pMenu.addMenuItem("Show pillars", (pClickEvent) => {
+      this.router.goTo("pillars-minion", {"minionid": pMinionId}, undefined, pClickEvent);
     });
   }
 
   _addMenuItemShowBeacons (pMenu, pMinionId) {
-    pMenu.addMenuItem("Show beacons", () => {
-      this.router.goTo("beacons-minion", {"minionid": pMinionId});
+    pMenu.addMenuItem("Show beacons", (pClickEvent) => {
+      this.router.goTo("beacons-minion", {"minionid": pMinionId}, undefined, pClickEvent);
     });
   }
 

--- a/saltgui/static/scripts/panels/Nodegroups.js
+++ b/saltgui/static/scripts/panels/Nodegroups.js
@@ -416,32 +416,32 @@ export class NodegroupsPanel extends Panel {
   }
 
   _addMenuItemShowKeys (pMenu) {
-    pMenu.addMenuItem("Show keys", () => {
-      this.router.goTo("keys");
+    pMenu.addMenuItem("Show keys", (pClickEvent) => {
+      this.router.goTo("keys", undefined, undefined, pClickEvent);
     });
   }
 
   _addMenuItemShowGrains (pMenu, pMinionId) {
-    pMenu.addMenuItem("Show grains", () => {
-      this.router.goTo("grains-minion", {"minionid": pMinionId});
+    pMenu.addMenuItem("Show grains", (pClickEvent) => {
+      this.router.goTo("grains-minion", {"minionid": pMinionId}, undefined, pClickEvent);
     });
   }
 
   _addMenuItemShowSchedules (pMenu, pMinionId) {
-    pMenu.addMenuItem("Show schedules", () => {
-      this.router.goTo("schedules-minion", {"minionid": pMinionId});
+    pMenu.addMenuItem("Show schedules", (pClickEvent) => {
+      this.router.goTo("schedules-minion", {"minionid": pMinionId}, undefined, pClickEvent);
     });
   }
 
   _addMenuItemShowPillars (pMenu, pMinionId) {
-    pMenu.addMenuItem("Show pillars", () => {
-      this.router.goTo("pillars-minion", {"minionid": pMinionId});
+    pMenu.addMenuItem("Show pillars", (pClickEvent) => {
+      this.router.goTo("pillars-minion", {"minionid": pMinionId}, undefined, pClickEvent);
     });
   }
 
   _addMenuItemShowBeacons (pMenu, pMinionId) {
-    pMenu.addMenuItem("Show beacons", () => {
-      this.router.goTo("beacons-minion", {"minionid": pMinionId});
+    pMenu.addMenuItem("Show beacons", (pClickEvent) => {
+      this.router.goTo("beacons-minion", {"minionid": pMinionId}, undefined, pClickEvent);
     });
   }
 }

--- a/saltgui/static/scripts/panels/Pillars.js
+++ b/saltgui/static/scripts/panels/Pillars.js
@@ -63,7 +63,7 @@ export class PillarsPanel extends Panel {
       this._addMenuItemShowPillars(menu, minionId);
 
       minionTr.addEventListener("click", (pClickEvent) => {
-        this.router.goTo("pillars-minion", {"minionid": minionId});
+        this.router.goTo("pillars-minion", {"minionid": minionId}, undefined, pClickEvent);
         pClickEvent.stopPropagation();
       });
     }

--- a/saltgui/static/scripts/panels/Pillars.js
+++ b/saltgui/static/scripts/panels/Pillars.js
@@ -108,8 +108,8 @@ export class PillarsPanel extends Panel {
   }
 
   _addMenuItemShowPillars (pMenu, pMinionId) {
-    pMenu.addMenuItem("Show pillars", () => {
-      this.router.goTo("pillars-minion", {"minionid": pMinionId});
+    pMenu.addMenuItem("Show pillars", (pClickEvent) => {
+      this.router.goTo("pillars-minion", {"minionid": pMinionId}, undefined, pClickEvent);
     });
   }
 }

--- a/saltgui/static/scripts/panels/PillarsMinion.js
+++ b/saltgui/static/scripts/panels/PillarsMinion.js
@@ -15,7 +15,9 @@ export class PillarsMinionPanel extends Panel {
     this.addPanelMenu();
     this._addPanelMenuItemSaltUtilRefreshPillar();
     this.addSearchButton();
-    this.addCloseButton();
+    if (Utils.getQueryParam("popup") !== "true") {
+      this.addCloseButton();
+    }
     this.addHelpButton([
       "The content of specific well-known pillar values can be made visible",
       "automatically by configuring their name in the server-side configuration file.",

--- a/saltgui/static/scripts/panels/Schedules.js
+++ b/saltgui/static/scripts/panels/Schedules.js
@@ -93,7 +93,7 @@ export class SchedulesPanel extends Panel {
       this._addMenuItemShowSchedules(menu, minionId);
 
       minionTr.addEventListener("click", (pClickEvent) => {
-        this.router.goTo("schedules-minion", {"minionid": minionId});
+        this.router.goTo("schedules-minion", {"minionid": minionId}, undefined, pClickEvent);
         pClickEvent.stopPropagation();
       });
     }

--- a/saltgui/static/scripts/panels/Schedules.js
+++ b/saltgui/static/scripts/panels/Schedules.js
@@ -151,8 +151,8 @@ export class SchedulesPanel extends Panel {
   }
 
   _addMenuItemShowSchedules (pMenu, pMinionId) {
-    pMenu.addMenuItem("Show schedules", () => {
-      this.router.goTo("schedules-minion", {"minionid": pMinionId});
+    pMenu.addMenuItem("Show schedules", (pClickEvent) => {
+      this.router.goTo("schedules-minion", {"minionid": pMinionId}, undefined, pClickEvent);
     });
   }
 }

--- a/saltgui/static/scripts/panels/SchedulesMinion.js
+++ b/saltgui/static/scripts/panels/SchedulesMinion.js
@@ -20,7 +20,9 @@ export class SchedulesMinionPanel extends Panel {
     this._addPanelMenuItemScheduleAddCron();
     this._addPanelMenuItemScheduleAddOnce();
     this.addSearchButton();
-    this.addCloseButton();
+    if (Utils.getQueryParam("popup") !== "true") {
+      this.addCloseButton();
+    }
     this.addTable(["Name", "-menu-", "Details"]);
     this.setTableSortable("Name", "asc");
     this.setTableClickable();


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**

Many pages like pillars, grains, jobs, etc., contain an extensive list that might take a while to load, depending on the number of minions. In this context, whenever you click in the row, it loads the content on the same page. But once you go back, it needs to load everything again.

There is a good side to always getting the latest data. But it is very annoying when you have a huge list or a filter to load, and when you get back to the page, it loads the default content again. It would be amazing to open a new tab for each job we want to look deeper into without the need to load the whole list for each of them (that would also decrease the load on the server calls).

**Describe the solution you'd like**

Create a configuration to force every row click to open in a new tab so the user can decide whether this behavior is more convenient. Right-clicking and opening a new tab could also be possible as a solution.

**Describe alternatives you've considered**

Adding an extra button on this kind of page to open the content in a new tab _(if the row behavior is more challenging to implement)_.

**Additional context**

I could contribute if you gave me some guidance. I saw panels and page folders, but I'm not sure exactly how to add things there.

Thanks in advance for reading the message and maintaining this great project. Cheers!