### PR TITLE
Showing output automatically upon completion and animated icon

### DIFF
--- a/saltgui/static/scripts/DropDown.js
+++ b/saltgui/static/scripts/DropDown.js
@@ -24,7 +24,7 @@ export class DropDownMenu {
 
   // Creates an empty dropdown menu
   // The visual clue for the menu is added to the given element
-  constructor (pParentElement, pIsSmall) {
+  constructor (pParentElement, pStyle) {
 
     // allow reduced code on the caller side
     if (pParentElement.tagName === "TR") {
@@ -48,8 +48,8 @@ export class DropDownMenu {
       this.menuButton = Utils.createDiv("", Character.CH_HAMBURGER);
     }
     this.menuButton.classList.add("small-button", "small-button-for-hover", "menu-dropdown");
-    if (pIsSmall) {
-      this.menuButton.classList.add("small-small-button");
+    if (pStyle) {
+      this.menuButton.classList.add(pStyle + "-small-button");
     }
     this.menuButton.addEventListener("click", (pClickEvent) => {
       // better support for touch screens where user touch

--- a/saltgui/static/scripts/Utils.js
+++ b/saltgui/static/scripts/Utils.js
@@ -257,7 +257,7 @@ export class Utils {
 
     const menuAndFieldDiv = Utils.createDiv("search-menu-and-field", "");
 
-    const searchOptionsMenu = new DropDownMenu(menuAndFieldDiv, true);
+    const searchOptionsMenu = new DropDownMenu(menuAndFieldDiv, "smaller");
 
     const input = Utils.createElem("input", "filter-text");
     input.type = "text";

--- a/saltgui/static/scripts/issues/Issues.js
+++ b/saltgui/static/scripts/issues/Issues.js
@@ -49,7 +49,7 @@ export class Issues {
 
     const theTr = Utils.createTr();
 
-    const menu = new DropDownMenu(theTr, true);
+    const menu = new DropDownMenu(theTr, "smaller");
     theTr.menu = menu;
 
     const descTd = Utils.createTd();

--- a/saltgui/static/scripts/panels/BeaconsMinion.js
+++ b/saltgui/static/scripts/panels/BeaconsMinion.js
@@ -141,7 +141,7 @@ export class BeaconsMinionPanel extends Panel {
     for (const beaconName of keys) {
       const tr = Utils.createTr("", "", "beacon-" + beaconName);
 
-      const beaconMenu = new DropDownMenu(tr, true);
+      const beaconMenu = new DropDownMenu(tr, "smaller");
 
       const nameTd = Utils.createTd("beacon-name", beaconName);
       tr.appendChild(nameTd);

--- a/saltgui/static/scripts/panels/GrainsMinion.js
+++ b/saltgui/static/scripts/panels/GrainsMinion.js
@@ -69,7 +69,7 @@ export class GrainsMinionPanel extends Panel {
     for (const grainName of grainNames) {
       const grainTr = Utils.createTr();
 
-      const grainMenu = new DropDownMenu(grainTr, true);
+      const grainMenu = new DropDownMenu(grainTr, "smaller");
 
       const grainNameTd = Utils.createTd("grain-name", grainName);
       grainTr.appendChild(grainNameTd);

--- a/saltgui/static/scripts/panels/Job.js
+++ b/saltgui/static/scripts/panels/Job.js
@@ -525,7 +525,7 @@ export class JobPanel extends Panel {
         // show that this minion is still active on the request
         noResponseSpan.innerText = "(active) ";
 
-        const menu = new DropDownMenu(noResponseSpan, "smaller");
+        const menu = new DropDownMenu(noResponseSpan, "verysmall");
         menu.addMenuItem("Show process info...", () => {
           const cmdArr = ["ps.proc_info", pid];
           this.runCommand("", minionId, cmdArr);

--- a/saltgui/static/scripts/panels/Job.js
+++ b/saltgui/static/scripts/panels/Job.js
@@ -525,7 +525,7 @@ export class JobPanel extends Panel {
         // show that this minion is still active on the request
         noResponseSpan.innerText = "(active) ";
 
-        const menu = new DropDownMenu(noResponseSpan, true);
+        const menu = new DropDownMenu(noResponseSpan, "smaller");
         menu.addMenuItem("Show process info...", () => {
           const cmdArr = ["ps.proc_info", pid];
           this.runCommand("", minionId, cmdArr);

--- a/saltgui/static/scripts/panels/Job.js
+++ b/saltgui/static/scripts/panels/Job.js
@@ -19,6 +19,7 @@ export class JobPanel extends Panel {
     }
     this.addPanelMenu();
     this.addSearchButton();
+    this.addPlayPauseButton();
 
     // 1: re-run with original target pattern
     this._addPanelMenuItemJobRerunJob();
@@ -57,6 +58,21 @@ export class JobPanel extends Panel {
     this.div.append(this.output);
   }
 
+  _scheduleRefreshJob () {
+    const jobsActiveSpan = document.getElementById("summary-jobs-active");
+    if (jobsActiveSpan && jobsActiveSpan.innerText === "done") {
+console.log("DONE");
+      // no updates after "done"
+      return;
+    }
+
+console.log("scheduling onShow in 5s");
+    window.setTimeout(() => {
+console.log("running onShow");
+      this.onShow();
+    }, 5000);
+  }
+
   onShow () {
     const jobId = decodeURIComponent(Utils.getQueryParam("id"));
     const minionId = decodeURIComponent(Utils.getQueryParam("minionid"));
@@ -70,6 +86,7 @@ export class JobPanel extends Panel {
       this._handleJobRunnerJobsListJob(pRunnerJobsListJobData, jobId, minionId);
       runnerJobsActivePromise.then((pRunnerJobsActiveData) => {
         this._handleRunnerJobsActive(jobId, pRunnerJobsActiveData);
+        this._scheduleRefreshJob();
         return true;
       }, (pRunnerJobsActiveMsg) => {
         this._handleRunnerJobsActive(jobId, JSON.stringify(pRunnerJobsActiveMsg));

--- a/saltgui/static/scripts/panels/JobsDetails.js
+++ b/saltgui/static/scripts/panels/JobsDetails.js
@@ -337,7 +337,7 @@ export class JobsDetailsPanel extends JobsPanel {
     tr.id = Utils.getIdFromJobId(job.id);
     tr.dataset.jobid = job.id;
 
-    const menu = new DropDownMenu(tr, true);
+    const menu = new DropDownMenu(tr, "smaller");
 
     tr.appendChild(Utils.createTd("", job.id));
 

--- a/saltgui/static/scripts/panels/JobsSummary.js
+++ b/saltgui/static/scripts/panels/JobsSummary.js
@@ -37,7 +37,7 @@ export class JobsSummaryPanel extends JobsPanel {
     tr.id = Utils.getIdFromJobId(job.id);
 
     // menu on left side to prevent it from going past end of window
-    const menu = new DropDownMenu(tr, true);
+    const menu = new DropDownMenu(tr, "smaller");
 
     const td = Utils.createTd();
 

--- a/saltgui/static/scripts/panels/Nodegroups.js
+++ b/saltgui/static/scripts/panels/Nodegroups.js
@@ -149,7 +149,7 @@ export class NodegroupsPanel extends Panel {
         oldMenuButton.parentElement.remove();
         const newMenuButton = Utils.createTd();
         minionTr2.insertBefore(newMenuButton, minionTr2.firstChild);
-        minionTr2.dropdownmenu = new DropDownMenu(newMenuButton, true);
+        minionTr2.dropdownmenu = new DropDownMenu(newMenuButton, "smaller");
         if (minionIsOk) {
           this._addMenuItemStateApplyMinion(minionTr2.dropdownmenu, pMinionId);
           this._addMenuItemStateApplyTestMinion(minionTr2.dropdownmenu, pMinionId);
@@ -303,7 +303,7 @@ export class NodegroupsPanel extends Panel {
     tr.style.borderTop = "4px double #ddd";
 
     const menuTd = Utils.createTd();
-    tr.dropdownmenu = new DropDownMenu(menuTd, true);
+    tr.dropdownmenu = new DropDownMenu(menuTd, "smaller");
     tr.appendChild(menuTd);
 
     const titleTd = Utils.createTd();

--- a/saltgui/static/scripts/panels/Panel.js
+++ b/saltgui/static/scripts/panels/Panel.js
@@ -394,7 +394,7 @@ export class Panel {
 
     // drop down menu
     const menuTd = Utils.createTd();
-    const menu = new DropDownMenu(menuTd, true);
+    const menu = new DropDownMenu(menuTd, "smaller");
     minionTr.dropdownmenu = menu;
     minionTr.appendChild(menuTd);
 
@@ -434,7 +434,7 @@ export class Panel {
 
     // drop down menu
     const menuTd = Utils.createTd();
-    const menu = new DropDownMenu(menuTd, true);
+    const menu = new DropDownMenu(menuTd, "smaller");
     minionTr.dropdownmenu = menu;
     minionTr.appendChild(menuTd);
 

--- a/saltgui/static/scripts/panels/SchedulesMinion.js
+++ b/saltgui/static/scripts/panels/SchedulesMinion.js
@@ -95,7 +95,7 @@ export class SchedulesMinionPanel extends Panel {
 
       const tr = Utils.createTr();
 
-      const scheduleMenu = new DropDownMenu(tr, true);
+      const scheduleMenu = new DropDownMenu(tr, "smaller");
 
       const nameTd = Utils.createTd("schedule-name", scheduleName);
       tr.appendChild(nameTd);

--- a/saltgui/static/scripts/panels/Templates.js
+++ b/saltgui/static/scripts/panels/Templates.js
@@ -113,7 +113,7 @@ export class TemplatesPanel extends Panel {
   _addTemplate (pTemplateName, template) {
     const tr = Utils.createTr();
 
-    const menu = new DropDownMenu(tr, true);
+    const menu = new DropDownMenu(tr, "smaller");
 
     tr.appendChild(Utils.createTd("name", pTemplateName));
 

--- a/saltgui/static/stylesheets/main.css
+++ b/saltgui/static/stylesheets/main.css
@@ -131,6 +131,15 @@ h1 {
   min-width: 0;
 }
 
+.verysmall-small-button {
+  padding-left: 5px;
+  padding-right: 5px;
+  min-width: 0;
+  display: inherit;
+  font-size: inherit;
+  height: inherit;
+}
+
 .small-button-left {
   margin-right: 10px;
 }

--- a/saltgui/static/stylesheets/main.css
+++ b/saltgui/static/stylesheets/main.css
@@ -125,7 +125,7 @@ h1 {
   padding-right: 10px;
 }
 
-.small-small-button {
+.smaller-small-button {
   padding-left: 5px;
   padding-right: 5px;
   min-width: 0;


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
I find it annoying when I'm waiting for a state/highstate to complete but all I get is a little reload icon color to see if it's done.
![image](https://github.com/erwindon/SaltGUI/assets/8518567/a432b824-2b48-43d7-ab99-939823d4a169)

**Describe the solution you'd like**
I think the arrow icon should rotate or be animated when running and then, instead of changing to green or red based on the result, it should simply display the output automatically without having to click on it...

**Describe alternatives you've considered**
Any kind of animated icon that shows it is still in progress, but for showing the output, I don't see why it wouldn't be that way. There is a callback making the icon change color so it should probably be simple enough to make the call to show the output. Something that is always wanted.

It could be an option in the advanced section as well to please everyone.

**Additional context**
I'm using SaltGUI on a lot of minions and the less click I do, the happier I am! This is clearly a polishing feature, but those features could make this tool production ready.

Thanks a lot!