### PR TITLE
Potential fix for code scanning alert no. 13: DOM text reinterpreted as HTML

### DIFF
--- a/saltgui/static/scripts/Documentation.js
+++ b/saltgui/static/scripts/Documentation.js
@@ -310,15 +310,15 @@ export class Documentation {
 
       switch (concreteModules.length) {
       case 0:
-        html += "<p>'" + cmd[1] + "' is an unknown module name. We'll just assume it actually exists. The links below (if any) might not work.</p>";
+        html += "<p>'" + Documentation._escapeHtml(cmd[1]) + "' is an unknown module name. We'll just assume it actually exists. The links below (if any) might not work.</p>";
         break;
       case 1:
         // simple modules case
         // wheel/runners cases are always simple
         if (cmd[0] !== "modules") {
-          html += "<p>Module-name '" + cmd[0] + "." + cmd[1] + "' cannot be verified. We'll just assume it actually exists. The links below might not work.</p>";
+          html += "<p>Module-name '" + Documentation._escapeHtml(cmd[0]) + "." + Documentation._escapeHtml(cmd[1]) + "' cannot be verified. We'll just assume it actually exists. The links below might not work.</p>";
         } else if (cmd[1] !== concreteModules[0]) {
-          html += "<p>The internal name for '" + cmd[1] + "' is '" + concreteModules[0] + "'.</p>";
+          html += "<p>The internal name for '" + Documentation._escapeHtml(cmd[1]) + "' is '" + Documentation._escapeHtml(concreteModules[0]) + "'.</p>";
         }
         break;
       default:


### PR DESCRIPTION
Potential fix for [https://github.com/erwindon/SaltGUI/security/code-scanning/13](https://github.com/erwindon/SaltGUI/security/code-scanning/13)

To fix the issue, ensure that all untrusted data concatenated into the `html` variable is properly escaped using the `_escapeHtml` method. This involves identifying all instances where untrusted data flows into `html` and applying `_escapeHtml` to sanitize the data. Specifically, the `cmd` variable and any other untrusted inputs should be escaped before being used in HTML strings.

Changes are required in the following areas:
1. Ensure that `cmd` is escaped before being concatenated into `html` on line 313.
2. Review all other instances where untrusted data is concatenated into `html` and apply `_escapeHtml` as needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
