### PR TITLE
Potential fix for code scanning alert no. 13: DOM text reinterpreted as HTML

### DIFF
--- a/saltgui/static/scripts/Documentation.js
+++ b/saltgui/static/scripts/Documentation.js
@@ -10,6 +10,15 @@ import {Utils} from "./Utils.js";
 
 export class Documentation {
 
+  static _escapeHtml(unsafe) {
+    return unsafe
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;");
+  }
+
   // formatting of the documentation is done as a regular output type
   // that is therefore in output.js
 
@@ -412,8 +421,8 @@ export class Documentation {
 
     if (cmd.length >= 3 && cmd[0] === "modules" && cmd[1] === "beacons" && ["add", "modify"].indexOf(cmd[2]) >= 0 && argsArray.length >= 2 && typeof argsArray[1] === "string") {
       const beaconName = argsArray[1];
-      html += "<p>Beacon-name '" + beaconName + "' cannot be verified. We'll just assume it actually exists. The link below might not work.</p>";
-      html += "<p><a href='" + Documentation.DOCUMENTATION_URL + "beacons/all/salt.beacons." + beaconName + ".html' target='_blank' rel='noopener'>Beacon Module '" + beaconName + "'</a>" + Documentation.EXTERNAL_LINK + "</p>";
+      html += "<p>Beacon-name '" + Documentation._escapeHtml(beaconName) + "' cannot be verified. We'll just assume it actually exists. The link below might not work.</p>";
+      html += "<p><a href='" + Documentation.DOCUMENTATION_URL + "beacons/all/salt.beacons." + Documentation._escapeHtml(beaconName) + ".html' target='_blank' rel='noopener'>Beacon Module '" + Documentation._escapeHtml(beaconName) + "'</a>" + Documentation.EXTERNAL_LINK + "</p>";
     }
 
     const output = document.querySelector(".run-command pre");


### PR DESCRIPTION
Potential fix for [https://github.com/erwindon/SaltGUI/security/code-scanning/13](https://github.com/erwindon/SaltGUI/security/code-scanning/13)

To fix the issue, we need to ensure that any user-controlled input interpolated into the `html` string is properly escaped to prevent it from being interpreted as HTML. This can be achieved by using a utility function to escape special HTML characters (`<`, `>`, `&`, `"`, `'`) in the `beaconName` variable before including it in the `html` string.

The fix involves:
1. Adding an HTML-escaping utility function to safely encode user-controlled input.
2. Applying this escaping function to `beaconName` before interpolating it into the `html` string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
