### PR TITLE
Changed File Path to PERMISSIONS.md in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -67,7 +67,7 @@ netapi_enable_clients:
     - wheel
 ```
 
-- See [Permissions](docs/PERMISSIONS.md) for more restricted security configurations.
+- See [Permissions](PERMISSIONS.md) for more restricted security configurations.
 - The username 'saltuser1' is only an example. Generic accounts are not recommended, use personal accounts instead. Or use a user-group, see [EAUTH](https://docs.saltproject.io/en/latest/topics/eauth/index.html) for details.
 - Multiple entries like `saltuser1` can be added when you have multiple users.
 - `saltuser1` is a unix (PAM) user, make sure it exists or create a new one.
@@ -92,7 +92,7 @@ rest_cherrypy:
 
 **Note: With this configuration, the user has access to all salt modules available, maybe this is not what you want**
 
-Please read [Permissions](docs/PERMISSIONS.md) for more information.
+Please read [Permissions](PERMISSIONS.md) for more information.
 
 
 ## Authentication


### PR DESCRIPTION
This PR changes the file path for PERMISSIONS.md from `docs/PERMISSIONS.md` to `PERMISSIONS.md` in the README.md, which was moved to the `docs` folder and caused the path to PERMISSIONS.md no longer pointing at the correct destination.