### PR TITLE
Docker build fails

### DIFF
--- a/docker/dockerfiles/conf/supervisord.conf
+++ b/docker/dockerfiles/conf/supervisord.conf
@@ -1,5 +1,7 @@
 [supervisord]
 nodaemon=true
+user=root
+loglevel=warn
 
 [program:saltmaster]
 command=/usr/bin/salt-master -l info

--- a/docker/dockerfiles/dockerfile-saltgui-nginx
+++ b/docker/dockerfiles/dockerfile-saltgui-nginx
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 LABEL maintainer="Erwin Dondorp <saltgui@dondorp.com>"
 LABEL name=saltgui-nginx
@@ -7,10 +7,6 @@ LABEL version=1.18.0
 
 ENV NGINX_VERSION=1.18.0
 ENV DEBIAN_FRONTEND=noninteractive
-
-# fix ubuntu
-# see https://askubuntu.com/questions/1235914/hash-sum-mismatch-error-due-to-identical-sha1-and-md5-but-different-sha256
-RUN mkdir /etc/gcrypt && echo all >> /etc/gcrypt/hwf.deny
 
 RUN apt-get update \
   # install nginx

--- a/docker/dockerfiles/dockerfile-saltmaster
+++ b/docker/dockerfiles/dockerfile-saltmaster
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 LABEL maintainer="Erwin Dondorp <saltgui@dondorp.com>"
 LABEL name=salt-master
@@ -8,28 +8,27 @@ LABEL version=3007.1
 ENV SALT_VERSION=3007.1
 ENV DEBIAN_FRONTEND=noninteractive
 
-# fix ubuntu
-# see https://askubuntu.com/questions/1235914/hash-sum-mismatch-error-due-to-identical-sha1-and-md5-but-different-sha256
-RUN mkdir /etc/gcrypt && echo all >> /etc/gcrypt/hwf.deny
-
-# add saltstack repo
+# make download possible, make encrypted password generation possible
 RUN apt-get update
-RUN apt-get install --yes --no-install-recommends curl ca-certificates gnupg2 net-tools dirmngr
-RUN curl -fsSL -o /etc/apt/keyrings/salt-archive-keyring-2023.gpg https://repo.saltproject.io/salt/py3/ubuntu/22.04/amd64/SALT-PROJECT-GPG-PUBKEY-2023.gpg
-RUN echo "deb [signed-by=/etc/apt/keyrings/salt-archive-keyring-2023.gpg arch=amd64] https://repo.saltproject.io/salt/py3/ubuntu/22.04/amd64/minor/${SALT_VERSION} jammy main" > /etc/apt/sources.list.d/salt.list
-RUN apt-get update
-
-# install salt-master and salt-api
-RUN apt-get install salt-master=${SALT_VERSION} salt-api=${SALT_VERSION} --yes --no-install-recommends
+RUN apt-get install --yes --no-install-recommends curl openssl adduser
 
 # add a user for the frontend salt:salt
+RUN adduser salt
 RUN usermod -s /bin/bash -p "$(openssl passwd -1 salt)" salt
 
+# install salt-master with salt-api
+# not using repo, so must explicitly do all packages
+RUN curl -k -L -o salt-common_${SALT_VERSION}.deb https://packages.broadcom.com/artifactory/saltproject-deb/pool/salt-common_${SALT_VERSION}_amd64.deb
+RUN curl -k -L -o salt-api_${SALT_VERSION}.deb https://packages.broadcom.com/artifactory/saltproject-deb/pool/salt-api_${SALT_VERSION}_amd64.deb
+RUN curl -k -L -o salt-master_${SALT_VERSION}.deb https://packages.broadcom.com/artifactory/saltproject-deb/pool/salt-master_${SALT_VERSION}_amd64.deb
+RUN apt install --yes --no-install-recommends ./salt-common_${SALT_VERSION}.deb ./salt-master_${SALT_VERSION}.deb ./salt-api_${SALT_VERSION}.deb
+
 # install supervisor
-RUN apt-get install supervisor --yes --no-install-recommends
+# becausewe need to run salt-master and salt-api
+RUN apt-get install --yes --no-install-recommends supervisor
 
 # cleanup temporary files
