### PR TITLE
SaltGUI slowness

### DIFF
--- a/saltgui/static/scripts/CommandBox.js
+++ b/saltgui/static/scripts/CommandBox.js
@@ -459,17 +459,6 @@ export class CommandBox {
       targetList.appendChild(option);
     }
 
-    if (Utils.getStorageItem("session", "minions", "N/A") === "N/A") {
-      const wheelKeyListAllPromise = pApi.getWheelKeyListAll();
-      /* eslint-disable no-unused-vars */
-      wheelKeyListAllPromise.then((pWheelKeyListAllData) => {
-        const minions = pWheelKeyListAllData.return[0].data.return.minions;
-        Utils.setStorageItem("session", "minions", JSON.stringify(minions));
-      }, (pWheelKeyListAllMsg) => {
-        // VOID
-      });
-      /* eslint-enable no-unused-vars */
-    }
     const minions = Utils.getStorageItemList("session", "minions");
     for (const minionId of [...minions].sort()) {
       const option = Utils.createElem("option");

--- a/saltgui/static/scripts/CommandBox.js
+++ b/saltgui/static/scripts/CommandBox.js
@@ -459,6 +459,17 @@ export class CommandBox {
       targetList.appendChild(option);
     }
 
+    if (Utils.getStorageItem("session", "minions", "N/A") === "N/A") {
+      const wheelKeyListAllPromise = pApi.getWheelKeyListAll();
+      /* eslint-disable no-unused-vars */
+      wheelKeyListAllPromise.then((pWheelKeyListAllData) => {
+        const minions = pWheelKeyListAllData.return[0].data.return.minions;
+        Utils.setStorageItem("session", "minions", JSON.stringify(minions));
+      }, (pWheelKeyListAllMsg) => {
+        // VOID
+      });
+      /* eslint-enable no-unused-vars */
+    }
     const minions = Utils.getStorageItemList("session", "minions");
     for (const minionId of [...minions].sort()) {
       const option = Utils.createElem("option");

--- a/saltgui/static/scripts/panels/Login.js
+++ b/saltgui/static/scripts/panels/Login.js
@@ -306,6 +306,7 @@ export class LoginPanel extends Panel {
     // We need these functions to populate the dropdown boxes
     const wheelConfigValuesPromise = this.api.getWheelConfigValues();
     const runnerStateOrchestrateShowSlsPromise = this.api.getRunnerStateOrchestrateShowSls();
+    const wheelKeyListAllPromise = this.api.getWheelKeyListAll();
 
     // these may have been hidden on a previous logout
     Utils.hideAllMenus(false);
@@ -322,6 +323,16 @@ export class LoginPanel extends Panel {
       Router.updateMainMenu();
       return true;
     }, () => false);
+
+    // save for the autocompletion
+    /* eslint-disable no-unused-vars */
+    wheelKeyListAllPromise.then((pWheelKeyListAllData) => {
+      const minions = pWheelKeyListAllData.return[0].data.return.minions;
+      Utils.setStorageItem("session", "minions", JSON.stringify(minions));
+    }, (pWheelKeyListAllMsg) => {
+      // VOID
+    });
+    /* eslint-enable no-unused-vars */
 
     // allow the success message to be seen
     window.setTimeout(() => {

--- a/saltgui/static/scripts/panels/Panel.js
+++ b/saltgui/static/scripts/panels/Panel.js
@@ -709,13 +709,6 @@ export class Panel {
     const minionIds = Object.keys(minions).sort();
     const minionsDict = Utils.getStorageItemObject("session", "minions_txt");
 
-    // save for the autocompletion
-    // This callback will also be called after LOGOUT due to the regular error handling
-    // Do not store the information in that case
-    if (Utils.getStorageItem("session", "token")) {
-      Utils.setStorageItem("session", "minions", JSON.stringify(minionIds));
-    }
-
     this.nrOnline = 0;
     this.nrOffline = 0;
     for (const minionId of minionIds) {


### PR DESCRIPTION
Hi Team,

I have a Salt Master running on Ubuntu 22.04 with Salt version 3006.1, managing over 1000 minions. To simplify management, I’ve configured SaltGUI for access. However, I’m noticing significant performance issues — particularly, it takes a long time to load and display the list of minions after logging into SaltGUI.

The Salt Master is running on a server with a 16-core CPU and 12 GB of RAM. I’d like to know if this hardware specification is sufficient for managing this number of minions, or if an upgrade is recommended. Additionally, are there any specific configuration best practices for optimizing Salt/SaltGUI performance in large environments like this?

Looking forward to your suggestions.

Best regards,
Sunder