### PR TITLE
add support for orchestrations

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,0 +1,12 @@
+Branch zzz-orchestrate
+("zzz" to move it to the bottom of the list)
+PoC for supporting the orchestration mechanism
+
+PRO:
+* previously, orchestrations were not supported
+
+CON:
+* so far, no one really need this
+
+VERDICT:
+Keep until there is an actual request for it

--- a/docs/README.md
+++ b/docs/README.md
@@ -347,6 +347,22 @@ saltgui_hide_saltenvs:
 Typically only one of these variables should be set.
 Jobs that were started without the `saltenv` parameter are, for this purpose only, assumed to use the value `default` for this parameter. This allows these jobs to be hidden/showed using the same mechanism. SaltGUI does not replicate the internal logic of the salt-master and/or the salt-minion to determine which saltenv would actually have been used for such jobs.
 
+## Orchestrations
+The Orchestrations page shows the available orchestrations with their steps. Name, target and function are listed in separate columns.
+All other details will be visible in the details column. The steps are listed in priority order.
+But note that additional dependencies may cause an alternative execution sequence.
+
+In the configuration files, SaltStack does not clearly distingish between state-configuration and orchestration-configuration.
+SaltGUI only shows information that has the orechestration format.
+
+An orchestration can be executed. The output resembles the output of highstate commands, but now each step is a whole salt command instead of a state.
+Since the orchestration is run by the salt-master, the results are organized for only this host.
+Note that SaltStack uses a slightly different minion-name for that.
+
+Note that each stage is started as a separate job. Neither SaltStack, nor SaltGUI, has information available to somehow group the results.
+
+Unlike the highstate system, there are no events available in the SaltStack that can be used to track the progress of an orchestration.
+
 ## Issues
 The Issues page provides an overview of the system and reports any issues.
 When no issues are found, the list remains empty.

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,7 @@ such as `yubico_client`, or execution modules such as `boto3_sns`.
 - Keyboard control for top-level navigation
 - Keyboard control to apply templates
 - Choose between live info and cached info for grains/pillar
+- View details of orchestrations and allow to start them
 
 
 ## Quick start using PAM as authentication method
@@ -353,9 +354,9 @@ All other details will be visible in the details column. The steps are listed in
 But note that additional dependencies may cause an alternative execution sequence.
 
 In the configuration files, SaltStack does not clearly distingish between state-configuration and orchestration-configuration.
-SaltGUI only shows information that has the orechestration format.
+SaltGUI only shows information that has the orchestration format.
 
-An orchestration can be executed. The output resembles the output of highstate commands, but now each step is a whole salt command instead of a state.
+An orchestration can be executed or tested. The output resembles the output of highstate commands, but now each step is a whole salt command instead of a state.
 Since the orchestration is run by the salt-master, the results are organized for only this host.
 Note that SaltStack uses a slightly different minion-name for that.
 

--- a/saltgui/static/scripts/Api.js
+++ b/saltgui/static/scripts/Api.js
@@ -254,6 +254,15 @@ export class API {
     return this.apiRequest("POST", "/", params);
   }
 
