### PR TITLE
get local test providers for targeted minions only

### DIFF
--- a/saltgui/static/scripts/Api.js
+++ b/saltgui/static/scripts/Api.js
@@ -180,11 +180,11 @@ export class API {
     return this.apiRequest("POST", "/", params);
   }
 
-  getLocalTestProviders () {
+  getLocalTestProviders (pTgt) {
     const params = {
       "client": "local",
       "fun": "test.providers",
-      "tgt": "*"
+      "tgt": pTgt || "*"
     };
     return this.apiRequest("POST", "/", params);
   }

--- a/saltgui/static/scripts/Api.js
+++ b/saltgui/static/scripts/Api.js
@@ -180,12 +180,25 @@ export class API {
     return this.apiRequest("POST", "/", params);
   }
 
-  getLocalTestProviders (pTgt) {
+  getLocalTestProviders (pTgt, pTgtType) {
+    pTgtType = pTgtType || 'glob';
+
+    switch (pTgtType) {
+      case 'glob':
+        pTgt = pTgt || '*';
+        break;
+      case 'list':
+        pTgt = pTgt.split(',').map(t => t.trim());
+        break;
+    }
+
     const params = {
       "client": "local",
       "fun": "test.providers",
-      "tgt": pTgt || "*"
+      "tgt": pTgt || "*",
+      "tgt_type": pTgtType || 'glob'
     };
+
     return this.apiRequest("POST", "/", params);
   }
 

--- a/saltgui/static/scripts/CommandBox.js
+++ b/saltgui/static/scripts/CommandBox.js
@@ -477,15 +477,18 @@ export class CommandBox {
     CommandBox._populateTemplateCatMenu();
     CommandBox._populateTemplateTmplMenu();
 
-    targetField.addEventListener('change', (evt) => {
-      const localTestProviders = pApi.getLocalTestProviders(targetField.value);
+    const refreshTestProviders = (evt) => {
+      const targetType = TargetType.menuTargetType._value;
+      const localTestProviders = pApi.getLocalTestProviders(targetField.value, targetType);
 
       localTestProviders.then((pData) => {
         Documentation._handleLocalTestProviders(pData);
       }, () => {
         // VOID
       });
-    });
+      TargetType._callback = refreshTestProviders;
+    };
+    targetField.addEventListener('change', refreshTestProviders);
   }
 
   static hideManualRun () {

--- a/saltgui/static/scripts/CommandBox.js
+++ b/saltgui/static/scripts/CommandBox.js
@@ -477,12 +477,14 @@ export class CommandBox {
     CommandBox._populateTemplateCatMenu();
     CommandBox._populateTemplateTmplMenu();
 
-    const localTestProviders = pApi.getLocalTestProviders();
+    targetField.addEventListener('change', (evt) => {
+      const localTestProviders = pApi.getLocalTestProviders(targetField.value);
 
-    localTestProviders.then((pData) => {
-      Documentation._handleLocalTestProviders(pData);
-    }, () => {
-      // VOID
+      localTestProviders.then((pData) => {
+        Documentation._handleLocalTestProviders(pData);
+      }, () => {
+        // VOID
+      });
     });
   }
 

--- a/saltgui/static/scripts/TargetType.js
+++ b/saltgui/static/scripts/TargetType.js
@@ -72,6 +72,10 @@ export class TargetType {
     TargetType.menuTargetType._value = targetType;
 
     TargetType._setMenuMarker();
+
+    if (this._callback) {
+      this._callback(targetType);
+    }
   }
 
   static _setMenuMarker () {

--- a/saltgui/static/scripts/panels/Panel.js
+++ b/saltgui/static/scripts/panels/Panel.js
@@ -875,6 +875,7 @@ export class Panel {
     TargetType.autoSelectTargetType(pTargetString);
 
     target.value = pTargetString;
+    target.dispatchEvent(new Event('change'));
     command.value = pCommandString;
     // the menu may become (in)visible due to content of command field
     this.router.commandbox.cmdmenu.verifyAll();


### PR DESCRIPTION
This PR reduces the amount of calls to minions when "Manual run" window is opened after a click on a row in the  "Minions" table.

Up until now the behaviour is such that all minions are targeted with "test.providers", no matter what is in the target selection box.
