### PR TITLE
move all in-table menu-items to the first column

### DIFF
--- a/saltgui/static/scripts/panels/Beacons.js
+++ b/saltgui/static/scripts/panels/Beacons.js
@@ -1,6 +1,5 @@
 /* global */
 
-import {DropDownMenu} from "../DropDown.js";
 import {Panel} from "./Panel.js";
 import {Utils} from "../Utils.js";
 
@@ -11,7 +10,7 @@ export class BeaconsPanel extends Panel {
 
     this.addTitle("Beacons");
     this.addSearchButton();
-    this.addTable(["Minion", "Status", "Beacons", "-menu-"]);
+    this.addTable(["-menu-", "Minion", "Status", "Beacons"]);
     this.setTableSortable("Minion", "asc");
     this.setTableClickable("page");
     this.addMsg();
@@ -90,11 +89,10 @@ export class BeaconsPanel extends Panel {
 
     const minionIds = keys.minions.sort();
     for (const minionId of minionIds) {
-      const minionTr = this.addMinion(minionId, 1);
+      const minionTr = this.addMinion(minionId);
 
       // preliminary dropdown menu
-      const menu = new DropDownMenu(minionTr, true);
-      this._addMenuItemShowBeacons(menu, minionId);
+      this._addMenuItemShowBeacons(minionTr.dropdownmenu, minionId);
 
       minionTr.addEventListener("click", (pClickEvent) => {
         this.router.goTo("beacons-minion", {"minionid": minionId}, undefined, pClickEvent);
@@ -139,8 +137,7 @@ export class BeaconsPanel extends Panel {
       minionTr.appendChild(beaconInfoTd);
     }
 
-    const menu = new DropDownMenu(minionTr, true);
-    this._addMenuItemShowBeacons(menu, pMinionId);
+    this._addMenuItemShowBeacons(minionTr.dropdownmenu, pMinionId);
   }
 
   _addMenuItemShowBeacons (pMenu, pMinionId) {

--- a/saltgui/static/scripts/panels/BeaconsMinion.js
+++ b/saltgui/static/scripts/panels/BeaconsMinion.js
@@ -30,7 +30,7 @@ export class BeaconsMinionPanel extends Panel {
       "Note that some beacons produce multiple values, e.g. one per disk.",
       "In that case, effectively only one of the values is visible here."
     ]);
-    this.addTable(["Name", "-menu-", "Config", "Timestamp", "Value", "-help-"]);
+    this.addTable(["-menu-", "Name", "Config", "Timestamp", "Value", "-help-"]);
     this.setTableSortable("Name", "asc");
     this.setTableClickable("cmd");
     this.addMsg();
@@ -141,6 +141,8 @@ export class BeaconsMinionPanel extends Panel {
     for (const beaconName of keys) {
       const tr = Utils.createTr("", "", "beacon-" + beaconName);
 
+      const beaconMenu = new DropDownMenu(tr, true);
+
       const nameTd = Utils.createTd("beacon-name", beaconName);
       tr.appendChild(nameTd);
 
@@ -154,7 +156,6 @@ export class BeaconsMinionPanel extends Panel {
         delete beacon.enabled;
       }
 
-      const beaconMenu = new DropDownMenu(tr, true);
       this._addMenuItemBeaconsDisableBeaconWhenNeeded(beaconMenu, pMinionId, beaconName, beacon);
       this._addMenuItemBeaconsEnableBeaconWhenNeeded(beaconMenu, pMinionId, beaconName, beacon);
       this._addMenuItemBeaconsDelete(beaconMenu, pMinionId, beaconName);

--- a/saltgui/static/scripts/panels/Grains.js
+++ b/saltgui/static/scripts/panels/Grains.js
@@ -1,6 +1,5 @@
 /* global jsonPath */
 
-import {DropDownMenu} from "../DropDown.js";
 import {Output} from "../output/Output.js";
 import {Panel} from "./Panel.js";
 import {Utils} from "../Utils.js";
@@ -18,7 +17,7 @@ export class GrainsPanel extends Panel {
       "See README.md for more details."
     ]);
     this.addWarningField();
-    this.addTable(["Minion", "Status", "Salt version", "OS version", "Grains", "-menu-"]);
+    this.addTable(["-menu-", "Minion", "Status", "Salt version", "OS version", "Grains"]);
 
     // cannot initialize sorting before all columns are present
     // this.setTableSortable("Minion", "asc");
@@ -83,11 +82,10 @@ export class GrainsPanel extends Panel {
 
     const minionIds = keys.minions.sort();
     for (const minionId of minionIds) {
-      const minionTr = this.addMinion(minionId, 1 + this.previewGrains.length);
+      const minionTr = this.addMinion(minionId, this.previewGrains.length);
 
       // preliminary dropdown menu
-      const menu = new DropDownMenu(minionTr, true);
-      this._addMenuItemShowGrains(menu, minionId);
+      this._addMenuItemShowGrains(minionTr.dropdownmenu, minionId);
 
       for (let i = 0; i < this.previewGrains.length; i++) {
         minionTr.appendChild(Utils.createTd());
@@ -134,8 +132,7 @@ export class GrainsPanel extends Panel {
       minionTr.appendChild(grainInfoTd);
     }
 
-    const menu = new DropDownMenu(minionTr, true);
-    this._addMenuItemShowGrains(menu, pMinionId);
+    this._addMenuItemShowGrains(minionTr.dropdownmenu, pMinionId);
 
     // add the preview columns
     /* eslint-disable max-depth */

--- a/saltgui/static/scripts/panels/GrainsMinion.js
+++ b/saltgui/static/scripts/panels/GrainsMinion.js
@@ -21,7 +21,7 @@ export class GrainsMinionPanel extends Panel {
       this.addCloseButton();
     }
     this.addWarningField();
-    this.addTable(["Name", "-menu-", "Value"]);
+    this.addTable(["-menu-", "Name", "Value"]);
     this.setTableSortable("Name", "asc");
     this.setTableClickable("cmd");
     this.addMsg();
@@ -69,12 +69,13 @@ export class GrainsMinionPanel extends Panel {
     for (const grainName of grainNames) {
       const grainTr = Utils.createTr();
 
+      const grainMenu = new DropDownMenu(grainTr, true);
+
       const grainNameTd = Utils.createTd("grain-name", grainName);
       grainTr.appendChild(grainNameTd);
 
       const grainValue = Output.formatObject(grains[grainName]);
 
-      const grainMenu = new DropDownMenu(grainTr, true);
       this._addMenuItemGrainsSetValUpdate(grainMenu, pMinionId, grainName, grains);
       this._addMenuItemGrainsAppendWhenNeeded(grainMenu, pMinionId, grainName, grainValue);
       this._addMenuItemGrainsDelKey(grainMenu, pMinionId, grainName, grains[grainName]);

--- a/saltgui/static/scripts/panels/HighState.js
+++ b/saltgui/static/scripts/panels/HighState.js
@@ -1,7 +1,6 @@
 /* global */
 
 import {Character} from "../Character.js";
-import {DropDownMenu} from "../DropDown.js";
 import {JobPanel} from "./Job.js";
 import {JobsPanel} from "./Jobs.js";
 import {Output} from "../output/Output.js";
@@ -36,7 +35,7 @@ export class HighStatePanel extends Panel {
       "Click on an individual state to re-apply only that state."
     ]);
     this.addWarningField();
-    this.addTable(["Minion", "State", "Latest JID", "Target", "Function", "Start Time", "-menu-", "States"]);
+    this.addTable(["-menu-", "Minion", "State", "Latest JID", "Target", "Function", "Start Time", "States"]);
     this.setTableSortable("Minion", "asc");
     this.setTableClickable("cmd");
     this.addMsg();
@@ -138,14 +137,11 @@ export class HighStatePanel extends Panel {
     this.nrUnaccepted = keys.minions_pre.length;
 
     for (const minionId of minionIds) {
-      const minionTr = this.addMinion(minionId, 2);
+      const minionTr = this.addMinion(minionId);
 
       // preliminary dropdown menu
-      const menu = new DropDownMenu(minionTr, true);
-      this._addMenuItemStateApply(menu, minionId);
-      this._addMenuItemStateApplyTest(menu, minionId);
-
-      minionTr.appendChild(Utils.createTd());
+      this._addMenuItemStateApply(minionTr.dropdownmenu, minionId);
+      this._addMenuItemStateApplyTest(minionTr.dropdownmenu, minionId);
 
       minionTr.addEventListener("click", (pClickEvent) => {
         const functionField = minionTr.querySelector(".function");
@@ -402,10 +398,9 @@ export class HighStatePanel extends Panel {
       startTimeTd.appendChild(startTimeSpan);
       minionTr.appendChild(startTimeTd);
 
-      const menu = new DropDownMenu(minionTr, true);
-      this._addMenuItemStateApply(menu, minionId);
-      this._addMenuItemStateApplyTest(menu, minionId);
-      this._addJobsMenuItemShowDetails(menu, jobData, minionId);
+      this._addMenuItemStateApply(minionTr.dropdownmenu, minionId);
+      this._addMenuItemStateApplyTest(minionTr.dropdownmenu, minionId);
+      this._addJobsMenuItemShowDetails(minionTr.dropdownmenu, jobData, minionId);
 
       const minionResult = jobData.Result[minionId];
       const tasksTd = Utils.createTd("tasks");

--- a/saltgui/static/scripts/panels/JobsDetails.js
+++ b/saltgui/static/scripts/panels/JobsDetails.js
@@ -38,7 +38,7 @@ export class JobsDetailsPanel extends JobsPanel {
       "It is possible to define exceptions on that, and also to define additions to that.",
       "See README.md for more details."
     ]);
-    this.addTable(["JID", "Target", "Function", "Start Time", "-menu-", "Status", "Details"], "data-list-jobs");
+    this.addTable(["-menu-", "JID", "Target", "Function", "Start Time", "Status", "Details"], "data-list-jobs");
     this.setTableSortable("JID", "desc");
     this.setTableClickable("page");
     this.addMsg();
@@ -176,7 +176,7 @@ export class JobsDetailsPanel extends JobsPanel {
 
       if (this.nrErrors >= 3) {
         // don't bother getting more data
-        // may show more then 3 errors when some are stil in-flight
+        // may show more then 3 errors when some are still in-flight
         this._handleJobsRunnerJobsListJob(jobId, "skipped");
         continue;
       }
@@ -336,6 +336,9 @@ export class JobsDetailsPanel extends JobsPanel {
     const tr = Utils.createTr();
     tr.id = Utils.getIdFromJobId(job.id);
     tr.dataset.jobid = job.id;
+
+    const menu = new DropDownMenu(tr, true);
+
     tr.appendChild(Utils.createTd("", job.id));
 
     let targetText = TargetType.makeTargetText(job);
@@ -360,7 +363,6 @@ export class JobsDetailsPanel extends JobsPanel {
     startTimeTd.appendChild(startTimeSpan);
     tr.appendChild(startTimeTd);
 
-    const menu = new DropDownMenu(tr, true);
     this._addJobsMenuItemShowDetails(menu, job);
     this._addMenuItemJobsRerunJob(menu, job, argumentsText);
 

--- a/saltgui/static/scripts/panels/JobsSummary.js
+++ b/saltgui/static/scripts/panels/JobsSummary.js
@@ -36,6 +36,9 @@ export class JobsSummaryPanel extends JobsPanel {
     const tr = Utils.createTr();
     tr.id = Utils.getIdFromJobId(job.id);
 
+    // menu on left side to prevent it from going past end of window
+    const menu = new DropDownMenu(tr, true);
+
     const td = Utils.createTd();
 
     let targetText = TargetType.makeTargetText(job);
@@ -70,7 +73,7 @@ export class JobsSummaryPanel extends JobsPanel {
 
     tr.appendChild(td);
 
-    const menu = new DropDownMenu(tr, true);
+    // complete the menu
     this._addMenuItemShowDetails(menu, job);
     this._addMenuItemUpdateStatus(menu, statusSpan);
 

--- a/saltgui/static/scripts/panels/Keys.js
+++ b/saltgui/static/scripts/panels/Keys.js
@@ -1,7 +1,6 @@
 /* global */
 
 import {Character} from "../Character.js";
-import {DropDownMenu} from "../DropDown.js";
 import {Panel} from "./Panel.js";
 import {Utils} from "../Utils.js";
 
@@ -28,7 +27,7 @@ export class KeysPanel extends Panel {
       "automatically refreshed."
     ]);
     this.addWarningField();
-    this.addTable(["Minion", "Status", "-menu-", "Fingerprint"], "data-list-keys");
+    this.addTable(["-menu-", "Minion", "Status", "Fingerprint"], "data-list-keys");
     this.setTableSortable("Status", "asc");
     this.addMsg();
 
@@ -255,7 +254,7 @@ export class KeysPanel extends Panel {
       }
     }
 
-    const minionIdTd = pMinionTr.querySelector("td");
+    const minionIdTd = pMinionTr.querySelectorAll("td")[1];
     const minionIdSpan = minionIdTd.querySelector("span");
 
     if (txt) {
@@ -399,12 +398,10 @@ export class KeysPanel extends Panel {
 
   _addDropDownMenu (pMinionTr, pMinionId, pStatusField) {
     // final dropdownmenu
-    const menu = new DropDownMenu(pMinionTr, true);
-    this._addMenuItemWheelKeyAccept1(menu, pMinionId, pStatusField);
-    this._addMenuItemWheelKeyReject(menu, pMinionId, pStatusField);
-    this._addMenuItemWheelKeyDelete(menu, pMinionId, pStatusField);
-    this._addMenuItemWheelKeyAccept2(menu, pMinionId, pStatusField);
-    pMinionTr.saltguidropdownmenu = menu;
+    this._addMenuItemWheelKeyAccept1(pMinionTr.dropdownmenu, pMinionId, pStatusField);
+    this._addMenuItemWheelKeyReject(pMinionTr.dropdownmenu, pMinionId, pStatusField);
+    this._addMenuItemWheelKeyDelete(pMinionTr.dropdownmenu, pMinionId, pStatusField);
+    this._addMenuItemWheelKeyAccept2(pMinionTr.dropdownmenu, pMinionId, pStatusField);
   }
 
   _addMenuItemWheelKeyAccept1 (pMenu, pMinionId, pStatusField) {
@@ -648,7 +645,7 @@ export class KeysPanel extends Panel {
       }
       // keep the fingerprint
       // update the menu because it may be in a hidden state
-      tr.saltguidropdownmenu.verifyAll();
+      tr.dropdownmenu.verifyAll();
       this.panelMenu.verifyAll();
     } else if (this.table.querySelector("tr") === null) {
       // only when the full list is already available

--- a/saltgui/static/scripts/panels/Minions.js
+++ b/saltgui/static/scripts/panels/Minions.js
@@ -1,7 +1,6 @@
 /* global */
 
 import {Character} from "../Character.js";
-import {DropDownMenu} from "../DropDown.js";
 import {Panel} from "./Panel.js";
 import {Utils} from "../Utils.js";
 
@@ -23,7 +22,7 @@ export class MinionsPanel extends Panel {
     this._addMenuItemStateApplyTest(this.panelMenu, "*");
     this.addSearchButton();
     this.addWarningField();
-    this.addTable(["Minion", "Status", "Salt version", "OS version", "-menu-"]);
+    this.addTable(["-menu-", "Minion", "Status", "Salt version", "OS version"]);
     this.setTableSortable("Minion", "asc");
     this.setTableClickable("cmd");
     this.addMsg();
@@ -91,16 +90,15 @@ export class MinionsPanel extends Panel {
 
     const minionIds = keys.minions.sort();
     for (const minionId of minionIds) {
-      const minionTr = this.addMinion(minionId, 1);
+      const minionTr = this.addMinion(minionId);
 
       // preliminary dropdown menu
-      const menu = new DropDownMenu(minionTr, true);
-      this._addMenuItemStateApply(menu, minionId);
-      this._addMenuItemStateApplyTest(menu, minionId);
-      this._addMenuItemShowGrains(menu, minionId);
-      this._addMenuItemShowPillars(menu, minionId);
-      this._addMenuItemShowSchedules(menu, minionId);
-      this._addMenuItemShowBeacons(menu, minionId);
+      this._addMenuItemStateApply(minionTr.dropdownmenu, minionId);
+      this._addMenuItemStateApplyTest(minionTr.dropdownmenu, minionId);
+      this._addMenuItemShowGrains(minionTr.dropdownmenu, minionId);
+      this._addMenuItemShowPillars(minionTr.dropdownmenu, minionId);
+      this._addMenuItemShowSchedules(minionTr.dropdownmenu, minionId);
+      this._addMenuItemShowBeacons(minionTr.dropdownmenu, minionId);
     }
 
     this.updateFooter();
@@ -190,13 +188,12 @@ export class MinionsPanel extends Panel {
     super.updateMinion(pMinionData, pMinionId, pAllMinionsGrains);
 
     const minionTr = this.table.querySelector("#" + Utils.getIdFromMinionId(pMinionId));
-    const menu = new DropDownMenu(minionTr, true);
-    this._addMenuItemStateApply(menu, pMinionId);
-    this._addMenuItemStateApplyTest(menu, pMinionId);
-    this._addMenuItemShowGrains(menu, pMinionId);
-    this._addMenuItemShowPillars(menu, pMinionId);
-    this._addMenuItemShowSchedules(menu, pMinionId);
-    this._addMenuItemShowBeacons(menu, pMinionId);
+    this._addMenuItemStateApply(minionTr.dropdownmenu, pMinionId);
+    this._addMenuItemStateApplyTest(minionTr.dropdownmenu, pMinionId);
+    this._addMenuItemShowGrains(minionTr.dropdownmenu, pMinionId);
+    this._addMenuItemShowPillars(minionTr.dropdownmenu, pMinionId);
+    this._addMenuItemShowSchedules(minionTr.dropdownmenu, pMinionId);
+    this._addMenuItemShowBeacons(minionTr.dropdownmenu, pMinionId);
 
     minionTr.addEventListener("click", (pClickEvent) => {
       const cmdArr = ["state.apply"];

--- a/saltgui/static/scripts/panels/Nodegroups.js
+++ b/saltgui/static/scripts/panels/Nodegroups.js
@@ -17,7 +17,7 @@ export class NodegroupsPanel extends Panel {
     this.addSearchButton();
     this.addPlayPauseButton();
     this.addWarningField();
-    this.addTable(["Minion", "Status", "Salt version", "OS version", "-menu-"]);
+    this.addTable(["-menu-", "Minion", "Status", "Salt version", "OS version"]);
     this.setTableClickable("cmd");
     this.addMsg();
   }
@@ -118,8 +118,7 @@ export class NodegroupsPanel extends Panel {
       minionTr.appendChild(status);
       minionTr.appendChild(Utils.createTd());
       minionTr.appendChild(Utils.createTd());
-      const menu = new DropDownMenu(minionTr, true);
-      this._addMenuItemShowKeys(menu);
+      this._addMenuItemShowKeys(minionTr.dropdownmenu);
       minionTr.offline = true;
     }
 
@@ -148,16 +147,18 @@ export class NodegroupsPanel extends Panel {
 
       if (oldMenuButton) {
         oldMenuButton.parentElement.remove();
-        const menu = new DropDownMenu(minionTr2, true);
+        const newMenuButton = Utils.createTd();
+        minionTr2.insertBefore(newMenuButton, minionTr2.firstChild);
+        minionTr2.dropdownmenu = new DropDownMenu(newMenuButton, true);
         if (minionIsOk) {
-          this._addMenuItemStateApplyMinion(menu, pMinionId);
-          this._addMenuItemStateApplyTestMinion(menu, pMinionId);
-          this._addMenuItemShowGrains(menu, pMinionId);
-          this._addMenuItemShowPillars(menu, pMinionId);
-          this._addMenuItemShowSchedules(menu, pMinionId);
-          this._addMenuItemShowBeacons(menu, pMinionId);
+          this._addMenuItemStateApplyMinion(minionTr2.dropdownmenu, pMinionId);
+          this._addMenuItemStateApplyTestMinion(minionTr2.dropdownmenu, pMinionId);
+          this._addMenuItemShowGrains(minionTr2.dropdownmenu, pMinionId);
+          this._addMenuItemShowPillars(minionTr2.dropdownmenu, pMinionId);
+          this._addMenuItemShowSchedules(minionTr2.dropdownmenu, pMinionId);
+          this._addMenuItemShowBeacons(minionTr2.dropdownmenu, pMinionId);
         } else {
-          this._addMenuItemShowKeys(menu);
+          this._addMenuItemShowKeys(minionTr2.dropdownmenu);
         }
       }
 
@@ -192,7 +193,7 @@ export class NodegroupsPanel extends Panel {
         this._moveMinionToNodegroup(minionId, nodegroup, pWheelKeyListAllSimpleData);
       }
 
-      const titleElement = this.table.querySelector("#ng-" + nodegroup + " td");
+      const titleElement = this.table.querySelector("#ng-" + nodegroup + " td:nth-child(2)");
       const cnt = nodelist.length;
 
       let txt = Utils.txtZeroOneMany(cnt, "no minions", cnt + " minion", cnt + " minions");
@@ -301,6 +302,10 @@ export class NodegroupsPanel extends Panel {
     const tr = Utils.createTr("no-search", null, "ng-" + pNodegroup);
     tr.style.borderTop = "4px double #ddd";
 
+    const menuTd = Utils.createTd();
+    tr.dropdownmenu = new DropDownMenu(menuTd, true);
+    tr.appendChild(menuTd);
+
     const titleTd = Utils.createTd();
     if (pNodegroup) {
       titleTd.innerHTML = Character.EM_DASH + " nodegroup <b>" + pNodegroup + "</b> " + Character.EM_DASH + " (loading) " + Character.EM_DASH;
@@ -310,11 +315,8 @@ export class NodegroupsPanel extends Panel {
     titleTd.colSpan = 4;
     tr.append(titleTd);
 
-    const menuTd = Utils.createTd();
-    const menu = new DropDownMenu(menuTd, true);
-    this._addMenuItemStateApplyGroup(menu, pNodegroup, pAllNodegroups);
-    this._addMenuItemStateApplyTestGroup(menu, pNodegroup, pAllNodegroups);
-    tr.append(menuTd);
+    this._addMenuItemStateApplyGroup(tr.dropdownmenu, pNodegroup, pAllNodegroups);
+    this._addMenuItemStateApplyTestGroup(tr.dropdownmenu, pNodegroup, pAllNodegroups);
 
     tr.addEventListener("click", (pClickEvent) => {
       const cmdArr = ["state.apply"];
@@ -336,16 +338,15 @@ export class NodegroupsPanel extends Panel {
 
     const minionIds = keys.minions.sort();
     for (const minionId of minionIds) {
-      const minionTr = this.addMinion(minionId, 1);
+      const minionTr = this.addMinion(minionId);
 
       // preliminary dropdown menu
-      const menu = new DropDownMenu(minionTr, true);
-      this._addMenuItemStateApplyMinion(menu, minionId);
-      this._addMenuItemStateApplyTestMinion(menu, minionId);
-      this._addMenuItemShowGrains(menu, minionId);
-      this._addMenuItemShowPillars(menu, minionId);
-      this._addMenuItemShowSchedules(menu, minionId);
-      this._addMenuItemShowBeacons(menu, minionId);
+      this._addMenuItemStateApplyMinion(minionTr.dropdownmenu, minionId);
+      this._addMenuItemStateApplyTestMinion(minionTr.dropdownmenu, minionId);
+      this._addMenuItemShowGrains(minionTr.dropdownmenu, minionId);
+      this._addMenuItemShowPillars(minionTr.dropdownmenu, minionId);
+      this._addMenuItemShowSchedules(minionTr.dropdownmenu, minionId);
+      this._addMenuItemShowBeacons(minionTr.dropdownmenu, minionId);
     }
 
     this.updateFooter();
@@ -355,13 +356,12 @@ export class NodegroupsPanel extends Panel {
     super.updateMinion(pMinionData, pMinionId, pAllNodegroupsGrains);
 
     const minionTr = this.table.querySelector("#" + Utils.getIdFromMinionId(pMinionId));
-    const menu = new DropDownMenu(minionTr, true);
-    this._addMenuItemStateApplyMinion(menu, pMinionId);
-    this._addMenuItemStateApplyTestMinion(menu, pMinionId);
-    this._addMenuItemShowGrains(menu, pMinionId);
-    this._addMenuItemShowPillars(menu, pMinionId);
-    this._addMenuItemShowSchedules(menu, pMinionId);
-    this._addMenuItemShowBeacons(menu, pMinionId);
+    this._addMenuItemStateApplyMinion(minionTr.dropdownmenu, pMinionId);
+    this._addMenuItemStateApplyTestMinion(minionTr.dropdownmenu, pMinionId);
+    this._addMenuItemShowGrains(minionTr.dropdownmenu, pMinionId);
+    this._addMenuItemShowPillars(minionTr.dropdownmenu, pMinionId);
+    this._addMenuItemShowSchedules(minionTr.dropdownmenu, pMinionId);
+    this._addMenuItemShowBeacons(minionTr.dropdownmenu, pMinionId);
 
     minionTr.addEventListener("click", (pClickEvent) => {
       const cmdArr = ["state.apply"];

--- a/saltgui/static/scripts/panels/Panel.js
+++ b/saltgui/static/scripts/panels/Panel.js
@@ -392,6 +392,12 @@ export class Panel {
     minionTr.id = Utils.getIdFromMinionId(pMinionId);
     minionTr.dataset.minionId = pMinionId;
 
+    // drop down menu
+    const menuTd = Utils.createTd();
+    const menu = new DropDownMenu(menuTd, true);
+    minionTr.dropdownmenu = menu;
+    minionTr.appendChild(menuTd);
+
     minionTr.appendChild(Utils.createTd("minion-id", pMinionId));
 
     const minionTd = Utils.createTd(["status", "accepted"], "accepted");
@@ -425,6 +431,12 @@ export class Panel {
     while (minionTr.firstChild) {
       minionTr.removeChild(minionTr.firstChild);
     }
+
+    // drop down menu
+    const menuTd = Utils.createTd();
+    const menu = new DropDownMenu(menuTd, true);
+    minionTr.dropdownmenu = menu;
+    minionTr.appendChild(menuTd);
 
     return minionTr;
   }

--- a/saltgui/static/scripts/panels/Pillars.js
+++ b/saltgui/static/scripts/panels/Pillars.js
@@ -1,6 +1,5 @@
 /* global */
 
-import {DropDownMenu} from "../DropDown.js";
 import {Panel} from "./Panel.js";
 import {Utils} from "../Utils.js";
 
@@ -12,7 +11,7 @@ export class PillarsPanel extends Panel {
     this.addTitle("Pillars");
     this.addSearchButton();
     this.addWarningField();
-    this.addTable(["Minion", "Status", "Pillars", "-menu-"]);
+    this.addTable(["-menu-", "Minion", "Status", "Pillars"]);
     this.setTableSortable("Minion", "asc");
     this.setTableClickable("page");
     this.addMsg();
@@ -56,11 +55,10 @@ export class PillarsPanel extends Panel {
 
     const minionIds = keys.minions.sort();
     for (const minionId of minionIds) {
-      const minionTr = this.addMinion(minionId, 1);
+      const minionTr = this.addMinion(minionId);
 
       // preliminary dropdown menu
-      const menu = new DropDownMenu(minionTr, true);
-      this._addMenuItemShowPillars(menu, minionId);
+      this._addMenuItemShowPillars(minionTr.dropdownmenu, minionId);
 
       minionTr.addEventListener("click", (pClickEvent) => {
         this.router.goTo("pillars-minion", {"minionid": minionId}, undefined, pClickEvent);
@@ -103,8 +101,7 @@ export class PillarsPanel extends Panel {
     }
     minionTr.appendChild(pillarInfoTd);
 
-    const menu = new DropDownMenu(minionTr, true);
-    this._addMenuItemShowPillars(menu, pMinionId);
+    this._addMenuItemShowPillars(minionTr.dropdownmenu, pMinionId);
   }
 
   _addMenuItemShowPillars (pMenu, pMinionId) {

--- a/saltgui/static/scripts/panels/Schedules.js
+++ b/saltgui/static/scripts/panels/Schedules.js
@@ -1,6 +1,5 @@
 /* global */
 
-import {DropDownMenu} from "../DropDown.js";
 import {Panel} from "./Panel.js";
 import {Utils} from "../Utils.js";
 
@@ -11,7 +10,7 @@ export class SchedulesPanel extends Panel {
 
     this.addTitle("Schedules");
     this.addSearchButton();
-    this.addTable(["Minion", "Status", "Schedules", "-menu-"]);
+    this.addTable(["-menu-", "Minion", "Status", "Schedules"]);
     this.setTableSortable("Minion", "asc");
     this.setTableClickable("page");
     this.addMsg();
@@ -86,11 +85,10 @@ export class SchedulesPanel extends Panel {
 
     const minionIds = keys.minions.sort();
     for (const minionId of minionIds) {
-      const minionTr = this.addMinion(minionId, 1);
+      const minionTr = this.addMinion(minionId);
 
       // preliminary dropdown menu
-      const menu = new DropDownMenu(minionTr, true);
-      this._addMenuItemShowSchedules(menu, minionId);
+      this._addMenuItemShowSchedules(minionTr.dropdownmenu, minionId);
 
       minionTr.addEventListener("click", (pClickEvent) => {
         this.router.goTo("schedules-minion", {"minionid": minionId}, undefined, pClickEvent);
@@ -146,8 +144,7 @@ export class SchedulesPanel extends Panel {
     minionTr.appendChild(td);
 
     // final dropdownmenu
-    const menu = new DropDownMenu(minionTr, true);
-    this._addMenuItemShowSchedules(menu, pMinionId);
+    this._addMenuItemShowSchedules(minionTr.dropdownmenu, pMinionId);
   }
 
   _addMenuItemShowSchedules (pMenu, pMinionId) {

--- a/saltgui/static/scripts/panels/SchedulesMinion.js
+++ b/saltgui/static/scripts/panels/SchedulesMinion.js
@@ -23,7 +23,7 @@ export class SchedulesMinionPanel extends Panel {
     if (Utils.getQueryParam("popup") !== "true") {
       this.addCloseButton();
     }
-    this.addTable(["Name", "-menu-", "Details"]);
+    this.addTable(["-menu-", "Name", "Details"]);
     this.setTableSortable("Name", "asc");
     this.setTableClickable("cmd");
     this.addMsg();
@@ -95,10 +95,11 @@ export class SchedulesMinionPanel extends Panel {
 
       const tr = Utils.createTr();
 
+      const scheduleMenu = new DropDownMenu(tr, true);
+
       const nameTd = Utils.createTd("schedule-name", scheduleName);
       tr.appendChild(nameTd);
 
-      const scheduleMenu = new DropDownMenu(tr, true);
       const scheduleModifyCmdArr = ["schedule.modify", scheduleName];
       for (const key in schedule) {
         const value = schedule[key];

--- a/saltgui/static/scripts/panels/Templates.js
+++ b/saltgui/static/scripts/panels/Templates.js
@@ -12,7 +12,7 @@ export class TemplatesPanel extends Panel {
 
     this.addTitle("Templates");
     this.addSearchButton();
-    this.addTable(["Name", "Category", "Key", "Description", "Target", "Command", "-menu-"], "data-list-templates");
+    this.addTable(["-menu-", "Name", "Category", "Key", "Description", "Target", "Command"], "data-list-templates");
     this.setTableSortable("Name", "asc");
     this.setTableClickable("cmd");
     this.addMsg();
@@ -113,6 +113,8 @@ export class TemplatesPanel extends Panel {
   _addTemplate (pTemplateName, template) {
     const tr = Utils.createTr();
 
+    const menu = new DropDownMenu(tr, true);
+
     tr.appendChild(Utils.createTd("name", pTemplateName));
 
     const categories = TemplatesPanel.getTemplateCategories(template);
@@ -166,7 +168,6 @@ export class TemplatesPanel extends Panel {
       tr.appendChild(Utils.createTd("command value-none", "(none)"));
     }
 
-    const menu = new DropDownMenu(tr, true);
     this._addMenuItemApplyTemplate(menu, targetType, target, command);
 
     const tbody = this.table.tBodies[0];


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
in-table dropdown menus currently are mostly at the end of the row. Unless a potentially big last column is present, in which case the menu is moved one column to the second-to last position (possibly third-to-last, etc).
for task items, often the dropdown menu is off-window

**Describe the solution you'd like**
Move all in-table dropdown menus to the start of their row.

**Additional context**
This also improves consistency...