+  getRunnerStateOrchestrateShowSls () {
+    const params = {
+      "arg": ["*"],
+      "client": "runner",
+      "fun": "state.orchestrate_show_sls"
+    };
+    return this.apiRequest("POST", "/", params);
+  }
+
   getWheelConfigValues () {
     const params = {
       "client": "wheel",

--- a/saltgui/static/scripts/Router.js
+++ b/saltgui/static/scripts/Router.js
@@ -18,6 +18,7 @@ import {LogoutPage} from "./pages/Logout.js";
 import {MinionsPage} from "./pages/Minions.js";
 import {NodegroupsPage} from "./pages/Nodegroups.js";
 import {OptionsPage} from "./pages/Options.js";
+import {OrchestrationsPage} from "./pages/Orchestrations.js";
 import {Output} from "./output/Output.js";
 import {PillarsMinionPage} from "./pages/PillarsMinion.js";
 import {PillarsPage} from "./pages/Pillars.js";
@@ -57,6 +58,7 @@ export class Router {
     this._registerPage(Router.templatesPage = new TemplatesPage(this));
     this._registerPage(Router.eventsPage = new EventsPage(this));
     this._registerPage(Router.reactorsPage = new ReactorsPage(this));
+    this._registerPage(Router.orchestrationsPage = new OrchestrationsPage(this));
     this._registerPage(Router.optionsPage = new OptionsPage(this));
     this._registerPage(Router.issuesPage = new IssuesPage(this));
     this._registerPage(Router.logoutPage = new LogoutPage(this));
@@ -208,6 +210,7 @@ export class Router {
     this._registerMenuItem(null, "keys", "keys", "k");
     this._registerMenuItem(null, "jobs", "jobs", "j");
     this._registerMenuItem("jobs", "highstate", "highstate", "h");
+    this._registerMenuItem("jobs", "orchestrations", "orchestrations", "o");
     this._registerMenuItem("jobs", "templates", "templates", "t");
     this._registerMenuItem(null, "events", "events", "e");
     this._registerMenuItem("events", "reactors", "reactors", "r");
@@ -300,8 +303,9 @@ export class Router {
     Router._showMenuItem(pages, Router.beaconsPage);
     Router._showMenuItem(pages, Router.nodegroupsPage);
     Router._showMenuItem(pages, Router.keysPage);
-    Router._showMenuItem(pages, Router.jobsPage, ["highstate", "templates"]);
+    Router._showMenuItem(pages, Router.jobsPage, ["highstate", "orchestrations", "templates"]);
     Router._showMenuItem(pages, Router.highStatePage);
+    Router._showMenuItem(pages, Router.orchestrationsPage);
     Router._showMenuItem(pages, Router.templatesPage);
     Router._showMenuItem(pages, Router.eventsPage, ["reactors"]);
     Router._showMenuItem(pages, Router.reactorsPage);

--- a/saltgui/static/scripts/output/Output.js
+++ b/saltgui/static/scripts/output/Output.js
@@ -906,6 +906,10 @@ export class Output {
 
       let minionResponse = pResponse[minionId];
 
+      if (commandCmd === "runner.state.orchestrate" && minionResponse.return && minionResponse.return.return && minionResponse.return.return.data) {
+        minionResponse = minionResponse.return.return.data[minionId];
+      }
+
       const isSuccess = Output._getIsSuccess(minionResponse);
       minionResponse = Output._getMinionResponse(pCommand, minionResponse);
       // provide the same (simplified) object for download
@@ -960,8 +964,10 @@ export class Output {
         // first put all the values in an array
         Object.keys(minionResponse).forEach(
           (taskKey) => {
-            minionResponse[taskKey].___key___ = taskKey;
-            tasks.push(minionResponse[taskKey]);
+            if (typeof minionResponse[taskKey] === "object") {
+              minionResponse[taskKey].___key___ = taskKey;
+              tasks.push(minionResponse[taskKey]);
+            }
           }
         );
         // then sort the array

--- a/saltgui/static/scripts/output/Output.js
+++ b/saltgui/static/scripts/output/Output.js
@@ -418,7 +418,7 @@ export class Output {
 
     let txt = "";
 
-    if ("__sls__" in pTask) {
+    if ("__sls__" in pTask && pTask.__sls__) {
       txt += "\n" + pTask.__sls__.replace(/[.]/g, "/") + ".sls";
     }
 
@@ -908,6 +908,9 @@ export class Output {
 
       if (commandCmd === "runner.state.orchestrate" && minionResponse.return && minionResponse.return.return && minionResponse.return.return.data) {
         minionResponse = minionResponse.return.return.data[minionId];
+      }
+      if (commandCmd === "runner.state.orchestrate_single" && minionResponse.return && minionResponse.return.return && typeof minionResponse.return.return === "object") {
+        minionResponse = Object.values(minionResponse.return.return)[0];
       }
 
       const isSuccess = Output._getIsSuccess(minionResponse);

--- a/saltgui/static/scripts/output/OutputHighstate.js
+++ b/saltgui/static/scripts/output/OutputHighstate.js
@@ -16,6 +16,7 @@ export class OutputHighstate {
       return false;
     }
     switch (pCommand) {
+    case "runner.state.orchestrate_single":
     case "state.apply":
     case "state.high":
     case "state.highstate":

--- a/saltgui/static/scripts/output/OutputHighstate.js
+++ b/saltgui/static/scripts/output/OutputHighstate.js
@@ -21,8 +21,11 @@ export class OutputHighstate {
     case "state.highstate":
     case "state.sls":
     case "state.sls_id":
-    case "runners.state.orchestrate":
       break;
+    case "runner.state.orchestrate":
+    case "runners.state.orchestrate":
+      // we need command-names in both variants
+      return true;
     case "state.low":
       // almost, but it is only one task
       // and we can handle only an object with tasks

--- a/saltgui/static/scripts/pages/Orchestrations.js
+++ b/saltgui/static/scripts/pages/Orchestrations.js
@@ -1,0 +1,25 @@
+/* global */
+
+import {JobsSummaryPanel} from "../panels/JobsSummary.js";
+import {OrchestrationsPanel} from "../panels/Orchestrations.js";
+import {Page} from "./Page.js";
+import {Utils} from "../Utils.js";
+
+export class OrchestrationsPage extends Page {
+
+  constructor (pRouter) {
+    super("orchestrations", "Orchestrations", "page-orchestrations", "button-orchestrations", pRouter);
+
+    this.orchestrations = new OrchestrationsPanel();
+    super.addPanel(this.orchestrations);
+    this.jobs = new JobsSummaryPanel();
+    super.addPanel(this.jobs);
+  }
+
+  /* eslint-disable class-methods-use-this */
+  isVisible () {
+  /* eslint-enable class-methods-use-this */
+    // show orchestrations menu item if orchestrations defined
+    return Utils.getStorageItemBoolean("session", "orchestrations");
+  }
+}

--- a/saltgui/static/scripts/panels/Jobs.js
+++ b/saltgui/static/scripts/panels/Jobs.js
@@ -175,6 +175,8 @@ export class JobsPanel extends Panel {
     this._hideJobs.push("runner.jobs.list_job");
     this._hideJobs.push("runner.jobs.list_jobs");
     this._hideJobs.push("runner.manage.versions");
+    // do not hide "runner.state.orchestrate"
+    this._hideJobs.push("runner.state.orchestrate_show_sls");
     // wheel jobs
     this._hideJobs.push("wheel.config.values");
     this._hideJobs.push("wheel.key.accept");

--- a/saltgui/static/scripts/panels/Login.js
+++ b/saltgui/static/scripts/panels/Login.js
@@ -356,12 +356,13 @@ export class LoginPanel extends Panel {
       const obj = ret[key];
       for (const stepkey in obj) {
         const step = obj[stepkey].salt;
-        if (step !== undefined) {
-          for (const item of step) {
-            if (item === "function" || item === "state" || item === "runner" || item === "wheel") {
-              Utils.setStorageItem("session", "orchestrations", "true");
-              return;
-            }
+        if (step === undefined) {
+          continue;
+        }
+        for (const item of step) {
+          if (item === "function" || item === "state" || item === "runner" || item === "wheel") {
+            Utils.setStorageItem("session", "orchestrations", "true");
+            return;
           }
         }
       }

--- a/saltgui/static/scripts/panels/Login.js
+++ b/saltgui/static/scripts/panels/Login.js
@@ -304,13 +304,21 @@ export class LoginPanel extends Panel {
 
     // We need these functions to populate the dropdown boxes
     const wheelConfigValuesPromise = this.api.getWheelConfigValues();
+    const runnerStateOrchestrateShowSlsPromise = this.api.getRunnerStateOrchestrateShowSls();
 
     // these may have been hidden on a previous logout
     Utils.hideAllMenus(false);
 
     // We need these functions to populate the dropdown boxes
+    // or determine visibility of menu items
     wheelConfigValuesPromise.then((pWheelConfigValuesData) => {
       LoginPanel._handleLoginWheelConfigValues(pWheelConfigValuesData);
+      Router.updateMainMenu();
+      return true;
+    }, () => false);
+    runnerStateOrchestrateShowSlsPromise.then((pRunnerStateOrchestrateShowSlsData) => {
+      LoginPanel._handleRunnerStateOrchestrateShowSls(pRunnerStateOrchestrateShowSlsData);
+      Router.updateMainMenu();
       return true;
     }, () => false);
 
@@ -337,6 +345,27 @@ export class LoginPanel extends Panel {
         }
       }
     }, 1000);
+  }
+
+  static _handleRunnerStateOrchestrateShowSls (pRunnerStateOrchestrateShowSlsData) {
+    // until we prove it it available
+    Utils.setStorageItem("session", "orchestrations", "false");
+
+    const ret = pRunnerStateOrchestrateShowSlsData.return[0];
+    for (const key in ret) {
+      const obj = ret[key];
+      for (const stepkey in obj) {
+        const step = obj[stepkey].salt;
+        if (step !== undefined) {
+          for (const item of step) {
+            if (item === "function" || item === "state" || item === "runner" || item === "wheel") {
+              Utils.setStorageItem("session", "orchestrations", "true");
+              return;
+            }
+          }
+        }
+      }
+    }
   }
 
   static _handleLoginWheelConfigValues (pWheelConfigValuesData) {
@@ -443,8 +472,6 @@ export class LoginPanel extends Panel {
 
     const fullReturn = wheelConfigValuesData.saltgui_full_return;
     Utils.setStorageItem("session", "full_return", fullReturn);
-
-    Router.updateMainMenu();
   }
 
   _onLoginFailure (error) {

--- a/saltgui/static/scripts/panels/Orchestrations.js
+++ b/saltgui/static/scripts/panels/Orchestrations.js
@@ -135,8 +135,16 @@ export class OrchestrationsPanel extends Panel {
     for (const step of steps) {
       const tr1 = Utils.createTr();
 
-      // no menu per item
-      tr1.appendChild(Utils.createTd());
+      // menu per item
+      const smenu = new DropDownMenu(tr1, "smaller");
+      this._addMenuItemApplyOrchestrationStep(smenu, step);
+      this._addMenuItemApplyOrchestrationStepTest(smenu, step);
+
+      const cmdArr = OrchestrationsPanel._makeCmdArr(step, false);
+      tr1.addEventListener("click", (pClickEvent) => {
+        this.runCommand("", "", cmdArr);
+        pClickEvent.stopPropagation();
+      });
 
       tr1.appendChild(Utils.createTd("name", Character.NO_BREAK_SPACE.repeat(3) + step.__key__));
 
@@ -207,6 +215,44 @@ export class OrchestrationsPanel extends Panel {
   _addMenuItemApplyOrchestrationTest (pMenu, pOrchestrationName) {
     pMenu.addMenuItem("Test orchestration...", () => {
       const cmdArr = ["runners.state.orchestrate", "test=", true, pOrchestrationName];
+      this.runCommand("", "", cmdArr);
+    });
+  }
+
+  static _makeCmdArr (pSteps, pTest) {
+    /* eslint-disable prefer-object-spread */
+    const kwArgs = Object.assign({}, pSteps);
+    /* eslint-enable prefer-object-spread */
+    delete kwArgs["require"];
+    delete kwArgs["salt"];
+    delete kwArgs["__sls__"];
+    delete kwArgs["__env__"];
+    delete kwArgs["__key__"];
+    delete kwArgs["__type__"];
+    delete kwArgs["order"];
+    if(!kwArgs["name"]) {
+      // orchestrate_single has his as mandatory parameter
+      kwArgs["name"] = "dummy";
+    }
+    kwArgs["fun"] = "salt." + pSteps.__type__;
+    if(pTest) {
+      kwArgs["test"] = true;
+    }
+    const cmdArr = ["runners.state.orchestrate_single"];
+    cmdArr.push("kwarg=", kwArgs);
+    return cmdArr;
+  }
+
+  _addMenuItemApplyOrchestrationStep (pMenu, pSteps) {
+    const cmdArr = OrchestrationsPanel._makeCmdArr(pSteps, false);
+    pMenu.addMenuItem("Apply orchestration step...", () => {
+      this.runCommand("", "", cmdArr);
+    });
+  }
+
+  _addMenuItemApplyOrchestrationStepTest (pMenu, pSteps) {
+    const cmdArr = OrchestrationsPanel._makeCmdArr(pSteps, true);
+    pMenu.addMenuItem("Test orchestration step...", () => {
       this.runCommand("", "", cmdArr);
     });
   }

--- a/saltgui/static/scripts/panels/Orchestrations.js
+++ b/saltgui/static/scripts/panels/Orchestrations.js
@@ -1,0 +1,213 @@
+/* global */
+
+import {Character} from "../Character.js";
+import {DropDownMenu} from "../DropDown.js";
+import {Output} from "../output/Output.js";
+import {Panel} from "./Panel.js";
+import {Utils} from "../Utils.js";
+
+export class OrchestrationsPanel extends Panel {
+
+  constructor () {
+    super("orchestrations");
+
+    this.addTitle("Orchestrations");
+    this.addSearchButton();
+    this.addWarningField();
+    this.addTable(["-menu-", "Name", "Target", "Type", "Name", "Details"]);
+    this.setTableClickable("cmd");
+    this.addMsg();
+  }
+
+  onShow () {
+    const runnerStateOrchestrateShowSlsPromise = this.router.api.getRunnerStateOrchestrateShowSls();
+
+    runnerStateOrchestrateShowSlsPromise.then((pStateOrchestrateShowSlsData) => {
+      this._handleOrchestrationsStateOrchestrateShowSls(pStateOrchestrateShowSlsData);
+    }, (pStateOrchestrateShowSlsMsg) => {
+      this._handleOrchestrationsStateOrchestrateShowSls(JSON.stringify(pStateOrchestrateShowSlsMsg));
+    });
+  }
+
+  _handleOrchestrationsStateOrchestrateShowSls (pStateOrchestrateShowSlsData) {
+    if (this.showErrorRowInstead(pStateOrchestrateShowSlsData)) {
+      return;
+    }
+
+    // should we update it or just use from cache (see commandbox) ?
+    let orchestrations = pStateOrchestrateShowSlsData.return[0];
+    if (!orchestrations) {
+      orchestrations = {"dummy": {}};
+    }
+    orchestrations = orchestrations[Object.keys(orchestrations)[0]];
+    if (!orchestrations) {
+      orchestrations = {};
+    }
+
+    if (Array.isArray(orchestrations)) {
+      // that's a list of errors, show them
+      this.setWarningText("warn", "There " +
+        Utils.txtZeroOneMany(orchestrations.length, "are no errors", "is an error", "are errors") +
+        " in the orchestration configuration");
+      for (const msg of orchestrations) {
+        const tr0 = Utils.createTr();
+        const td = Utils.createTd("name", msg);
+        td.colSpan = 4;
+        tr0.appendChild(td);
+        this.table.tBodies[0].appendChild(tr0);
+      }
+      const txt = Utils.txtZeroOneMany(orchestrations.length,
+        "No errors", "{0} error", "{0} errors");
+      this.setMsg(txt);
+      return;
+    }
+
+    const keys = {};
+    for (const key of Object.keys(orchestrations)) {
+      keys[orchestrations[key].__sls__] = [];
+    }
+    for (const key of Object.keys(orchestrations)) {
+      const orchestration = orchestrations[key];
+      keys[orchestration.__sls__][key] = orchestration;
+    }
+    let nrOrchestrations = 0;
+    for (const key of Object.keys(keys).sort()) {
+      const orchestration = keys[key];
+      if (this._addOrchestration(key, orchestration)) {
+        nrOrchestrations += 1;
+      }
+    }
+
+    const txt = Utils.txtZeroOneMany(nrOrchestrations,
+      "No orchestrations", "{0} orchestration", "{0} orchestrations");
+    this.setMsg(txt);
+  }
+
+  _addOrchestration (pOrchestrationName, pOrchestrations) {
+
+    const steps = [];
+    let ok = false;
+    for (const name of Object.keys(pOrchestrations)) {
+      const step = pOrchestrations[name];
+      // add key-name to object itself
+      step.__key__ = name;
+      const salt = step.salt || [];
+      for (const item of salt) {
+        if (item && typeof item === "object") {
+          pOrchestrations[name] = Object.assign(step, item);
+        } else {
+          // assuming there is only one non-object...
+          step["__type__"] = item;
+          ok = true;
+        }
+      }
+      step.salt = [];
+      steps.push(step);
+    }
+
+    if (!ok) {
+      // no evidence that this is an orchestration (likely just a highstate)
+      return false;
+    }
+
+    const tr0 = Utils.createTr();
+
+    const menu = new DropDownMenu(tr0, "smaller");
+    this._addMenuItemApplyOrchestration(menu, pOrchestrationName);
+    this._addMenuItemApplyOrchestrationTest(menu, pOrchestrationName);
+
+    tr0.appendChild(Utils.createTd("name", pOrchestrationName));
+    tr0.appendChild(Utils.createTd());
+    tr0.appendChild(Utils.createTd());
+    tr0.appendChild(Utils.createTd());
+    tr0.appendChild(Utils.createTd());
+
+    this.table.tBodies[0].appendChild(tr0);
+
+    tr0.addEventListener("click", (pClickEvent) => {
+      const cmdArr = ["runners.state.orchestrate", pOrchestrationName];
+      this.runCommand("", "", cmdArr);
+      pClickEvent.stopPropagation();
+    });
+
+    steps.sort((aa, bb) => aa.order > bb.order);
+
+    for (const step of steps) {
+      const tr1 = Utils.createTr();
+
+      // no menu per item
+      tr1.appendChild(Utils.createTd());
+
+      tr1.appendChild(Utils.createTd("name", Character.NO_BREAK_SPACE.repeat(3) + step.__key__));
+
+      // calculate targettype
+      const targetType = step["tgt_type"];
+      // calculate target
+      const tgt = step["tgt"];
+      if (!targetType && !tgt) {
+        tr1.appendChild(Utils.createTd("target value-none", "(none)"));
+      } else if (!tgt) {
+        // targetType cannot be null here
+        tr1.appendChild(Utils.createTd("target", targetType));
+      } else if (targetType && targetType !== "glob" && targetType !== "list") {
+        // target cannot be null here
+        tr1.appendChild(Utils.createTd("target", targetType + " " + tgt));
+      } else {
+        tr1.appendChild(Utils.createTd("target", tgt));
+      }
+
+      // show command
+      const typeTd = Utils.createTd();
+      const typeSpan = Utils.createSpan("command", step.__type__);
+      typeTd.appendChild(typeSpan);
+      Utils.addToolTip(typeSpan, "salt." + step.__type__);
+      tr1.appendChild(typeTd);
+
+      // show name
+      const nameTd = Utils.createTd();
+      const nameSpan = Utils.createSpan("command", step.name);
+      nameTd.appendChild(nameSpan);
+      tr1.appendChild(nameTd);
+
+      // calculate details
+      // TODO should support ENV
+      delete step["__env__"];
+      delete step["__key__"];
+      delete step["__sls__"];
+      delete step["__type__"];
+      delete step["name"];
+      // the steps are already sorted by this
+      // don't show actual values
+      delete step["order"];
+      // only value for 'salt' seems to be []
+      delete step["salt"];
+      delete step["tgt"];
+      delete step["tgt_type"];
+      if (Object.keys(step).length === 0) {
+        // nothing more to show
+        tr1.appendChild(Utils.createTd("details value-none", "(none)"));
+      } else {
+        const formattedStep = Output.formatObject(step);
+        tr1.appendChild(Utils.createTd("grain-value", formattedStep));
+      }
+
+      this.table.tBodies[0].appendChild(tr1);
+    }
+
+    return true;
+  }
+
+  _addMenuItemApplyOrchestration (pMenu, pOrchestrationName) {
+    pMenu.addMenuItem("Apply orchestration...", () => {
+      const cmdArr = ["runners.state.orchestrate", pOrchestrationName];
+      this.runCommand("", "", cmdArr);
+    });
+  }
+
+  _addMenuItemApplyOrchestrationTest (pMenu, pOrchestrationName) {
+    pMenu.addMenuItem("Test orchestration...", () => {
+      const cmdArr = ["runners.state.orchestrate", "test=", true, pOrchestrationName];
+      this.runCommand("", "", cmdArr);
+    });
+  }
+}


### PR DESCRIPTION
orchestrations are similar to highstates.
difference is that highstates are applied to individual minions (possibly multiple at the same time),
but orchestrations are schemes that coordinate work across minions.

this PR makes it possible to:
* view the defined orchestrations with their steps and the details of these steps; and
* start the execution of an orchestration; and
* display the outcome of an orchestration.

note that unlike highstates, SaltStack does not allow tracking an orchestration step-by-step. the system just does not generate any useful events for this.

note that the orchestrations page is only visible when there is at least one orchestration defined in the system.

please feel free to try out this feature before it is merged into SaltGUI.
comments and suggestions are welcome!