### PR TITLE
timers are not always stopped when leaving a page

### DIFF
--- a/saltgui/static/scripts/issues/State.js
+++ b/saltgui/static/scripts/issues/State.js
@@ -65,7 +65,7 @@ export class StateIssues extends Issues {
       jobs = jobs.slice(0, MAX_HIGHSTATE_JOBS);
     }
 
-    this.jobs = jobs;
+    pPanel.jobs = jobs;
     // this is good only while "State" is the only issue-provider that uses play/pause
     pPanel.setPlayPauseButton(jobs.length === 0 ? "none" : "play");
 
@@ -73,31 +73,33 @@ export class StateIssues extends Issues {
   }
 
   _updateNextJob (pPanel, pMsg, pKeys) {
-    if (!this.jobs) {
+    if (!pPanel.jobs) {
       return;
     }
-    if (!this.jobs.length) {
+    if (!pPanel.jobs.length) {
       // this is good only while "State" is the only issue-provider
       pPanel.setPlayPauseButton("none");
-      this.jobs = null;
+      pPanel.jobs = null;
       Issues.readyCategory(pPanel, pMsg);
       return;
     }
 
     if (pPanel.playOrPause !== "play") {
-      window.setTimeout(() => {
+      pPanel.issuesStateTimeout = window.setTimeout(() => {
+        pPanel.issuesStateTimeout = null;
         this._updateNextJob(pPanel, pMsg, pKeys);
       }, 1000);
       return;
     }
 
-    const job = this.jobs.pop();
+    const job = pPanel.jobs.pop();
 
     const runnerJobsListJobPromise = this.api.getRunnerJobsListJob(job.id);
 
     runnerJobsListJobPromise.then((pRunnerJobsListJobData) => {
       StateIssues._handleJobRunnerJobsListJob(pPanel, pRunnerJobsListJobData, pKeys);
-      window.setTimeout(() => {
+      pPanel.issuesStateTimeout = window.setTimeout(() => {
+        pPanel.issuesStateTimeout = null;
         this._updateNextJob(pPanel, pMsg, pKeys);
       }, 100);
       return true;

--- a/saltgui/static/scripts/pages/HighState.js
+++ b/saltgui/static/scripts/pages/HighState.js
@@ -23,4 +23,8 @@ export class HighStatePage extends Page {
       this.jobs.handleSaltJobRetEvent(pData);
     }
   }
+
+  onHide () {
+    this.highstate.onHide();
+  }
 }

--- a/saltgui/static/scripts/pages/Issues.js
+++ b/saltgui/static/scripts/pages/Issues.js
@@ -23,4 +23,8 @@ export class IssuesPage extends Page {
       this.jobs.handleSaltJobRetEvent(pData);
     }
   }
+
+  onHide () {
+    this.issues.onHide();
+  }
 }

--- a/saltgui/static/scripts/pages/Job.js
+++ b/saltgui/static/scripts/pages/Job.js
@@ -15,4 +15,8 @@ export class JobPage extends Page {
   handleSaltJobRetEvent (pData) {
     this.job.handleSaltJobRetEvent(pData);
   }
+
+  onHide () {
+    this.job.onHide();
+  }
 }

--- a/saltgui/static/scripts/pages/Jobs.js
+++ b/saltgui/static/scripts/pages/Jobs.js
@@ -15,4 +15,8 @@ export class JobsPage extends Page {
   handleSaltJobRetEvent (pData) {
     this.jobs.handleSaltJobRetEvent(pData);
   }
+
+  onHide () {
+    this.jobs.onHide();
+  }
 }

--- a/saltgui/static/scripts/pages/Logout.js
+++ b/saltgui/static/scripts/pages/Logout.js
@@ -12,7 +12,7 @@ export class LogoutPage extends Page {
   onRegister () {
     // don't verify for invalid sessions too often
     // this happens only when the server was reset
-    this.logoutTimer = window.setInterval(() => {
+    this.logoutInterval = window.setInterval(() => {
       this._logoutTimer();
     }, 60000);
 
@@ -51,9 +51,9 @@ export class LogoutPage extends Page {
         // not to any regular api functions
         // may happen due to https://github.com/saltstack/salt/issues/59620
         // repeating this is not so useful
-        if (this.logoutTimer) {
-          clearInterval(this.logoutTimer);
-          this.logoutTimer = null;
+        if (this.logoutInterval) {
+          clearInterval(this.logoutInterval);
+          this.logoutInterval = null;
         }
         return;
       }

--- a/saltgui/static/scripts/pages/Nodegroups.js
+++ b/saltgui/static/scripts/pages/Nodegroups.js
@@ -31,4 +31,8 @@ export class NodegroupsPage extends Page {
     const nodegroups = Utils.getStorageItemObject("session", "nodegroups");
     return Object.keys(nodegroups).length > 0;
   }
+
+  onHide () {
+    this.nodegroups.onHide();
+  }
 }

--- a/saltgui/static/scripts/panels/HighState.js
+++ b/saltgui/static/scripts/panels/HighState.js
@@ -85,6 +85,14 @@ export class HighStatePanel extends Panel {
     });
   }
 
+  onHide () {
+    if (this.nextJobTimeout) {
+      // stop the timer when nobody is looking
+      window.clearTimeout(this.nextJobTimeout);
+      this.nextJobTimeout = null;
+    }
+  }
+
   _addMenuItemStateApply (pMenu, pMinionId) {
     pMenu.addMenuItem("Apply state...", () => {
       const cmdArr = ["state.apply"];
@@ -205,7 +213,8 @@ export class HighStatePanel extends Panel {
       this._handleJob(job);
     }
 
-    window.setTimeout(() => {
+    this.nextJobTimeout = window.setTimeout(() => {
+      this.nextJobTimeout = null;
       this._updateNextJob();
     }, 1000);
   }

--- a/saltgui/static/scripts/panels/Issues.js
+++ b/saltgui/static/scripts/panels/Issues.js
@@ -66,4 +66,15 @@ export class IssuesPanel extends Panel {
       Utils.addToolTip(this.msgDiv, pErrorMsg);
     });
   }
+
+  onHide () {
+    // from StateIssues
+    this.jobs = null;
+
+    if (this.issuesStateTimeout) {
+      // stop the timer when nobody is looking
+      window.clearTimeout(this.issuesStateTimeout);
+      this.issuesStateTimeout = null;
+    }
+  }
 }

--- a/saltgui/static/scripts/panels/Job.js
+++ b/saltgui/static/scripts/panels/Job.js
@@ -74,7 +74,8 @@ export class JobPanel extends Panel {
       return;
     }
 
-    window.setTimeout(() => {
+    this.refreshJobTimeout = window.setTimeout(() => {
+      this.refreshJobTimeout = null;
       if (this.playOrPause === "play") {
         this.onShow();
       } else {
@@ -116,6 +117,14 @@ export class JobPanel extends Panel {
       jobRefresh = "pause";
     }
     this.setPlayPauseButton(jobRefresh);
+  }
+
+  onHide () {
+    if (this.refreshJobTimeout) {
+      // stop the timer when nobody is looking
+      window.clearTimeout(this.refreshJobTimeout);
+      this.refreshJobTimeout = null;
+    }
   }
 
   static _isResultOk (result) {

--- a/saltgui/static/scripts/panels/JobsDetails.js
+++ b/saltgui/static/scripts/panels/JobsDetails.js
@@ -64,6 +64,14 @@ export class JobsDetailsPanel extends JobsPanel {
     super.onShow(cnt);
   }
 
+  onHide () {
+    if (this.updateNextJobInterval) {
+      // stop the timer when nobody is looking
+      window.clearInterval(this.updateNextJobInterval);
+      this.updateNextJobInterval = null;
+    }
+  }
+
   jobsListIsReady () {
     this.nrErrors = 0;
 
@@ -185,6 +193,7 @@ export class JobsDetailsPanel extends JobsPanel {
       // only update one item at a time
       return;
     }
+
     if (!workLeft) {
       this.setPlayPauseButton("none");
       this.updateFooter();

--- a/saltgui/static/scripts/panels/Nodegroups.js
+++ b/saltgui/static/scripts/panels/Nodegroups.js
@@ -43,7 +43,8 @@ export class NodegroupsPanel extends Panel {
 
       localGrainsItemsPromise.then((pLocalGrainsItemsData) => {
         this.updateMinions(pLocalGrainsItemsData);
-        window.setTimeout(() => {
+        this.nodeGroupTimeout = window.setTimeout(() => {
+          this.nodeGroupTimeout = null;
           this._handleStep(pWheelKeyListAllData.return[0].data.return);
         }, 100);
         return true;
@@ -59,6 +60,14 @@ export class NodegroupsPanel extends Panel {
       Utils.ignorePromise(localGrainsItemsPromise);
       return false;
     });
+  }
+
+  onHide () {
+    if (this.nodeGroupTimeout) {
+      // stop the timer when nobody is looking
+      window.clearTimeout(this.nodeGroupTimeout);
+      this.nodeGroupTimeout = null;
+    }
   }
 
   updateFooter () {
@@ -222,7 +231,8 @@ export class NodegroupsPanel extends Panel {
       titleElement.innerHTML = titleElement.innerHTML.replace("(loading)", txt);
 
       // try again for more
-      window.setTimeout(() => {
+      this.nodeGroupTimeout = window.setTimeout(() => {
+        this.nodeGroupTimeout = null;
         this._handleStep(pWheelKeyListAllSimpleData);
       }, 100);
     }, (pLocalTestVersionMsg) => {
@@ -271,7 +281,8 @@ export class NodegroupsPanel extends Panel {
     // system can decide to remove the play/pause button
     if (this.playOrPause !== "play") {
       // try again later for more
-      window.setTimeout(() => {
+      this.nodeGroupTimeout = window.setTimeout(() => {
+        this.nodeGroupTimeout = null;
         this._handleStep(pWheelKeyListAllSimpleData);
       }, 100);
       return;

--- a/saltgui/static/scripts/panels/Options.js
+++ b/saltgui/static/scripts/panels/Options.js
@@ -278,14 +278,6 @@ export class OptionsPanel extends Panel {
     }
   }
 
-  onHide () {
-    if (this.updateExpiresTimer) {
-      // stop the timer when noone is looking
-      window.clearInterval(this.updateExpiresTimer);
-      this.updateExpiresTimer = null;
-    }
-  }
-
   onShow () {
     // build the controls for all options
     for (const option of this.options) {
@@ -332,7 +324,7 @@ export class OptionsPanel extends Panel {
       }
 
       if (category === "session" && name === "expire") {
-        this.updateExpiresTimer = window.setInterval(() => {
+        this.updateExpiresInterval = window.setInterval(() => {
           // just redo the whole text-block
           OptionsPanel._enhanceSessionExpire(td, value, sessionStart);
         }, 1000);
@@ -374,6 +366,14 @@ export class OptionsPanel extends Panel {
           }
         }
       }
+    }
+  }
+
+  onHide () {
+    if (this.updateExpiresInterval) {
+      // stop the timer when nobody is looking
+      window.clearInterval(this.updateExpiresInterval);
+      this.updateExpiresInterval = null;
     }
   }
 

--- a/saltgui/static/scripts/panels/Stats.js
+++ b/saltgui/static/scripts/panels/Stats.js
@@ -33,7 +33,7 @@ export class StatsPanel extends Panel {
 
     this.onShowNow();
 
-    this.updateStatsTimer = window.setInterval(() => {
+    this.updateStatsInterval = window.setInterval(() => {
       this.onShowNow();
     }, 5000);
   }
@@ -51,10 +51,10 @@ export class StatsPanel extends Panel {
   }
 
   onHide () {
-    if (this.updateStatsTimer) {
-      // stop the timer when noone is looking
-      window.clearInterval(this.updateStatsTimer);
-      this.updateStatsTimer = null;
+    if (this.updateStatsInterval) {
+      // stop the timer when nobody is looking
+      window.clearInterval(this.updateStatsInterval);
+      this.updateStatsInterval = null;
     }
   }
 
@@ -70,8 +70,8 @@ export class StatsPanel extends Panel {
   _handleStats (pStatsData) {
     if (this.showErrorRowInstead(pStatsData)) {
       this.statsTd.innerHTML = "<span style='color:red'>this error is typically caused by using the <tt>collect_stats: True</tt> setting in the master configuration file, which is broken in at least the recent versions of salt-api</span>";
-      window.clearInterval(this.updateStatsTimer);
-      this.updateStatsTimer = null;
+      window.clearInterval(this.updateStatsInterval);
+      this.updateStatsInterval = null;
       return;
     }
 


### PR DESCRIPTION
**Describe the bug**
When leaving a page, the associated timer-sequence continues.
In some cases, returning to the page starts a new timer, causing multiple timers to be active.

**To Reproduce**
tbd

**Expected behaviour**
Page/panel-related timers must be stopped when leaving the page.
See e.g. `options.js`. function `onHide`.

**Additional context**
one positive factor: most timer-sequences are not infinite sequences.

proposal to create panelTimerHelper function.
timer is registered in Panel.
timer is disabled when `isFinished`=true, or when `onHide` is called
parameters:
* actionCallback function
* runFirstTime flag, runs the callback extra immediately
* isFinished function, signals that no more runs are needed
* isSkipped function, signals that this run is not needed
* playPause setting is always considered for skipping the function
* playPause will be hidden when `isFinished`=true