### PR TITLE
only call test.providers when results were not retrieved before

### DIFF
--- a/saltgui/static/scripts/CommandBox.js
+++ b/saltgui/static/scripts/CommandBox.js
@@ -476,6 +476,15 @@ export class CommandBox {
 
     CommandBox._populateTemplateCatMenu();
     CommandBox._populateTemplateTmplMenu();
+    CommandBox._populateProviders(pApi);
+  }
+
+  static _populateProviders (pApi) {
+
+    if (Object.keys(Documentation.PROVIDERS).length > 0) {
+      // no need to collect it again
+      return;
+    }
 
     const localTestProviders = pApi.getLocalTestProviders();
 


### PR DESCRIPTION
general alternative for #660 (but not a replacement for it)