-RUN rm -rf /var/lib/apt/lists/* \
+RUN rm -rf /var/lib/apt/lists/* *.deb \
   && apt-get --yes autoremove \
   && apt-get clean
 
@@ -41,4 +40,5 @@ VOLUME ["/pki", "/var/cache/salt", "/var/log/salt"]
 EXPOSE 3333 4505 4506
 
 # define main container command
-CMD /usr/bin/supervisord
+# explicitly mentioning the (default) configuration file saves a warning
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/docker/dockerfiles/dockerfile-saltminion-centos
+++ b/docker/dockerfiles/dockerfile-saltminion-centos
@@ -8,21 +8,20 @@ LABEL version=3007.1
 ENV SALT_VERSION=3007.1
 ENV DEBIAN_FRONTEND=noninteractive
 
-# add saltstack repo
-RUN yum install --assumeyes epel-release curl gnupg2 net-tools
-RUN rpm --import https://repo.saltproject.io/salt/py3/redhat/9/x86_64/SALT-PROJECT-GPG-PUBKEY-2023.pub
-RUN curl -fsSL https://repo.saltproject.io/salt/py3/redhat/9/x86_64/minor/3007.1.repo > /etc/yum.repos.d/salt.repo
-RUN yum update --assumeyes
+# get saltstack software
+RUN yum install --assumeyes epel-release curl
 
 # install salt-minion
-RUN yum install --assumeyes salt-minion-${SALT_VERSION}
+# not using repo, so must explicitly do all packages
+RUN yum install --assumeyes https://packages.broadcom.com/artifactory/saltproject-rpm/salt-${SALT_VERSION}-0.x86_64.rpm
+RUN yum install --assumeyes https://packages.broadcom.com/artifactory/saltproject-rpm/salt-minion-${SALT_VERSION}-0.x86_64.rpm
 
 # cleanup temporary files
-RUN rm -rf /var/lib/yum/* /var/cache/yum \
+RUN rm -rf /var/lib/yum/* /var/cache/yum *.rpm \
   && yum clean all
 
 # copy the minion configuration
 COPY ./conf/minion /etc/salt/minion
 
 # define main container command
-CMD /usr/bin/salt-minion
+CMD ["/usr/bin/salt-minion"]

--- a/docker/dockerfiles/dockerfile-saltminion-debian
+++ b/docker/dockerfiles/dockerfile-saltminion-debian
@@ -8,23 +8,25 @@ LABEL version=3007.1
 ENV SALT_VERSION=3007.1
 ENV DEBIAN_FRONTEND=noninteractive
 
-# add saltstack repo
+# make download possible
 RUN apt-get update
-RUN apt-get install --yes --no-install-recommends curl ca-certificates gnupg2 net-tools dirmngr
-RUN curl -fsSL -o /etc/apt/keyrings/salt-archive-keyring-2023.gpg https://repo.saltproject.io/salt/py3/debian/12/amd64/SALT-PROJECT-GPG-PUBKEY-2023.gpg
-RUN echo "deb [signed-by=/etc/apt/keyrings/salt-archive-keyring-2023.gpg arch=amd64] https://repo.saltproject.io/salt/py3/debian/12/amd64/minor/${SALT_VERSION} bookworm main" > /etc/apt/sources.list.d/salt.list
-RUN apt-get update
+RUN apt-get install --yes --no-install-recommends curl
 
 # install salt-minion
-RUN apt-get install salt-minion=${SALT_VERSION} --yes --no-install-recommends
+# not using repo, so must explicitly do all packages
+RUN curl -k -L -o salt-common_${SALT_VERSION}.deb https://packages.broadcom.com/artifactory/saltproject-deb/pool/salt-common_${SALT_VERSION}_amd64.deb
+RUN curl -k -L -o salt-minion_${SALT_VERSION}.deb https://packages.broadcom.com/artifactory/saltproject-deb/pool/salt-minion_${SALT_VERSION}_amd64.deb
+RUN apt install --yes --no-install-recommends ./salt-common_${SALT_VERSION}.deb ./salt-minion_${SALT_VERSION}.deb
 
 # cleanup temporary files
-RUN rm -rf /var/lib/apt/lists/* \
+RUN rm -rf /var/lib/apt/lists/* *.deb \
   && apt-get -y autoremove \
   && apt-get clean
 
 # copy the minion configuration
 COPY ./conf/minion /etc/salt/minion
 
+ENV CRYPTOGRAPHY_OPENSSL_NO_LEGACY=true
+
 # define main container command
-CMD /usr/bin/salt-minion
+CMD ["/usr/bin/salt-minion"]

--- a/docker/dockerfiles/dockerfile-saltminion-ubuntu
+++ b/docker/dockerfiles/dockerfile-saltminion-ubuntu
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 LABEL maintainer="Erwin Dondorp <saltgui@dondorp.com>"
 LABEL name=salt-minion
@@ -8,27 +8,25 @@ LABEL version=3007.1
 ENV SALT_VERSION=3007.1
 ENV DEBIAN_FRONTEND=noninteractive
 
-# fix ubuntu
-# see https://askubuntu.com/questions/1235914/hash-sum-mismatch-error-due-to-identical-sha1-and-md5-but-different-sha256
-RUN mkdir /etc/gcrypt && echo all >> /etc/gcrypt/hwf.deny
-
-# add saltstack repo
+# make download possible
 RUN apt-get update
-RUN apt-get install --yes --no-install-recommends curl ca-certificates gnupg2 net-tools
-RUN curl -fsSL -o /etc/apt/keyrings/salt-archive-keyring-2023.gpg https://repo.saltproject.io/salt/py3/ubuntu/22.04/amd64/SALT-PROJECT-GPG-PUBKEY-2023.gpg
-RUN echo "deb [signed-by=/etc/apt/keyrings/salt-archive-keyring-2023.gpg arch=amd64] https://repo.saltproject.io/salt/py3/ubuntu/22.04/amd64/minor/${SALT_VERSION} jammy main" > /etc/apt/sources.list.d/salt.list
-RUN apt-get update
+RUN apt-get install --yes --no-install-recommends curl
 
 # install salt-minion
-RUN apt-get install salt-minion=${SALT_VERSION} --yes --no-install-recommends
+# not using repo, so must explicitly do all packages
+RUN curl -k -L -o salt-common_${SALT_VERSION}.deb https://packages.broadcom.com/artifactory/saltproject-deb/pool/salt-common_${SALT_VERSION}_amd64.deb
+RUN curl -k -L -o salt-minion_${SALT_VERSION}.deb https://packages.broadcom.com/artifactory/saltproject-deb/pool/salt-minion_${SALT_VERSION}_amd64.deb
+RUN apt install --yes --no-install-recommends ./salt-common_${SALT_VERSION}.deb ./salt-minion_${SALT_VERSION}.deb
 
 # cleanup temporary files
-RUN rm -rf /var/lib/apt/lists/* \
+RUN rm -rf /var/lib/apt/lists/* *.deb \
   && apt-get -y autoremove \
   && apt-get clean
 
 # copy the minion configuration
 COPY ./conf/minion /etc/salt/minion
 
+ENV CRYPTOGRAPHY_OPENSSL_NO_LEGACY=true
+
 # define main container command
-CMD /usr/bin/salt-minion
+CMD ["/usr/bin/salt-minion"]


### PR DESCRIPTION
**Describe the bug**
Docker build commands fails

**To Reproduce**
Steps to reproduce the behaviour:
I went to this folder:
`cd SaltGUI/docker/dockerfiles`
and ran:
` docker build -f dockerfile-saltmaster --tag erwindon/saltgui-saltmaster:3007.1 .`
and got this error:
 => ERROR [ 5/12] RUN curl -fsSL -o /etc/apt/keyrings/salt-archive-keyring-2023.gpg https://repo.saltproject.io/salt/py3/ubuntu/22.04/amd64/SALT-PROJECT-G  0.8s 

**Expected behaviour**
successful build

**Additional context**
I think the reason for failure is the `repo.saltproject.io` domain does no longer exist and has migrated to `packages.broadcom.com`

related link:
https://saltproject.io/blog/salt-project-package-repo-migration-and-guidance/
