### PR TITLE
saltgui_preview_grains: Improvement

### DIFF
--- a/saltgui/static/stylesheets/grains.css
+++ b/saltgui/static/stylesheets/grains.css
@@ -1,5 +1,6 @@
 td.grain-value {
   white-space: pre-wrap;
+  word-break: keep-all;
 }
 
 #page-grains {


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Will be really nice to have better visualization of grains that contain list of values (strings), for example:
![image](https://github.com/erwindon/SaltGUI/assets/169650065/1ce74210-4a56-45f3-9770-04a61033c07c)
```
# salt salt-master grains.get roles
salt-master:
    - salt-master
    - salt-minion
```
```
salt-master-custom.conf:
...
saltgui_preview_grains:
  - Roles=roles    
  - Roles2=$.roles.[*]
  - Roles3=$.roles[*]
```

**Describe the solution you'd like**
Instead:
```
[
    "salt-master",
    "salt-minion"
]
```
will be nice to have a list separated by `\n` I guess (without brackets and quotes):
```
salt-master
salt-minion
```