### PR TITLE
Replace session storage menu key bindings with in-memory Map

### DIFF
--- a/saltgui/static/scripts/Router.js
+++ b/saltgui/static/scripts/Router.js
@@ -39,6 +39,7 @@ export class Router {
     this.commandbox = new CommandBox(this, this.api);
     this.pages = [];
     Router.currentPage = undefined;
+    Router.keyBindings = {};
 
     this._registerPage(new LoginPage(this));
     this._registerPage(Router.minionsPage = new MinionsPage(this));
@@ -87,7 +88,7 @@ export class Router {
     // shortcut
 
     if (pKey) {
-      Utils.setStorageItem("session", "menu_" + pKey, pUrl);
+      Router.keyBindings[pKey] = pUrl;
     }
 
     // full menu
@@ -218,6 +219,12 @@ export class Router {
     this._registerMenuItem(null, "issues", "issues", "i");
     // no shortcut for logout
     this._registerMenuItem(null, "logout", "logout");
+
+    // not a menu item, hidden page
+    Router.keyBindings["O"] = "options";
+
+    // not a menu item, not a page, but reserve key
+    // Router.keyBindings["c"] = "commandbox";
   }
 
   _registerPage (pPage) {

--- a/saltgui/static/scripts/pages/Page.js
+++ b/saltgui/static/scripts/pages/Page.js
@@ -77,7 +77,7 @@ export class Page {
     }
 
     const pages = Router._getPagesList();
-    const page = Utils.getStorageItem("session", "menu_" + keyUpEvent.key, "");
+    const page = Router.keyBindings[keyUpEvent.key];
     if (page && (pages.length === 0 || pages.includes(page))) {
       this.router.goTo(page);
       return true;


### PR DESCRIPTION
Using storageitems (session-keys) is a waste.
The Router can maintain its own table.

Note that other session-keys are initialized from external data that we do not want to retrieve again (and again).

Note that key "O" for "options" does not work yet. capital characters are enabled in another branch where we need it for a regular page. Once that is merged, "O" will work too.