### PR TITLE
Potential fix for code scanning alert no. 13: DOM text reinterpreted as HTML

### DIFF
--- a/saltgui/static/scripts/Documentation.js
+++ b/saltgui/static/scripts/Documentation.js
@@ -257,7 +257,7 @@ export class Documentation {
 
     // title line
     let html = "";
-    html += "<h3>Documentation for '" + cmd.join(".").replace(/^modules[.]/, "") + "':</h3>";
+    html += "<h3>Documentation for '" + Documentation._escapeHtml(cmd.join(".").replace(/^modules[.]/, "")) + "':</h3>";
 
     // level 0
     html += "<p><a href='" + Documentation.DOCUMENTATION_URL + "' target='_blank' rel='noopener'>Salt Module Reference</a>" + Documentation.EXTERNAL_LINK + "</p>";
@@ -266,13 +266,13 @@ export class Documentation {
     // Function getKeywordFragments makes sure that
     // the cmd array has at least one element.
     // The default is "modules"
-    let pageTitle = "All '" + cmd[0] + "' modules";
+    let pageTitle = "All '" + Documentation._escapeHtml(cmd[0]) + "' modules";
     if (cmd[0] === "modules") {
       // the page title is different for this page
       // the link to the page must use the same title
       pageTitle = "All 'execution' modules";
     }
-    html += "<p><a href='" + Documentation.DOCUMENTATION_URL + cmd[0] + "/all/index.html' target='_blank' rel='noopener'>" + pageTitle + "</a>" + Documentation.EXTERNAL_LINK + "</p>";
+    html += "<p><a href='" + Documentation.DOCUMENTATION_URL + Documentation._escapeHtml(cmd[0]) + "/all/index.html' target='_blank' rel='noopener'>" + Documentation._escapeHtml(pageTitle) + "</a>" + Documentation.EXTERNAL_LINK + "</p>";
 
     // When the module is a virtual module, we want
     // to show all relevant concrete modules


### PR DESCRIPTION
Potential fix for [https://github.com/erwindon/SaltGUI/security/code-scanning/13](https://github.com/erwindon/SaltGUI/security/code-scanning/13)

To fix the issue, all untrusted data concatenated into the `html` string must be sanitized using `_escapeHtml` before being assigned to `innerHTML`. This ensures that any potentially malicious characters are properly escaped, preventing them from being interpreted as HTML. Specifically:
1. Apply `_escapeHtml` to all dynamic data (e.g., `cmd` and `pageTitle`) before concatenating it into the `html` string.
2. Ensure consistent sanitization across all paths leading to `innerHTML`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
